### PR TITLE
Added some new blocks to the flyable list

### DIFF
--- a/Server/src/main/kotlin/net/starlegacy/feature/starship/flyable_blocks.kt
+++ b/Server/src/main/kotlin/net/starlegacy/feature/starship/flyable_blocks.kt
@@ -4,121 +4,9 @@ import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import java.util.EnumSet
 import net.minecraft.world.level.block.state.BlockState
-import net.starlegacy.util.BANNER_TYPES
-import net.starlegacy.util.BED_TYPES
-import net.starlegacy.util.BUTTON_TYPES
-import net.starlegacy.util.CAKE_TYPES
-import net.starlegacy.util.CANDLE_TYPES
-import net.starlegacy.util.CARPET_TYPES
-import net.starlegacy.util.CONCRETE_TYPES
-import net.starlegacy.util.DOOR_TYPES
-import net.starlegacy.util.FENCE_TYPES
-import net.starlegacy.util.GLAZED_TERRACOTTA_TYPES
-import net.starlegacy.util.PRESSURE_PLATE_TYPES
-import net.starlegacy.util.SHULKER_BOX_TYPES
-import net.starlegacy.util.SIGN_TYPES
-import net.starlegacy.util.SLAB_TYPES
-import net.starlegacy.util.STAINED_GLASS_PANE_TYPES
-import net.starlegacy.util.STAINED_GLASS_TYPES
-import net.starlegacy.util.STAINED_TERRACOTTA_TYPES
-import net.starlegacy.util.STAIR_TYPES
-import net.starlegacy.util.TRAPDOOR_TYPES
-import net.starlegacy.util.WALL_TYPES
-import net.starlegacy.util.WOOL_TYPES
+import net.starlegacy.util.*
 import org.bukkit.Material
