### PR TITLE
Fix docking tube message formatting

### DIFF
--- a/server/src/main/kotlin/net/starlegacy/feature/multiblock/dockingtube/ConnectedDockingTubeMultiblock.kt
+++ b/server/src/main/kotlin/net/starlegacy/feature/multiblock/dockingtube/ConnectedDockingTubeMultiblock.kt
@@ -28,7 +28,7 @@ object ConnectedDockingTubeMultiblock : DockingTubeMultiblock(
 
 	override fun toggle(sign: Sign, player: Player) {
 		if (ActiveStarships.findByBlock(sign.block) != null) {
-			player.userError("&cCannot toggle tube in an active ship")
+			player.userError("Cannot toggle tube in an active ship")
 			return
 		}
 

--- a/server/src/main/kotlin/net/starlegacy/feature/multiblock/dockingtube/DisconnectedDockingTubeMultiblock.kt
+++ b/server/src/main/kotlin/net/starlegacy/feature/multiblock/dockingtube/DisconnectedDockingTubeMultiblock.kt
@@ -24,7 +24,7 @@ object DisconnectedDockingTubeMultiblock : DockingTubeMultiblock(
 
 	override fun toggle(sign: Sign, player: Player) {
 		if (ActiveStarships.findByBlock(sign.block) != null) {
-			player.userError("&cCannot toggle tube in an active ship")
+			player.userError("Cannot toggle tube in an active ship")
 			return
 		}
 


### PR DESCRIPTION
Fixes the following:
![image](https://user-images.githubusercontent.com/66213737/219973287-ea255639-2e0f-4a08-ba2a-6c713628eb0a.png)
