### PR TITLE
Make Deepslate Detectable.

### DIFF
--- a/server/StarLegacy/src/main/kotlin/net/starlegacy/feature/starship/flyable_blocks.kt
+++ b/server/StarLegacy/src/main/kotlin/net/starlegacy/feature/starship/flyable_blocks.kt
@@ -23,7 +23,6 @@ import net.starlegacy.util.STAIR_TYPES
 import net.starlegacy.util.TRAPDOOR_TYPES
 import net.starlegacy.util.WALL_TYPES
 import net.starlegacy.util.WOOL_TYPES
-import org.bukkit.Material
 import org.bukkit.Material.ANVIL
 import org.bukkit.Material.BELL
 import org.bukkit.Material.BOOKSHELF
@@ -87,6 +86,19 @@ import org.bukkit.Material.WAXED_EXPOSED_COPPER
 import org.bukkit.Material.WAXED_OXIDIZED_COPPER
 import org.bukkit.Material.WAXED_WEATHERED_COPPER
 import org.bukkit.Material.WEATHERED_COPPER
+import org.bukkit.Material.CHISELED_DEEPSLATE
+import org.bukkit.Material.CRACKED_DEEPSLATE_BRICKS
+import org.bukkit.Material.CRACKED_DEEPSLATE_TILES
+import org.bukkit.Material.DEEPSLATE_BRICK_SLAB
+import org.bukkit.Material.DEEPSLATE_BRICK_STAIRS
+import org.bukkit.Material.DEEPSLATE_BRICK_WALL
+import org.bukkit.Material.DEEPSLATE_TILE_SLAB
+import org.bukkit.Material.DEEPSLATE_TILE_STAIRS
+import org.bukkit.Material.DEEPSLATE_TILE_WALL
+import org.bukkit.Material.DEEPSLATE_TILES
+import org.bukkit.Material.POLISHED_DEEPSLATE_SLAB
+import org.bukkit.Material.POLISHED_DEEPSLATE_STAIRS
+import org.bukkit.Material.POLISHED_DEEPSLATE_WALL
 
 val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	JUKEBOX, // ship computer
@@ -161,6 +173,20 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	WAXED_EXPOSED_COPPER,
 	WAXED_WEATHERED_COPPER,
 	WAXED_OXIDIZED_COPPER,
+
+	CHISELED_DEEPSLATE,
+	CRACKED_DEEPSLATE_BRICKS,
+	CRACKED_DEEPSLATE_TILES,
+	DEEPSLATE_BRICK_SLAB,
+	DEEPSLATE_BRICK_STAIRS,
+	DEEPSLATE_BRICK_WALL,
+	DEEPSLATE_TILE_SLAB,
+	DEEPSLATE_TILE_STAIRS,
+	DEEPSLATE_TILE_WALL,
+	DEEPSLATE_TILES,
+	POLISHED_DEEPSLATE_SLAB,
+	POLISHED_DEEPSLATE_STAIRS,
+	POLISHED_DEEPSLATE_WALL,
 
 	SHROOMLIGHT,
 	BELL,

--- a/server/StarLegacy/src/main/kotlin/net/starlegacy/util/materials.kt
+++ b/server/StarLegacy/src/main/kotlin/net/starlegacy/util/materials.kt
@@ -40,23 +40,24 @@ val Material.isCopperBlock: Boolean get() =
 	this == Material.WAXED_EXPOSED_CUT_COPPER   ||
 	this == Material.WAXED_WEATHERED_CUT_COPPER ||
 	this == Material.WAXED_OXIDIZED_CUT_COPPER
+//val COPPER_TYPES = getMatchingMaterials{ Material.isCopperBlock }
 