-import org.bukkit.Material.ANVIL
-import org.bukkit.Material.BARREL
-import org.bukkit.Material.BELL
-import org.bukkit.Material.BOOKSHELF
-import org.bukkit.Material.BREWING_STAND
-import org.bukkit.Material.BROWN_MUSHROOM_BLOCK
-import org.bukkit.Material.CAULDRON
-import org.bukkit.Material.CHAIN
-import org.bukkit.Material.CHEST
-import org.bukkit.Material.COMPARATOR
-import org.bukkit.Material.COPPER_BLOCK
-import org.bukkit.Material.CRAFTING_TABLE
-import org.bukkit.Material.DAYLIGHT_DETECTOR
-import org.bukkit.Material.DIAMOND_BLOCK
-import org.bukkit.Material.DISPENSER
-import org.bukkit.Material.DROPPER
-import org.bukkit.Material.EMERALD_BLOCK
-import org.bukkit.Material.ENDER_CHEST
-import org.bukkit.Material.END_PORTAL_FRAME
-import org.bukkit.Material.END_ROD
-import org.bukkit.Material.EXPOSED_COPPER
-import org.bukkit.Material.FLOWER_POT
-import org.bukkit.Material.FURNACE
-import org.bukkit.Material.GLASS
-import org.bukkit.Material.GLASS_PANE
-import org.bukkit.Material.GLOWSTONE
-import org.bukkit.Material.GOLD_BLOCK
-import org.bukkit.Material.GRINDSTONE
-import org.bukkit.Material.HOPPER
-import org.bukkit.Material.IRON_BARS
-import org.bukkit.Material.IRON_BLOCK
-import org.bukkit.Material.JUKEBOX
-import org.bukkit.Material.LADDER
-import org.bukkit.Material.LAPIS_BLOCK
-import org.bukkit.Material.LECTERN
-import org.bukkit.Material.LEVER
-import org.bukkit.Material.LODESTONE
-import org.bukkit.Material.MAGMA_BLOCK
-import org.bukkit.Material.MOVING_PISTON
-import org.bukkit.Material.NETHER_PORTAL
-import org.bukkit.Material.NOTE_BLOCK
-import org.bukkit.Material.OBSERVER
-import org.bukkit.Material.OXIDIZED_COPPER
-import org.bukkit.Material.PISTON
-import org.bukkit.Material.PISTON_HEAD
-import org.bukkit.Material.POTTED_AZURE_BLUET
-import org.bukkit.Material.POTTED_BAMBOO
-import org.bukkit.Material.POTTED_BIRCH_SAPLING
-import org.bukkit.Material.POTTED_BLUE_ORCHID
-import org.bukkit.Material.POTTED_BROWN_MUSHROOM
-import org.bukkit.Material.POTTED_CACTUS
-import org.bukkit.Material.POTTED_CORNFLOWER
-import org.bukkit.Material.POTTED_CRIMSON_FUNGUS
-import org.bukkit.Material.POTTED_CRIMSON_ROOTS
-import org.bukkit.Material.POTTED_DANDELION
-import org.bukkit.Material.POTTED_DARK_OAK_SAPLING
-import org.bukkit.Material.POTTED_DEAD_BUSH
-import org.bukkit.Material.POTTED_FERN
-import org.bukkit.Material.POTTED_FLOWERING_AZALEA_BUSH
-import org.bukkit.Material.POTTED_JUNGLE_SAPLING
-import org.bukkit.Material.POTTED_LILY_OF_THE_VALLEY
-import org.bukkit.Material.POTTED_OAK_SAPLING
-import org.bukkit.Material.POTTED_ORANGE_TULIP
-import org.bukkit.Material.POTTED_OXEYE_DAISY
-import org.bukkit.Material.POTTED_PINK_TULIP
-import org.bukkit.Material.POTTED_POPPY
-import org.bukkit.Material.POTTED_RED_MUSHROOM
-import org.bukkit.Material.POTTED_RED_TULIP
-import org.bukkit.Material.POTTED_SPRUCE_SAPLING
-import org.bukkit.Material.POTTED_WARPED_FUNGUS
-import org.bukkit.Material.POTTED_WARPED_ROOTS
-import org.bukkit.Material.POTTED_WHITE_TULIP
-import org.bukkit.Material.POTTED_WITHER_ROSE
-import org.bukkit.Material.REDSTONE_BLOCK
-import org.bukkit.Material.REDSTONE_LAMP
-import org.bukkit.Material.REDSTONE_TORCH
-import org.bukkit.Material.REDSTONE_WALL_TORCH
-import org.bukkit.Material.REDSTONE_WIRE
-import org.bukkit.Material.REPEATER
-import org.bukkit.Material.SCAFFOLDING
-import org.bukkit.Material.SCULK
-import org.bukkit.Material.SEA_LANTERN
-import org.bukkit.Material.SHROOMLIGHT
-import org.bukkit.Material.SPONGE
-import org.bukkit.Material.STICKY_PISTON
-import org.bukkit.Material.TORCH
-import org.bukkit.Material.TRAPPED_CHEST
-import org.bukkit.Material.WALL_TORCH
-import org.bukkit.Material.WAXED_COPPER_BLOCK
-import org.bukkit.Material.WAXED_EXPOSED_COPPER
-import org.bukkit.Material.WAXED_OXIDIZED_COPPER
-import org.bukkit.Material.WAXED_WEATHERED_COPPER
-import org.bukkit.Material.WEATHERED_COPPER
+import org.bukkit.Material.*
 
 val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	JUKEBOX, // ship computer
@@ -143,6 +31,7 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	IRON_BLOCK,
 	EMERALD_BLOCK,
 	BROWN_MUSHROOM_BLOCK, // custom ores
+	NETHERITE_BLOCK,
 
 	// used for landing gears
 	PISTON,
@@ -161,16 +50,37 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	// misc stuff
 	TORCH,
 	WALL_TORCH,
-	CRAFTING_TABLE,
+	SOUL_TORCH,
+	SOUL_WALL_TORCH,
+	LANTERN,
+	SOUL_LANTERN,
+	CAMPFIRE,
+	SOUL_CAMPFIRE,
 	END_ROD,
