### PR TITLE
Fix /customitem

### DIFF
--- a/server/StarLegacy/src/main/kotlin/net/starlegacy/command/misc/CustomItemCommand.kt
+++ b/server/StarLegacy/src/main/kotlin/net/starlegacy/command/misc/CustomItemCommand.kt
@@ -28,7 +28,7 @@ object CustomItemCommand : SLCommand() {
 	) {
 		val player = target?.player ?: sender as? Player ?: fail { "Console must specify a target player" }
 		failIf(amount <= 0) { "Amount cannot be <= 0" }
-        failIf(player != sender && !sender.hasPermission("ion.giveothercustomitem")) {"You cannot send others custom items. Reason: lacking permission node ion.giveothercustomitem"}
+        failIf(player != sender && !sender.hasPermission("ion.customitem.other")) {"You cannot send others custom items. Reason: lacking permission node ion.customitem.other"}
 
 		val item = customItem.itemStack(amount)
 		val result = player.inventory.addItem(item)

--- a/server/StarLegacy/src/main/kotlin/net/starlegacy/command/misc/CustomItemCommand.kt
+++ b/server/StarLegacy/src/main/kotlin/net/starlegacy/command/misc/CustomItemCommand.kt
@@ -28,7 +28,7 @@ object CustomItemCommand : SLCommand() {
 	) {
 		val player = target?.player ?: sender as? Player ?: fail { "Console must specify a target player" }
 		failIf(amount <= 0) { "Amount cannot be <= 0" }
-        failIf(target?.player != sender && !sender.hasPermission("ion.giveothercustomitem")) {"You cannot send others customitem, lacking permission node ion.giveothercustomitem"}
+        failIf(player != sender && !sender.hasPermission("ion.giveothercustomitem")) {"You cannot send others custom items. Reason: lacking permission node ion.giveothercustomitem"}
 
 		val item = customItem.itemStack(amount)
 		val result = player.inventory.addItem(item)


### PR DESCRIPTION
https://discord.com/channels/916891217596395631/922877447249231962/927391110366634024
Fixes `/customitem` with no player specified erroring due to missing the `ion.giveothercustomitem` permission even though it should default to the sender, and therefore the permission is not necessary.

Also tweaked the error message.