### PR TITLE
changed one character, maybe fixed hyperspace releasing

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
@@ -316,7 +316,7 @@ object PilotedStarships : IonServerComponent() {
 		if (!StarshipUnpilotEvent(starship, player).callEvent()) {
 			return false
 		}
-		if (starship.serverLevel.world.name.contains("hyperspace")) return false
+		if (starship.serverLevel.world.name.contains("hyperspace", ignoreCase=true)) return false
 
 		unpilot(starship)
 		DeactivatedPlayerStarships.deactivateAsync(starship)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
@@ -316,7 +316,7 @@ object PilotedStarships : IonServerComponent() {
 		if (!StarshipUnpilotEvent(starship, player).callEvent()) {
 			return false
 		}
-		if (starship.serverLevel.world.name.contains("Hyperspace")) return false
+		if (starship.serverLevel.world.name.contains("hyperspace")) return false
 
 		unpilot(starship)
 		DeactivatedPlayerStarships.deactivateAsync(starship)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
@@ -120,7 +120,7 @@ abstract class StarshipMovement(val starship: ActiveStarship, val newWorld: Worl
 
 			onComplete()
 		}
-		if (world1 != world2 && !world2.toString().contains("hyperspace")) {
+		if (world1 != world2 && !world2.toString().contains("hyperspace", ignoreCase=true)) {
 			EnterPlanetEvent(world1, world2, starship.controller).callEvent()
 		}
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/projectile/SimpleProjectile.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/projectile/SimpleProjectile.kt
@@ -104,7 +104,7 @@ abstract class SimpleProjectile(
 
 	private fun tryImpact(result: RayTraceResult, newLoc: Location): Boolean {
 		if (starship?.serverLevel?.world?.name?.lowercase(Locale.getDefault())
-				?.contains("hyperspace")!!
+				?.contains("hyperspace", ignoreCase=true)!!
 		) return false
 		if (GracePeriod.isGracePeriod) return false
 
@@ -132,7 +132,7 @@ abstract class SimpleProjectile(
 		if (GracePeriod.isGracePeriod) return
 
 		val world = newLoc.world
-		if (world.environment == World.Environment.NETHER && world.name.lowercase().contains("hyperspace")) {
+		if (world.environment == World.Environment.NETHER && world.name.contains("hyperspace", ignoreCase=true)) {
 			return
 		}
 


### PR DESCRIPTION
The check for hyperspace dimensions in the tryRelease function checks for capital-H "Hyperspace" in the dimension name. To my knowledge, all hyperspace dimensions on Horizon's End use a lowercase-h (the checks in SimpleProjectile.kt and StarshipMovement.kt also use lowercase-h). Assuming this is the case, this check would return false even in a dimension such as Asteri_hyperspace; now, it will return true.