### PR TITLE
feat: Item Search

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/IonServer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/IonServer.kt
@@ -7,6 +7,9 @@ import net.horizonsend.ion.common.loadConfiguration
 import net.horizonsend.ion.server.configuration.BalancingConfiguration
 import net.horizonsend.ion.server.configuration.ServerConfiguration
 import net.horizonsend.ion.server.features.customItems.CustomItems
+import net.horizonsend.ion.server.features.whereisit.mod.FoundS2C
+import net.horizonsend.ion.server.features.whereisit.mod.SearchC2S
+import net.horizonsend.ion.server.features.whereisit.mod.Searcher
 import net.horizonsend.ion.server.features.worlds.IonWorld
 import net.horizonsend.ion.server.miscellaneous.commands
 import net.horizonsend.ion.server.miscellaneous.initializeCrafting
@@ -65,6 +68,9 @@ class IonServer : JavaPlugin() {
 
 			// The listeners are defined in a separate file for the sake of keeping the main class clean.
 			for (listener in listeners) pluginManager.registerEvents(listener, this)
+
+			Bukkit.getMessenger().registerIncomingPluginChannel(this, SearchC2S.ID.toString(), Searcher::handle)
+			Bukkit.getMessenger().registerOutgoingPluginChannel(this, FoundS2C.ID.toString())
 
 			// Same deal as listeners.
 			initializeCrafting()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/SearchCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/SearchCommand.kt
@@ -1,0 +1,76 @@
+package net.horizonsend.ion.server.features.whereisit
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandCompletion
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Default
+import co.aikar.commands.annotation.Optional
+import co.aikar.commands.annotation.Subcommand
+import net.horizonsend.ion.server.extensions.userError
+import net.horizonsend.ion.server.features.customItems.CustomItems
+import net.horizonsend.ion.server.features.whereisit.mod.Searcher
+import net.horizonsend.ion.server.miscellaneous.highlightBlock
+import net.starlegacy.util.Tasks
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+@CommandAlias("itemsearch")
+@CommandPermission("ion.search")
+class SearchCommand : BaseCommand() {
+	@Default
+	fun default(
+		player: Player,
+		@Optional material: Material?
+	) = searchAndSend(player, if (material != null) ItemStack(material) else player.inventory.itemInMainHand)
+
+	@Subcommand("custom")
+	@CommandCompletion("@customItem")
+	fun custom(
+		player: Player,
+		customItem: String
+	) {
+		val itemStack = CustomItems.getByIdentifier(customItem)?.constructItemStack() ?: run {
+			player.userError("Can't find item $customItem!")
+			return
+		}
+
+		searchAndSend(player, itemStack)
+	}
+
+	@Subcommand("legacy")
+	@CommandCompletion("@customitems")
+	fun legacy(
+		player: Player,
+		customItem: String
+	) {
+		val itemStack = net.starlegacy.feature.misc.CustomItems[customItem]?.itemStack(1) ?: run {
+			player.userError("Can't find item $customItem!")
+			return
+		}
+
+		searchAndSend(player, itemStack)
+	}
+
+	private fun searchAndSend(player: Player, stack: ItemStack) = Tasks.async {
+		val res = Searcher.searchItemStack(
+			player,
+			stack
+		)
+
+		if (res.isEmpty()) {
+			player.userError("Couldn't find any item in a 20 block range.")
+			return@async
+		}
+
+		for (pos in res.keys) {
+			highlightBlock(player, pos)
+		}
+
+		player.sendRichMessage(
+			"<hover:show_text:\"${res.keys.joinToString("\n") { "<gray>X: ${it.x} Y: ${it.y} Z: ${it.z}" }}\">" +
+				"<#7f7fff>Found ${res.size} containers. [Hover]"
+		)
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/FoundType.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/FoundType.kt
@@ -1,0 +1,11 @@
+package net.horizonsend.ion.server.features.whereisit.mod
+
+/**
+ * States how an item was found, used for different colours.
+ * NOT_FOUND: The item was not found.
+ * FOUND: The item was found directly.
+ * FOUND_DEEP: The item was found in a nested inventory (shulker box, backpack).
+ */
+enum class FoundType {
+	NOT_FOUND, FOUND, FOUND_DEEP
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/Packets.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/Packets.kt
@@ -1,0 +1,64 @@
+package net.horizonsend.ion.server.features.whereisit.mod
+
+import io.netty.buffer.Unpooled
+import net.minecraft.core.BlockPos
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.FriendlyByteBuf
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.item.Item
+
+class FoundS2C(results: Map<BlockPos, SearchResult>) : FriendlyByteBuf(Unpooled.buffer()) {
+	init {
+		writeInt(results.size)
+		for ((key, value) in results) {
+			writeBlockPos(key)
+			writeEnum(value.foundType)
+			val hasName = value.name != null
+			writeBoolean(hasName)
+			if (hasName) this.writeComponent(value.name)
+		}
+	}
+
+	companion object {
+		val ID = ResourceLocation("whereisit", "found_item_s2c")
+		fun read(buf: FriendlyByteBuf): Map<BlockPos, SearchResult> {
+			val results: MutableMap<BlockPos, SearchResult> = LinkedHashMap()
+			val max = buf.readInt()
+			for (i in 0 until max) {
+				results[buf.readBlockPos()] = SearchResult(
+					buf.readEnum(
+						FoundType::class.java
+					),
+					if (buf.readBoolean()) buf.readComponent() else null
+				)
+			}
+			return results
+		}
+	}
+}
+
+class SearchC2S(toFind: Item?, matchNbt: Boolean, nbtCompound: CompoundTag?, maximum: Int) :
+	FriendlyByteBuf(Unpooled.buffer()) {
+	init {
+		writeResourceLocation(BuiltInRegistries.ITEM.getKey(toFind))
+		writeBoolean(matchNbt)
+		if (matchNbt) {
+			writeNbt(nbtCompound)
+		}
+		writeInt(maximum)
+	}
+
+	@JvmRecord
+	data class Context(val item: Item, val matchNbt: Boolean, val tag: CompoundTag?, val maximum: Int)
+	companion object {
+		val ID = ResourceLocation("whereisit", "find_item_c2s")
+		fun read(buf: FriendlyByteBuf): Context {
+			val item = BuiltInRegistries.ITEM[buf.readResourceLocation()]
+			val matchNbt = buf.readBoolean()
+			val tag = if (matchNbt) buf.readNbt() else null
+			val maximum = buf.readInt()
+			return Context(item, matchNbt, tag, maximum)
+		}
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/SearchResult.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/SearchResult.kt
@@ -1,0 +1,5 @@
+package net.horizonsend.ion.server.features.whereisit.mod
+
+import net.minecraft.network.chat.Component
+
+class SearchResult(val foundType: FoundType, val name: Component?)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/Searcher.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/whereisit/mod/Searcher.kt
@@ -1,0 +1,153 @@
+package net.horizonsend.ion.server.features.whereisit.mod
+
+import io.netty.buffer.Unpooled
+import net.horizonsend.ion.server.extensions.information
+import net.minecraft.core.BlockPos
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.FriendlyByteBuf
+import net.minecraft.network.chat.Component
+import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.Container
+import net.minecraft.world.Nameable
+import net.minecraft.world.WorldlyContainerHolder
+import net.minecraft.world.item.Item
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
+import net.minecraft.world.level.block.LecternBlock
+import net.minecraft.world.level.block.entity.LecternBlockEntity
+import net.starlegacy.listener.misc.ProtectionListener
+import net.starlegacy.util.Tasks
+import net.starlegacy.util.toLocation
+import org.bukkit.craftbukkit.v1_19_R2.CraftWorld
+import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack
+import org.bukkit.entity.Player
+
+object Searcher {
+	fun handle(s: String, player: Player, buf: ByteArray) = Tasks.async {
+		val searchContext = SearchC2S.read(FriendlyByteBuf(Unpooled.wrappedBuffer(buf)))
+		val itemToFind = searchContext.item
+		if (itemToFind == Items.AIR) return@async
+
+		val basePos = (player as CraftPlayer).handle.blockPosition()
+		val world = (player.world as CraftWorld).handle
+		val positions =
+			searchWorld(
+				basePos,
+				world,
+				itemToFind,
+				searchContext.tag
+			).filterNot {
+				ProtectionListener.denyBlockAccess(
+					player,
+					it.key.toLocation(player.world)
+				)
+			}
+
+		if (positions.isNotEmpty()) {
+			val packet = FoundS2C(positions)
+
+			player.handle.connection.send(
+				ClientboundCustomPayloadPacket(FoundS2C.ID, packet)
+			)
+		} else {
+			player.information("Item not found")
+		}
+	}
+
+	fun searchItemStack(player: Player, toFind: org.bukkit.inventory.ItemStack): Map<BlockPos, SearchResult> {
+		val item = CraftItemStack.asNMSCopy(toFind)
+		val itemToFind = item.item
+		val tag = item.tag
+
+		val basePos = (player as CraftPlayer).handle.blockPosition()
+		val world = (player.world as CraftWorld).handle
+
+		return searchWorld(
+			basePos,
+			world,
+			itemToFind,
+			tag
+		).filterNot {
+			ProtectionListener.denyBlockAccess(
+				player,
+				it.key.toLocation(player.world)
+			)
+		}
+	}
+
+	fun searchWorld(
+		playerPos: BlockPos,
+		world: ServerLevel,
+		toFind: Item,
+		toFindTag: CompoundTag?
+	): Map<BlockPos, SearchResult> {
+		val positions: MutableMap<BlockPos, SearchResult> = HashMap()
+		val radius = 20 // TODO config
+		var checkedBECount = 0
+		val minChunkX = -radius + playerPos.x shr 4
+		val maxChunkX = radius + 1 + playerPos.x shr 4
+		val minChunkZ = -radius + playerPos.z shr 4
+		val maxChunkZ = radius + 1 + playerPos.z shr 4
+		for (chunkX in minChunkX..maxChunkX) {
+			for (chunkZ in minChunkZ..maxChunkZ) {
+				val chunk = world.getChunk(chunkX, chunkZ)
+				checkedBECount += chunk.getBlockEntities().size
+				for ((pos, be) in chunk.getBlockEntities()) {
+					if (pos.closerThan(playerPos, radius.toDouble())) {
+						val state = chunk.getBlockState(pos)
+						var foundType = FoundType.NOT_FOUND
+						var invName: Component? = null
+						if (be is Nameable && be.hasCustomName()) invName = be.customName
+
+						// Lecterns
+						if (state.block is LecternBlock && state.getValue(LecternBlock.HAS_BOOK)) {
+							foundType = searchItemStack((be as LecternBlockEntity).book, toFind, toFindTag, true)
+							// Inventories (Chests etc)
+						} else if (be is Container) {
+							foundType = invContains(be as Container, toFind, toFindTag, true)
+							// Alternative inventories (Composters)
+						} else if (state.block is WorldlyContainerHolder) {
+							val inv: Container? =
+								(state.block as WorldlyContainerHolder).getContainer(state, world, pos)
+							if (inv != null) foundType = invContains(inv, toFind, toFindTag, true)
+						}
+						if (foundType !== FoundType.NOT_FOUND) {
+							positions[pos.immutable()] =
+								SearchResult(foundType, invName)
+						}
+					}
+				}
+			}
+		}
+
+		println("Checked $checkedBECount BlockEntities")
+		return positions
+	}
+
+	fun searchItemStack(itemStack: ItemStack, toFind: Item, toFindTag: CompoundTag?, deepSearch: Boolean): FoundType {
+		return if (itemStack.item === toFind && (toFindTag == null || toFindTag == itemStack.tag)) {
+			FoundType.FOUND
+		} else {
+			FoundType.NOT_FOUND
+		}
+	}
+
+	private fun invContains(
+		inv: Container,
+		searchingFor: Item,
+		searchingForNbt: CompoundTag?,
+		deepSearch: Boolean
+	): FoundType {
+		for (i in 0 until inv.containerSize) {
+			val result = searchItemStack(inv.getItem(i), searchingFor, searchingForNbt, deepSearch)
+			if (result !== FoundType.NOT_FOUND) return result
+		}
+		return FoundType.NOT_FOUND
+	}
+
+	fun areStacksEqual(item1: Item?, tag1: CompoundTag?, item2: Item?, tag2: CompoundTag?, matchNbt: Boolean): Boolean {
+		return item1 == item2 && (!matchNbt || tag1 == tag2)
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/Commands.kt
@@ -7,6 +7,7 @@ import net.horizonsend.ion.server.features.blasters.SettingsCommand
 import net.horizonsend.ion.server.features.bounties.BountyCommands
 import net.horizonsend.ion.server.features.customItems.commands.ConvertCommand
 import net.horizonsend.ion.server.features.customItems.commands.CustomItemCommand
+import net.horizonsend.ion.server.features.whereisit.SearchCommand
 import net.horizonsend.ion.server.miscellaneous.commands.CalcExpCommand
 
 val commands = arrayOf(
@@ -16,6 +17,7 @@ val commands = arrayOf(
 	CustomItemCommand(),
 	SettingsCommand(),
 	IonCommand(),
+	SearchCommand(),
 	CalcExpCommand(),
 
 	AchievementsCommand()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/Miscellaneous.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/Miscellaneous.kt
@@ -2,8 +2,18 @@ package net.horizonsend.ion.server.miscellaneous
 
 import net.horizonsend.ion.server.IonServer
 import net.milkbowl.vault.economy.Economy
+import net.minecraft.core.BlockPos
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket
+import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.monster.Shulker
+import net.minecraft.world.scores.Scoreboard
+import net.starlegacy.util.Tasks
 import org.bukkit.Bukkit
-import java.util.EnumSet
+import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_19_R2.scoreboard.CraftScoreboard
+import org.bukkit.entity.Player
+import java.util.*
 
 val vaultEconomy = try {
 	Bukkit.getServer().servicesManager.getRegistration(Economy::class.java)?.provider
@@ -16,5 +26,29 @@ inline fun <reified T : Enum<T>> enumSetOf(vararg elems: T): EnumSet<T> =
 
 /** Used for catching when a function that is not designed to be used async is being used async. */
 fun mainThreadCheck() {
-	if (!Bukkit.isPrimaryThread()) IonServer.Ion.slF4JLogger.warn("This function may be unsafe to use asynchronously.", Throwable())
+	if (!Bukkit.isPrimaryThread()) {
+		IonServer.Ion.slF4JLogger.warn(
+			"This function may be unsafe to use asynchronously.",
+			Throwable()
+		)
+	}
+}
+
+fun highlightBlock(player: Player, pos: BlockPos) {
+	val player = (player as CraftPlayer).handle
+	val conn = player.connection
+	//region DO NOT TOUCH; IT WORKS ONLY WITH THIS FOR SOME REASON
+	val nmsScoreBoard: Scoreboard = (Bukkit.getScoreboardManager().mainScoreboard as CraftScoreboard).handle
+	//endregion
+	val shulker =
+		Shulker(EntityType.SHULKER, player.level).apply {
+			setPos(pos.x + 0.5, pos.y.toDouble(), pos.z + 0.5)
+			setGlowingTag(true)
+			isInvisible = true
+		}
+
+	conn.send(ClientboundAddEntityPacket(shulker))
+	shulker.entityData.refresh(player)
+
+	Tasks.syncDelayTask(10 * 20) { conn.send(ClientboundRemoveEntitiesPacket(shulker.id)) }
 }

--- a/server/src/main/kotlin/net/starlegacy/listener/misc/ProtectionListener.kt
+++ b/server/src/main/kotlin/net/starlegacy/listener/misc/ProtectionListener.kt
@@ -63,7 +63,7 @@ object ProtectionListener : SLEventListener() {
 	/** Called on block break etc. GriefPrevention check should be done first.
 	 *  Loops through protected regions at location, checks each one for access message
 	 *  @return true if the event should be cancelled, false if it should stay the same. */
-	private fun denyBlockAccess(player: Player, location: Location): Boolean {
+	fun denyBlockAccess(player: Player, location: Location): Boolean {
 		if (isRegionDenied(player, location)) {
 			return true
 		}


### PR DESCRIPTION
This PR adds a very important time saver to the server, it lets players search items in chests via commands or a clientside mod (Where Is It). 

This feature is very useful for people with massive pipe buffers that need to find stuff in them, and is in general a very good QOL addon that not a lot of servers have. (Also, the search method filters out every chest that isn't accessible by the player running it).

Adds Where Is It integration
Adds three commands:
- /itemsearch: Searches the item you are holding.
- /itemsearch <material>: Searches for a vanilla material.
- /itemsearch <legacy/custom> <name>: Searches for a custom item.

The command will highlight the chests in vanilla too with a method I've added (Miscellaneous#highlightBlock) 