### PR TITLE
Replace .isAlphanumeric with RegEx

### DIFF
--- a/src/main/kotlin/net/starlegacy/command/nations/SettlementCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/nations/SettlementCommand.kt
@@ -55,7 +55,7 @@ import org.litote.kmongo.updateOneById
 @CommandAlias("settlement|s")
 internal object SettlementCommand : SLCommand() {
 	private fun validateName(name: String, settlementId: Oid<Settlement>?) {
-		if (!name.isAlphanumeric()) {
+		if (!"\\w*".toRegex().matches(name)) { 
 			throw InvalidCommandArgument("Name must be alphanumeric")
 		}
 


### PR DESCRIPTION
"The difference is that underscores are now possible."

Reimplement the RegEx (which was removed?)

My current theory is that Peter wiped the old repository and is reworking Ion from another clone of SL.  (I am confused as to where everything has gone.)