### PR TITLE
Gravity Wells on Planets / Pulsing affecting Allies

### DIFF
--- a/src/main/kotlin/net/starlegacy/feature/starship/Interdiction.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/Interdiction.kt
@@ -99,10 +99,6 @@ object Interdiction : SLComponent() {
 				continue
 			}
 
-			if (isAllied(pilot, player)) {
-				continue
-			}
-
 			cruisingShip.cruiseData.velocity.multiply(0.9)
 			cruisingShip.sendMessage("&cQuantum fluctuations detected - velocity has been reduced by 10%.")
 		}

--- a/src/main/kotlin/net/starlegacy/feature/starship/Interdiction.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/Interdiction.kt
@@ -39,10 +39,6 @@ object Interdiction : SLComponent() {
 			if (!starship.contains(block.x, block.y, block.z)) {
 				return@subscribe
 			}
-			if (!SpaceWorlds.contains(starship.world)) {
-				player msg "&cYou cannot cast a mass shadow within another mass shadow, so you can only use gravity wells in space"
-				return@subscribe
-			}
 			when (event.action) {
 				Action.RIGHT_CLICK_BLOCK -> {
 					toggleGravityWell(starship, sign)


### PR DESCRIPTION
"This does not affect balancing, because gravity wells enabled on planets would not do anything anyway.

This change is done to make lore less confusing, because multiple mass shadows on one location are possible in Star Legacy.
(Multiple ships activating wells beside each other.)"