### PR TITLE
Allow double slabs in turret terracotta positions

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockShape.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockShape.kt
@@ -279,6 +279,18 @@ class MultiblockShape {
 			return@complete blockData is Slab && blockData.type == Slab.Type.DOUBLE
 		}
 
+		fun terracottaOrDoubleslab() {
+			complete(
+				Material.TERRACOTTA.createBlockData()
+			) { block, _, loadChunks ->
+				val blockData: BlockData? = if (loadChunks) block.blockData else getBlockDataSafe(block.world, block.x, block.y, block.z)
+				val blockType = if (loadChunks) block.type else block.getTypeSafe()
+
+				return@complete (blockData is Slab && blockData.type == Slab.Type.DOUBLE)
+					|| TERRACOTTA_TYPES.contains(blockType)
+			}
+		}
+
 		fun concrete() = filteredTypes { it.isConcrete }
 
 		fun stoneBrick() = type(Material.STONE_BRICKS)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/HeavyTurretMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/HeavyTurretMultiblock.kt
@@ -54,9 +54,9 @@ sealed class HeavyTurretMultiblock : TurretMultiblock() {
 			}
 			y(getSign() * 3) {
 				x(-2).anyStairs()
-				x(-1).terracotta()
+				x(-1).terracottaOrDoubleslab()
 				x(+0).carbyne()
-				x(+1).terracotta()
+				x(+1).terracottaOrDoubleslab()
 				x(+2).anyStairs()
 			}
 			y(getSign() * 4) {
@@ -71,9 +71,9 @@ sealed class HeavyTurretMultiblock : TurretMultiblock() {
 			}
 			y(getSign() * 3) {
 				x(-2).anyStairs()
-				x(-1).terracotta()
+				x(-1).terracottaOrDoubleslab()
 				x(+0).carbyne()
-				x(+1).terracotta()
+				x(+1).terracottaOrDoubleslab()
 				x(+2).anyStairs()
 			}
 			y(getSign() * 4) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/LightTurretMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/LightTurretMultiblock.kt
@@ -24,7 +24,7 @@ sealed class LightTurretMultiblock : TurretMultiblock() {
 		z(-1) {
 			y(getSign() * 3) {
 				x(-1).anyStairs()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 			}
 			y(getSign() * 4) {
@@ -36,9 +36,9 @@ sealed class LightTurretMultiblock : TurretMultiblock() {
 				x(+0).sponge()
 			}
 			y(getSign() * 3) {
-				x(-1).terracotta()
+				x(-1).terracottaOrDoubleslab()
 				x(+0).ironBlock()
-				x(+1).terracotta()
+				x(+1).terracottaOrDoubleslab()
 			}
 			y(getSign() * 4) {
 				x(-1).anySlab()
@@ -49,7 +49,7 @@ sealed class LightTurretMultiblock : TurretMultiblock() {
 		z(+1) {
 			y(getSign() * 3) {
 				x(-1).anyStairs()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 			}
 			y(getSign() * 4) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/QuadTurretMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/QuadTurretMultiblock.kt
@@ -29,7 +29,7 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 		z(-4) {
 			y(getSign() * 3) {
 				x(-1).anyStairs()
-				x(0).terracotta()
+				x(0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 			}
 		}
@@ -59,9 +59,9 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 			}
 			y(getSign() * 4) {
 				x(-2).anyStairs()
-				x(-1).terracotta()
+				x(-1).terracottaOrDoubleslab()
 				x(0).anyStairs()
-				x(+1).terracotta()
+				x(+1).terracottaOrDoubleslab()
 				x(+2).anyStairs()
 			}
 		}
@@ -82,11 +82,11 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 			}
 			y(getSign() * 4) {
 				x(-3).anySlab()
-				x(-2).terracotta()
-				x(-1).terracotta()
-				x(+0).terracotta()
-				x(+1).terracotta()
-				x(+2).terracotta()
+				x(-2).terracottaOrDoubleslab()
+				x(-1).terracottaOrDoubleslab()
+				x(+0).terracottaOrDoubleslab()
+				x(+1).terracottaOrDoubleslab()
+				x(+2).terracottaOrDoubleslab()
 				x(+3).anySlab()
 			}
 		}
@@ -96,22 +96,22 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 				x(+1).sponge()
 			}
 			y(getSign() * 3) {
-				x(-4).terracotta()
+				x(-4).terracottaOrDoubleslab()
 				x(-3).carbyne()
-				x(-2).terracotta()
+				x(-2).terracottaOrDoubleslab()
 				x(-1).carbyne()
 				x(+0).carbyne()
 				x(+1).carbyne()
-				x(+2).terracotta()
+				x(+2).terracottaOrDoubleslab()
 				x(+3).carbyne()
-				x(+4).terracotta()
+				x(+4).terracottaOrDoubleslab()
 			}
 			y(getSign() * 4) {
 				x(-3).anySlab()
 				x(-2).type(GRINDSTONE)
-				x(-1).terracotta()
+				x(-1).terracottaOrDoubleslab()
 				x(+0).anyStairs()
-				x(+1).terracotta()
+				x(+1).terracottaOrDoubleslab()
 				x(+2).type(GRINDSTONE)
 				x(+3).anySlab()
 			}
@@ -123,11 +123,11 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 			y(getSign() * 3) {
 				x(-4).anyStairs()
 				x(-3).carbyne()
-				x(-2).terracotta()
-				x(-1).terracotta()
+				x(-2).terracottaOrDoubleslab()
+				x(-1).terracottaOrDoubleslab()
 				x(+0).carbyne()
-				x(+1).terracotta()
-				x(+2).terracotta()
+				x(+1).terracottaOrDoubleslab()
+				x(+2).terracottaOrDoubleslab()
 				x(+3).carbyne()
 				x(+4).anyStairs()
 			}
@@ -144,11 +144,11 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 		z(+2) {
 			y(getSign() * 3) {
 				x(-3).ironBlock()
-				x(-2).terracotta()
-				x(-1).terracotta()
+				x(-2).terracottaOrDoubleslab()
+				x(-1).terracottaOrDoubleslab()
 				x(+0).carbyne()
-				x(+1).terracotta()
-				x(+2).terracotta()
+				x(+1).terracottaOrDoubleslab()
+				x(+2).terracottaOrDoubleslab()
 				x(+3).ironBlock()
 			}
 			y(getSign() * 4) {
@@ -162,9 +162,9 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 		z(+3) {
 			y(getSign() * 3) {
 				x(-2).ironBlock()
-				x(-1).terracotta()
+				x(-1).terracottaOrDoubleslab()
 				x(0).carbyne()
-				x(+1).terracotta()
+				x(+1).terracottaOrDoubleslab()
 				x(+2).ironBlock()
 			}
 			y(getSign() * 4) {
@@ -176,7 +176,7 @@ sealed class QuadTurretMultiblock : TurretMultiblock() {
 		z(+4) {
 			y(getSign() * 3) {
 				x(-1).anyStairs()
-				x(0).terracotta()
+				x(0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 			}
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/TriTurretMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/starshipweapon/turret/TriTurretMultiblock.kt
@@ -45,7 +45,7 @@ sealed class TriTurretMultiblock : TurretMultiblock() {
 		y(getYFactor() * 3) {
 			z(-3) {
 				x(-1).anyStairs()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 			}
 
@@ -62,25 +62,25 @@ sealed class TriTurretMultiblock : TurretMultiblock() {
 			}
 
 			z(+0) {
-				x(-3..-2) { terracotta() }
+				x(-3..-2) { terracottaOrDoubleslab() }
 				x(-1..+1) { concrete() }
-				x(+2..+3) { terracotta() }
+				x(+2..+3) { terracottaOrDoubleslab() }
 			}
 
 			z(+1) {
 				x(-3).anyStairs()
-				x(-2).terracotta()
+				x(-2).terracottaOrDoubleslab()
 				x(-1).concrete()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).concrete()
-				x(+2).terracotta()
+				x(+2).terracottaOrDoubleslab()
 				x(+3).anyStairs()
 			}
 
 			z(+2) {
 				x(-2).ironBlock()
 				x(-1).concrete()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).concrete()
 				x(+2).ironBlock()
 			}
@@ -100,24 +100,24 @@ sealed class TriTurretMultiblock : TurretMultiblock() {
 			z(-2) {
 				x(-2).anySlab()
 				x(-1).anyStairs()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 				x(+2).anySlab()
 			}
 
 			z(-1) {
-				x(-2).terracotta()
-				x(-1).terracotta()
-				x(+0).terracotta()
-				x(+1).terracotta()
-				x(+2).terracotta()
+				x(-2).terracottaOrDoubleslab()
+				x(-1).terracottaOrDoubleslab()
+				x(+0).terracottaOrDoubleslab()
+				x(+1).terracottaOrDoubleslab()
+				x(+2).terracottaOrDoubleslab()
 			}
 
 			z(+0) {
 				x(-3).anyStairs()
 				x(-2).type(GRINDSTONE)
 				x(-1).anyStairs()
-				x(+0).terracotta()
+				x(+0).terracottaOrDoubleslab()
 				x(+1).anyStairs()
 				x(+2).type(GRINDSTONE)
 				x(+3).anyStairs()


### PR DESCRIPTION
Allow double slabs in place of terracotta in turret multiblocks. This does not allow single slabs in said positions.