### PR TITLE
revert corvette LT power usage upping

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
@@ -118,7 +118,7 @@ data class StarshipTypeBalancing(
 				volume = 10,
 				pitch = 2.0f,
 				soundName = "starship.weapon.turbolaser.light.shoot",
-				powerUsage = 7500,
+				powerUsage = 6000,
 				length = 0,
 				angleRadians = 0.0,
 				convergeDistance = 0.0,


### PR DESCRIPTION
6000 -> 7500 -> 6000, it left a gap between 2001 and 3374 where no LTs would fire on corvettes, just a confusing and unnecessary balancing change