### PR TITLE
Remove gravity wells not working on planets. [CAN BE ACCEPTED NOW]

### DIFF
--- a/StarLegacy/src/main/kotlin/net/starlegacy/feature/starship/Interdiction.kt
+++ b/StarLegacy/src/main/kotlin/net/starlegacy/feature/starship/Interdiction.kt
@@ -39,10 +39,6 @@ object Interdiction : SLComponent() {
 			if (!starship.contains(block.x, block.y, block.z)) {
 				return@subscribe
 			}
-			if (!SpaceWorlds.contains(starship.world)) {
-				player msg "&cYou cannot cast a mass shadow within another mass shadow, so you can only use gravity wells in space"
-				return@subscribe
-			}
 			when (event.action) {
 				Action.RIGHT_CLICK_BLOCK -> {
 					toggleGravityWell(starship, sign)


### PR DESCRIPTION
This does not affect balancing, because gravity wells enabled on planets would not do anything anyway.

This change is done to make lore less confusing, because multiple mass shadows on one location are possible in Star Legacy.
(Multiple ships activating wells beside each other.)