### PR TITLE
nation info command fix

### DIFF
--- a/server/src/main/kotlin/net/starlegacy/command/nations/NationCommand.kt
+++ b/server/src/main/kotlin/net/starlegacy/command/nations/NationCommand.kt
@@ -507,9 +507,7 @@ internal object NationCommand : SLCommand() {
 		}
 
 		val senderNationId: Oid<Nation>? = when (sender) {
-			is Player -> {
-				PlayerCache[sender].nation ?: fail { "You need to specify a nation. /n info <nation>" }
-			}
+			is Player -> PlayerCache[sender].nation
 			else -> null
 		}
 


### PR DESCRIPTION
- senderNationId (used for relation check) now returns null instead of failing command (NOT TESTED)