### PR TITLE
Revised BC balancing

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
@@ -219,7 +219,7 @@ data class StarshipTypeBalancing(
 		maxSneakFlyAccel = 3,
 		interdictionRange = 3200,
 		hyperspaceRangeMultiplier = 2.5,
-		cruiseSpeedMultiplier = 0.875,
+		cruiseSpeedMultiplier = 0.5,
 		weapons = StarshipWeapons(
 			quadTurret = StarshipWeapons.StarshipWeapon(
 				canFire = true,
@@ -232,7 +232,7 @@ data class StarshipTypeBalancing(
 				volume = 0,
 				pitch = 2.0f,
 				soundName = "starship.weapon.turbolaser.quad.shoot",
-				powerUsage = 3000,
+				powerUsage = 4500,
 				length = 0,
 				angleRadians = 0.0,
 				convergeDistance = 0.0,


### PR DESCRIPTION
BC speed ~14 -> ~8 (they were too fast to justify the weapon power) Quad turret power usage 3000 -> 4500 (in attempt to limit the armament of mini BCs and such)