### PR TITLE
Custom blocks hotfix

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/customblocks/CustomBlockListeners.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/customblocks/CustomBlockListeners.kt
@@ -2,6 +2,7 @@ package net.horizonsend.ion.server.features.customblocks
 
 import net.horizonsend.ion.server.features.customitems.CustomBlockItem
 import net.horizonsend.ion.server.features.customitems.CustomItems.customItem
+import net.horizonsend.ion.server.features.customitems.commands.ConvertCommand
 import net.horizonsend.ion.server.listener.SLEventListener
 import org.bukkit.GameMode
 import org.bukkit.Material
@@ -10,6 +11,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.inventory.InventoryOpenEvent
 
 class CustomBlockListeners : SLEventListener() {
 
@@ -58,5 +60,22 @@ class CustomBlockListeners : SLEventListener() {
             }
         }
          */
+    }
+
+    @EventHandler
+    @Suppress("Unused")
+    fun onInventoryOpen(event: InventoryOpenEvent)
+    {
+        val inventory = event.inventory
+        for (item in inventory)
+        {
+            val newVersion = ConvertCommand.convertCustomMineral(item)
+            if (newVersion != null)
+            {
+                item.type = newVersion.type
+                item.itemMeta = newVersion.itemMeta
+                item.amount = newVersion.amount
+            }
+        }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/customblocks/CustomBlockListeners.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/customblocks/CustomBlockListeners.kt
@@ -1,19 +1,15 @@
 package net.horizonsend.ion.server.features.customblocks
 
 import net.horizonsend.ion.server.features.customitems.CustomBlockItem
-import net.horizonsend.ion.server.features.customitems.CustomItems
 import net.horizonsend.ion.server.features.customitems.CustomItems.customItem
 import net.horizonsend.ion.server.listener.SLEventListener
-import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import org.bukkit.GameMode
 import org.bukkit.Material
 import org.bukkit.block.data.BlockData
-import org.bukkit.enchantments.Enchantment
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
-import org.bukkit.inventory.ItemStack
 
 class CustomBlockListeners : SLEventListener() {
 
@@ -39,11 +35,13 @@ class CustomBlockListeners : SLEventListener() {
         val block = event.block
         val customBlock = CustomBlocks.getByBlock(block) ?: return
 
+        // Prevents brown mushrooms from dropping
         if (event.isDropItems) {
             event.isDropItems = false
             block.type = Material.AIR
         }
 
+        /*
         val itemUsed = event.player.inventory.itemInMainHand
         val location = block.location.toCenterLocation()
         if (itemUsed.enchantments.containsKey(Enchantment.SILK_TOUCH)) {
@@ -59,5 +57,6 @@ class CustomBlockListeners : SLEventListener() {
                 }
             }
         }
+         */
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/customitems/commands/ConvertCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/customitems/commands/ConvertCommand.kt
@@ -10,6 +10,7 @@ import net.horizonsend.ion.server.features.customitems.CustomItems
 import net.horizonsend.ion.server.features.customitems.CustomItems.customItem
 import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
 
 @CommandAlias("convert")
 @Suppress("Unused")
@@ -74,61 +75,67 @@ object ConvertCommand : SLCommand() { // I imagine we'll need more than blasters
 	fun onConvertMineral(sender: Player) {
 		val heldItem = sender.inventory.itemInMainHand
 
-		if ((heldItem.type != Material.IRON_INGOT &&
-					heldItem.type != Material.IRON_ORE &&
-					heldItem.type != Material.IRON_BLOCK) ||
-			!heldItem.itemMeta.hasCustomModelData() ||
-			heldItem.itemMeta.customModelData == 0
-		) {
+		val newVersion = convertCustomMineral(heldItem)
+		if (newVersion == null) {
 			sender.userError("Not a valid custom item!")
 			return
 		}
 
-		if (heldItem.customItem != null) {
-			sender.userError("Item is already converted!")
-			return
+		sender.inventory.setItemInMainHand(newVersion)
+		sender.updateInventory()
+	}
+
+	fun convertCustomMineral(item: ItemStack?) : ItemStack? {
+		if (item == null) return null
+
+		if ((item.type != Material.IRON_INGOT &&
+				item.type != Material.IRON_ORE &&
+				item.type != Material.IRON_BLOCK) ||
+			!item.itemMeta.hasCustomModelData() ||
+			item.itemMeta.customModelData == 0
+			) {
+			return null
 		}
 
-		val newVersion = when (heldItem.type) {
-			Material.IRON_INGOT -> when (heldItem.itemMeta.customModelData) {
+		if (item.customItem != null) {
+			return null
+		}
+
+		val newVersion = when (item.type) {
+			Material.IRON_INGOT -> when (item.itemMeta.customModelData) {
 				1 -> CustomItems.ALUMINUM_INGOT
 				2 -> CustomItems.CHETHERITE
 				3 -> CustomItems.TITANIUM_INGOT
 				4 -> CustomItems.URANIUM
 				else -> {
-					sender.information("Wtf do you have")
-					return
+					return null
 				}
 			}
-			Material.IRON_ORE -> when (heldItem.itemMeta.customModelData) {
+			Material.IRON_ORE -> when (item.itemMeta.customModelData) {
 				1 -> CustomItems.ALUMINUM_ORE
 				2 -> CustomItems.CHETHERITE_ORE
 				3 -> CustomItems.TITANIUM_ORE
 				4 -> CustomItems.URANIUM_ORE
 				else -> {
-					sender.information("Wtf do you have")
-					return
+					return null
 				}
 			}
-			Material.IRON_BLOCK -> when (heldItem.itemMeta.customModelData) {
+			Material.IRON_BLOCK -> when (item.itemMeta.customModelData) {
 				1 -> CustomItems.ALUMINUM_BLOCK
 				2 -> CustomItems.CHETHERITE_BLOCK
 				3 -> CustomItems.TITANIUM_BLOCK
 				4 -> CustomItems.URANIUM_BLOCK
 				else -> {
-					sender.information("Wtf do you have")
-					return
+					return null
 				}
 			}
 			else -> {
-				sender.userError("This should not have exited here...")
-				return
+				return null
 			}
 		}.constructItemStack()
 
-		newVersion.amount = heldItem.amount
+		newVersion.amount = item.amount
 
-		sender.inventory.setItemInMainHand(newVersion)
-		sender.updateInventory()
+		return newVersion
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/misc/DecomposeTask.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/misc/DecomposeTask.kt
@@ -103,6 +103,7 @@ class DecomposeTask(
 
 				val block = newLocation.block
 				val blockData = block.blockData
+				val customBlock = CustomBlocks.getByBlock(block)
 
 				if (blockData.material.isAir) continue
 
@@ -118,13 +119,12 @@ class DecomposeTask(
 				PowerMachines.removePower(sign, 10)
 
 				// get drops BEFORE breaking
-				var drops: Collection<ItemStack> = block.drops
+				var drops: List<ItemStack> = block.drops.toList()
 
-				val customBlock = CustomBlocks.getByBlock(block) != null
 				var customOre = false
-				Ore.entries.forEach { ore -> if (ore.blockData == (CustomBlocks.getByBlock(block)?.blockData ?: false)) customOre = true }
+				Ore.entries.forEach { ore -> if (ore.blockData == (customBlock?.blockData ?: false)) customOre = true }
 
-				if (customBlock && !customOre) drops = CustomBlocks.getByBlock(block)?.getDrops()?.toList()!!
+				if (customBlock != null && !customOre) drops = customBlock.getDrops().toList()
 
 				block.setType(Material.AIR, false)
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/drills/DrillMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/drills/DrillMultiblock.kt
@@ -103,14 +103,14 @@ abstract class DrillMultiblock(tierText: String, val tierMaterial: Material) :
 					continue
 				}
 
-				if (!canBuild(block)) {
-					continue
-				}
-
 				val customBlock = CustomBlocks.getByBlock(block)
 				var drops = customBlock?.getDrops() ?: if (block.type == Material.SNOW_BLOCK) listOf() else block.drops
 
 				if (block.type.isShulkerBox) drops = listOf()
+
+				if (!canBuild(block)) {
+					continue
+				}
 
 				for (item in drops) {
 					if (!LegacyItemUtils.canFit(output, item)) {


### PR DESCRIPTION
- Improved Power Drill feedback when breaking custom blocks
- Opening chests/containers containing legacy mineral items will automatically convert them into new custom mineral items

- Fixed mining lasers not collecting custom blocks when in survival mode
- Fixed a duplication glitch

- Removed ability for pickaxes to mine custom ores
- Removed ability for silk touch pickaxes to mine custom ores and drop the original ore block