+	BEACON,
+
+	CRAFTING_TABLE,
+	BEEHIVE,
 	LEVER,
 	FLOWER_POT,
 	CAULDRON,
 	ANVIL,
+	CHIPPED_ANVIL,
+	DAMAGED_ANVIL,
 	BOOKSHELF,
 	LADDER,
 	DAYLIGHT_DETECTOR,
 	NETHER_PORTAL,
+	ENCHANTING_TABLE,
+	SMITHING_TABLE,
+	LOOM,
+	COMPOSTER,
+	SMOKER,
+	BLAST_FURNACE,
+	CARTOGRAPHY_TABLE,
+	FLETCHING_TABLE,
+	STONECUTTER,
+	DRIED_KELP_BLOCK,
 
 	OBSERVER,
 	REPEATER,
@@ -192,6 +102,8 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	SCAFFOLDING,
 	CHAIN,
 
+	POLISHED_BASALT,
+
 	COPPER_BLOCK,
 	EXPOSED_COPPER,
 	WEATHERED_COPPER,
@@ -200,6 +112,10 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	WAXED_EXPOSED_COPPER,
 	WAXED_WEATHERED_COPPER,
 	WAXED_OXIDIZED_COPPER,
+	LIGHTNING_ROD,
+
+	QUARTZ_BRICKS,
+	QUARTZ_PILLAR,
 
 	POTTED_AZURE_BLUET,
 	POTTED_BAMBOO,
@@ -230,6 +146,13 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	POTTED_WHITE_TULIP,
 	POTTED_WITHER_ROSE,
 
+	ZOMBIE_HEAD,
+	PLAYER_HEAD,
+	SKELETON_SKULL,
+	WITHER_SKELETON_SKULL,
+	CREEPER_HEAD,
+	DRAGON_HEAD,
+
 	SCULK
 
 	).also {
@@ -254,6 +177,9 @@ val FLYABLE_BLOCKS: EnumSet<Material> = mutableSetOf(
 	it.addAll(WALL_TYPES)
 	it.addAll(CANDLE_TYPES)
 	it.addAll(CAKE_TYPES)
+	it.addAll(FROGLIGHT_TYPES)
+	it.addAll(INFESTED_TYPES)
+	it.addAll(FENCE_GATE_TYPES)
 
 }.filter { it.isBlock }.toCollection(EnumSet.noneOf(Material::class.java))
 

--- a/Server/src/main/kotlin/net/starlegacy/util/materials.kt
+++ b/Server/src/main/kotlin/net/starlegacy/util/materials.kt
@@ -97,3 +97,14 @@ val WALL_TYPES = getMatchingMaterials { it.name.endsWith("_WALL") }
 val Material.isWall: Boolean get() = WALL_TYPES.contains(this)
 
 val CHISELED_TYPES = getMatchingMaterials { it.name.startsWith("CHISELED_") }
+
+val FROGLIGHT_TYPES = getMatchingMaterials {it.name.endsWith("_FROGLIGHT")}
+val Material.isFroglight: Boolean get() = FROGLIGHT_TYPES.contains(this)
+
+val INFESTED_TYPES = getMatchingMaterials {it.name.startsWith("INFESTED_")}
+
+val Material.isInfested: Boolean get() = INFESTED_TYPES.contains(this)
+
+val FENCE_GATE_TYPES = getMatchingMaterials {it.name.endsWith("_FENCE_GATE") }
+
+val RAIL_TYPES = getMatchingMaterials {it.name.endsWith("_RAIL") }


### PR DESCRIPTION
Added netherite blocks, quartz bricks/pillars, polished basalt, kelp blocks, froglights, various utility blocks, beehive, lanterns, campfires, torches(and their soul equivalents for each), mob/player heads, 2 broken anvils, enchanting table, infested blocks, fence gates, lightning rods, rails, and beacons.