### PR TITLE
Revert Shield Capacity Function [To be accepted by Balancing]

### DIFF
--- a/src/main/kotlin/net/starlegacy/feature/starship/subsystem/shield/ShieldSubsystem.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/subsystem/shield/ShieldSubsystem.kt
@@ -16,7 +16,7 @@ abstract class ShieldSubsystem(
 	multiblock: ShieldMultiblock
 ) : AbstractMultiblockSubsystem<ShieldMultiblock>(starship, sign, multiblock) {
 	val name: String = sign.getLine(2).stripColor()
-	val maxPower: Int = (starship.blockCount.coerceAtLeast(500).d().pow(2.0 / 3.0) * 7000.0).roundToInt()
+	val maxPower: Int = (starship.blockCount.coerceAtLeast(500).d().pow(3.0 / 5.0) * 10000.0).roundToInt()
 
 	var power: Int = maxPower
 		set(value) {


### PR DESCRIPTION
*Apparently all old pull requests were deleted, so I am resubmitting this.*

"11 months ago, in a post-combat update patch, Micle buffed shield capacities. This is why many fights went on for far too long.

You can compare the original values with the current patch here: https://www.desmos.com/calculator/966yb4oik3

As you can see, this made dreadnought shields almost 44% stronger. All ships were buffed, but larger ships were buffed by more.

This pull request will revert shield capacity values back to the original, if accepted."