### PR TITLE
Environmental module water breathing

### DIFF
--- a/Server/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorManager.kt
+++ b/Server/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorManager.kt
@@ -71,9 +71,8 @@ object PowerArmorManager {
 						PowerArmorModule.ENVIRONMENT -> {
 							player.addPotionEffect(
 								PotionEffect(PotionEffectType.WATER_BREATHING, 20, 1, true, true)
-							) {
+							)
 								removePower(item, 1)
-							}
 						}
 
 						else -> {

--- a/Server/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorManager.kt
+++ b/Server/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorManager.kt
@@ -68,6 +68,14 @@ object PowerArmorManager {
 							}
 						}
 
+						PowerArmorModule.ENVIRONMENT -> {
+							player.addPotionEffect(
+								PotionEffect(PotionEffectType.WATER_BREATHING, 20, 1, true, true)
+							) {
+								removePower(item, 1)
+							}
+						}
+
 						else -> {
 						}
 					}


### PR DESCRIPTION
Gives player the water breathing potion effect while wearing a power armor helmet with environment module, since the module currently has no use