### PR TITLE
Contacts Center of Mass Change

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
@@ -229,15 +229,21 @@ object ContactsSidebar {
         contactsList: MutableList<ContactsData>,
         player: Player
     ) {
+        val currentStarship = PilotedStarships[player]
+        val interdictionLocation = currentStarship?.centerOfMass?.toVector() ?: playerVector
+
         for (starship in starships) {
             val otherController = starship.controller
-            val vector = starship.centerOfMass.toVector()
+            val vector = when (otherController) {
+                is ActivePlayerController -> otherController.player.location.toVector()
+                else -> starship.centerOfMass.toVector()
+            }
 
             val distance = vector.distance(playerVector).toInt()
+            val interdictionDistance = starship.centerOfMass.toVector().distance(interdictionLocation).toInt()
             val direction = getDirectionToObject(vector.clone().subtract(playerVector).normalize())
             val height = vector.y.toInt()
             val color = distanceColor(distance)
-            val currentStarship = PilotedStarships[player]
 
             contactsList.add(
                 ContactsData(
@@ -248,7 +254,7 @@ object ContactsSidebar {
                             autoTurretTextComponent(currentStarship, starship)
                         } else Component.empty(),
                         if (starship.isInterdicting) {
-                            interdictionTextComponent(distance, starship.balancing.interdictionRange, true)
+                            interdictionTextComponent(interdictionDistance, starship.balancing.interdictionRange, true)
                         } else Component.empty()
                     ),
                     heading = constructHeadingTextComponent(direction, color),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
@@ -117,10 +117,10 @@ object ContactsSidebar {
         return directionString.toString()
     }
 
-    // Main method for generating all contacts a player cna see
+    // Main method for generating all contacts a player can see
     fun getPlayerContacts(player: Player): List<ContactsData> {
         val contactsList: MutableList<ContactsData> = mutableListOf()
-        val playerVector = player.location.toVector()
+        val playerVector = PilotedStarships[player]?.centerOfMass?.toVector() ?: player.location.toVector()
 
         val starshipsEnabled = PlayerCache[player].contactsStarships
         val lastStarshipEnabled = PlayerCache[player].lastStarshipEnabled
@@ -231,10 +231,7 @@ object ContactsSidebar {
     ) {
         for (starship in starships) {
             val otherController = starship.controller
-            val vector = when (otherController) {
-                is ActivePlayerController -> otherController.player.location.toVector()
-                else -> starship.centerOfMass.toVector()
-            }
+            val vector = starship.centerOfMass.toVector()
 
             val distance = vector.distance(playerVector).toInt()
             val direction = getDirectionToObject(vector.clone().subtract(playerVector).normalize())


### PR DESCRIPTION
- If a player is piloting a starship, the ship's center of mass will now be used to calculate the distance from other objects instead of the player's position. The player position will still be used if not piloted.
- Other starships' center of mass will always be used to calculate the distance to the contacts viewer.