### PR TITLE
Prevent players being kicked due to out of order chat

### DIFF
--- a/Server/src/main/kotlin/net/horizonsend/ion/server/IonServer.kt
+++ b/Server/src/main/kotlin/net/horizonsend/ion/server/IonServer.kt
@@ -8,6 +8,7 @@ import net.horizonsend.ion.server.listeners.PlayerDeathListener
 import net.horizonsend.ion.server.listeners.PlayerFishListener
 import net.horizonsend.ion.server.listeners.PlayerItemConsumeListener
 import net.horizonsend.ion.server.listeners.PlayerJoinListener
+import net.horizonsend.ion.server.listeners.PlayerKickListener
 import net.horizonsend.ion.server.listeners.PlayerQuitListener
 import net.horizonsend.ion.server.listeners.PlayerTeleportListener
 import net.horizonsend.ion.server.listeners.PotionSplashListener
@@ -34,6 +35,7 @@ class IonServer : JavaPlugin() {
 			PlayerFishListener(),
 			PlayerItemConsumeListener(),
 			PlayerJoinListener(),
+			PlayerKickListener(),
 			PlayerQuitListener(),
 			PlayerTeleportListener(),
 			PotionSplashListener(),

--- a/Server/src/main/kotlin/net/horizonsend/ion/server/listeners/PlayerKickListener.kt
+++ b/Server/src/main/kotlin/net/horizonsend/ion/server/listeners/PlayerKickListener.kt
@@ -1,0 +1,23 @@
+package net.horizonsend.ion.server.listeners
+
+import net.horizonsend.ion.common.utilities.feedback.FeedbackType
+import net.horizonsend.ion.common.utilities.feedback.sendFeedbackMessage
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerKickEvent
+
+class PlayerKickListener : Listener {
+	@EventHandler(priority = EventPriority.LOW)
+	@Suppress("Unused")
+	fun onPlayerKickEvent(event: PlayerKickEvent) {
+		// Really dumb solution for players being kicked due to "out of order chat messages"
+		if (event.reason().toString().lowercase().contains("out-of-order")) {
+			event.player.sendFeedbackMessage(
+				FeedbackType.SERVER_ERROR,
+				"The server attempted to kick you for out-of-order chat messages. You may need to retry any recent commands."
+			)
+			event.isCancelled = true
+		}
+	}
+}


### PR DESCRIPTION
Really dumb solution.

Not sure about `Component#toString()`, but otherwise this should work.
I am a little worried about https://github.com/PaperMC/Paper/issues/8019#issuecomment-1159582582, but a failed command is probably better than a kick. 

![image](https://user-images.githubusercontent.com/66213737/174652107-6873af8e-f082-4780-b430-9cfe709fec74.png)
