### PR TITLE
Remove Glowstone Thrusters.

### DIFF
--- a/src/main/kotlin/net/starlegacy/feature/starship/subsystem/thruster/ThrusterType.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/subsystem/thruster/ThrusterType.kt
@@ -8,11 +8,6 @@ import org.bukkit.Material
 import org.bukkit.block.BlockFace
 
 enum class ThrusterType(val accel: Double, val speed: Double, val weight: Int) {
-	GLOWSTONE(0.2, 2.25, 1) {
-		override fun MultiblockShape.buildStructure() {
-			at(0, 0, 0).type(Material.GLOWSTONE)
-		}
-	},
 	PLASMA(0.75, 2.5, 1) {
 		override fun MultiblockShape.buildStructure() {
 			at(0, 0, 0).type(Material.REDSTONE_LAMP)


### PR DESCRIPTION
Remove Glowstone Thrusters.  (From 30/12/2021)