### PR TITLE
State Pilot Name(helpful for mods)

### DIFF
--- a/Server/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
+++ b/Server/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
@@ -155,7 +155,7 @@ object PilotedStarships : SLComponent() {
 	operator fun get(player: Player): ActivePlayerStarship? = map[player]
 	fun tryPilot(player: Player, data: PlayerStarshipData, callback: (ActivePlayerStarship) -> Unit = {}): Boolean {
 		if (!data.isPilot(player)) {
-			player.sendFeedbackActionMessage(USER_ERROR, "You're not a pilot of this! \nPilot: ${data.captain}")
+			player.sendFeedbackActionMessage(USER_ERROR, "You're not a pilot of this, the captain is ${data.captain}")
 
 			return false
 		}

--- a/Server/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
+++ b/Server/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
@@ -155,7 +155,8 @@ object PilotedStarships : SLComponent() {
 	operator fun get(player: Player): ActivePlayerStarship? = map[player]
 	fun tryPilot(player: Player, data: PlayerStarshipData, callback: (ActivePlayerStarship) -> Unit = {}): Boolean {
 		if (!data.isPilot(player)) {
-			player.sendFeedbackActionMessage(USER_ERROR, "You're not a pilot of this!")
+			player.sendFeedbackActionMessage(USER_ERROR, "You're not a pilot of this! \nPilot: $player")
+
 			return false
 		}
 		if (!data.starshipType.canUse(player)) {

--- a/Server/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
+++ b/Server/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
@@ -155,7 +155,7 @@ object PilotedStarships : SLComponent() {
 	operator fun get(player: Player): ActivePlayerStarship? = map[player]
 	fun tryPilot(player: Player, data: PlayerStarshipData, callback: (ActivePlayerStarship) -> Unit = {}): Boolean {
 		if (!data.isPilot(player)) {
-			player.sendFeedbackActionMessage(USER_ERROR, "You're not a pilot of this! \nPilot: $player")
+			player.sendFeedbackActionMessage(USER_ERROR, "You're not a pilot of this! \nPilot: ${data.captain}")
 
 			return false
 		}


### PR DESCRIPTION
moderators can't check the pilot of starships, normal players find out the pilot by trying to re-detect, if a mod does it just re-detects with "pilot msg" because they have dutymode bypass