### PR TITLE
Fix underscores in usernames displaying as italics in discord join/leave/switch messages

### DIFF
--- a/Proxy/src/main/kotlin/net/horizonsend/ion/proxy/listeners/PlayerDisconnectListener.kt
+++ b/Proxy/src/main/kotlin/net/horizonsend/ion/proxy/listeners/PlayerDisconnectListener.kt
@@ -28,7 +28,7 @@ class PlayerDisconnectListener : Listener {
 
 			globalChannel.sendMessageEmbeds(
 				messageEmbed(
-					description = "[- ${event.player.server.info.name}] ${event.player.name}",
+					description = "[- ${event.player.server.info.name}] ${event.player.name.replace("_", "\\_")}",
 					color = ChatColor.RED.color.rgb
 				)
 			).queue()

--- a/Proxy/src/main/kotlin/net/horizonsend/ion/proxy/listeners/ServerConnectListener.kt
+++ b/Proxy/src/main/kotlin/net/horizonsend/ion/proxy/listeners/ServerConnectListener.kt
@@ -31,7 +31,7 @@ class ServerConnectListener : Listener {
 
 					globalChannel.sendMessageEmbeds(
 						messageEmbed(
-							description = "Welcome ${event.player.name} to the server!",
+							description = "Welcome ${event.player.name.replace("_", "\\_")} to the server!",
 							color = ChatColor.GOLD.color.rgb
 						)
 					).queue()
@@ -52,7 +52,7 @@ class ServerConnectListener : Listener {
 
 					globalChannel.sendMessageEmbeds(
 						messageEmbed(
-							description = "[+ ${event.target.name}] ${event.player.name}",
+							description = "[+ ${event.target.name}] ${event.player.name.replace("_", "\\_")}",
 							color = ChatColor.GREEN.color.rgb
 						)
 					).queue()
@@ -89,7 +89,7 @@ class ServerConnectListener : Listener {
 
 				globalChannel.sendMessageEmbeds(
 					messageEmbed(
-						description = "[> ${event.target.name}] ${event.player.name}",
+						description = "[> ${event.target.name}] ${event.player.name.replace("_", "\\_")}",
 						color = ChatColor.BLUE.color.rgb
 					)
 				).queue()


### PR DESCRIPTION
I don't like it, but it should work. 

Hopefully fixes 
![image](https://user-images.githubusercontent.com/66213737/194766720-c0676fb4-0eae-4412-b602-bd20c866f875.png)
but it's untested because I'm too lazy