-val Material.isDeepslateBlock: Boolean get() =
-	this == Material.CHISELED_DEEPSLATE         ||
-	this == Material.CRACKED_DEEPSLATE_BRICKS	||
-	this == Material.CRACKED_DEEPSLATE_TILES	||
-	this == Material.DEEPSLATE_BRICK_SLAB 		||
-	this == Material.DEEPSLATE_BRICK_STAIRS		||
-	this == Material.DEEPSLATE_BRICK_WALL		||
-	this == Material.DEEPSLATE_TILE_SLAB		||
-	this == Material.DEEPSLATE_TILE_STAIRS 		||
-	this == Material.DEEPSLATE_TILE_STAIRS		||
-	this == Material.DEEPSLATE_TILE_WALL		||
-	this == Material.DEEPSLATE_TILES			||
-	this == Material.POLISHED_DEEPSLATE_SLAB	||
-	this == Material.POLISHED_DEEPSLATE_STAIRS	||
-	this == Material.POLISHED_DEEPSLATE_WALL
- 
+//val Material.isDeepslateBlock: Boolean get() =
+//	this == Material.CHISELED_DEEPSLATE         ||
+//	this == Material.CRACKED_DEEPSLATE_BRICKS	||
+//	this == Material.CRACKED_DEEPSLATE_TILES	||
+//	this == Material.DEEPSLATE_BRICK_SLAB 		||
+//	this == Material.DEEPSLATE_BRICK_STAIRS		||
+//	this == Material.DEEPSLATE_BRICK_WALL		||
+//	this == Material.DEEPSLATE_TILE_SLAB		||
+//	this == Material.DEEPSLATE_TILE_STAIRS 		||
+//	this == Material.DEEPSLATE_TILE_WALL		||
+//	this == Material.DEEPSLATE_TILES			||
+//	this == Material.POLISHED_DEEPSLATE_SLAB	||
+//	this == Material.POLISHED_DEEPSLATE_STAIRS	||
+//	this == Material.POLISHED_DEEPSLATE_WALL
+//val DEEPSLATE_TYPES = getMatchingMaterials(Material.isDeepslateBlock)
+
 
 val Material.isLava: Boolean get() = this == Material.LAVA
 
@@ -110,6 +111,9 @@ val Material.isNetherWart: Boolean get() = NETHER_WART_TYPES.contains(this)
 
 val CONCRETE_POWDER_TYPES = getMatchingMaterials { it.name.endsWith("_CONCRETE_POWDER") }
 val Material.isConcretePowder: Boolean get() = CONCRETE_POWDER_TYPES.contains(this)
+
+val CONCRETE_TYPES = getMatchingMaterials { it.name.endsWith("_CONCRETE") }
+val Material.isConcrete: Boolean get() = CONCRETE_TYPES.contains(this)
 
 val CONCRETE_TYPES = getMatchingMaterials { it.name.endsWith("_CONCRETE") }
 val Material.isConcrete: Boolean get() = CONCRETE_TYPES.contains(this)

--- a/server/StarLegacy/src/main/kotlin/net/starlegacy/util/materials.kt
+++ b/server/StarLegacy/src/main/kotlin/net/starlegacy/util/materials.kt
@@ -41,6 +41,23 @@ val Material.isCopperBlock: Boolean get() =
 	this == Material.WAXED_WEATHERED_CUT_COPPER ||
 	this == Material.WAXED_OXIDIZED_CUT_COPPER
 
+val Material.isDeepslateBlock: Boolean get() =
+	this == Material.CHISELED_DEEPSLATE         ||
+	this == Material.CRACKED_DEEPSLATE_BRICKS	||
+	this == Material.CRACKED_DEEPSLATE_TILES	||
+	this == Material.DEEPSLATE_BRICK_SLAB 		||
+	this == Material.DEEPSLATE_BRICK_STAIRS		||
+	this == Material.DEEPSLATE_BRICK_WALL		||
+	this == Material.DEEPSLATE_TILE_SLAB		||
+	this == Material.DEEPSLATE_TILE_STAIRS 		||
+	this == Material.DEEPSLATE_TILE_STAIRS		||
+	this == Material.DEEPSLATE_TILE_WALL		||
+	this == Material.DEEPSLATE_TILES			||
+	this == Material.POLISHED_DEEPSLATE_SLAB	||
+	this == Material.POLISHED_DEEPSLATE_STAIRS	||
+	this == Material.POLISHED_DEEPSLATE_WALL
+ 
+
 val Material.isLava: Boolean get() = this == Material.LAVA
 
 val Material.isWater: Boolean get() = this == Material.WATER


### PR DESCRIPTION
Adds deepslate variants to the detectables list.

Blocks with slab alternatives not present.