### PR TITLE
Escape underscores in usernames in /playerlist

### DIFF
--- a/proxy/src/main/kotlin/net/horizonsend/ion/proxy/commands/DiscordCommands.kt
+++ b/proxy/src/main/kotlin/net/horizonsend/ion/proxy/commands/DiscordCommands.kt
@@ -41,7 +41,7 @@ object DiscordCommands {
 						field {
 							name =
 								"${server.serverInfo.name.replaceFirstChar { it.titlecase(Locale.getDefault()) }}'s players"
-							value = server.playersConnected.joinToString("\n") { it.username }
+							value = server.playersConnected.joinToString("\n") { it.username.replace("_", "\\_") }
 						}
 					}
 				}


### PR DESCRIPTION
Should fix the issue seen below
![image](https://github.com/HorizonsEndMC/Ion/assets/66213737/1e58ac7c-23e9-40df-931e-f51d7ec8e792)
(See \_MrBlock_'s username)

Untested as I'm too lazy, but I don't think this will break anything, as it's incredibly minor.