### PR TITLE
Removed hyperspace jump arrow

### DIFF
--- a/server/src/main/kotlin/net/starlegacy/feature/starship/hyperspace/HyperspaceMap.kt
+++ b/server/src/main/kotlin/net/starlegacy/feature/starship/hyperspace/HyperspaceMap.kt
@@ -72,11 +72,11 @@ object HyperspaceMap : SLComponent() {
 
 	/** Draws the marker on the Dynmap*/
 	private fun drawMarker(marker: HyperspaceMarker) {
-		if (marker.isArrow) {
+		/*if (marker.isArrow) {
 			drawArrow(marker)
 		} else {
 			deleteDraw(marker, true)
-		}
+		}*/
 		if (marker.inHyperspace) {
 			drawShipTrack(marker)
 		}


### PR DESCRIPTION
Commented out the arrow that appears when jumping to hyperspace. Will be re-implemented as a cone in the future.