### PR TITLE
Sidebar 2 Hotfix

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
@@ -44,7 +44,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 		var planetsEnabled: Boolean = true,
 		var starsEnabled: Boolean = true,
 		var beaconsEnabled: Boolean = true,
-		var stationsEnabled: Boolean = true,
+		var stationsEnabled: Boolean = false,
 		var bookmarksEnabled: Boolean = true,
 
 		var waypointsEnabled: Boolean = true,

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
@@ -70,7 +70,7 @@ data class SLPlayer(
 	var planetsEnabled: Boolean = true,
 	var starsEnabled: Boolean = true,
 	var beaconsEnabled: Boolean = true,
-	var stationsEnabled: Boolean = true,
+	var stationsEnabled: Boolean = false,
 	var bookmarksEnabled: Boolean = true,
 	var waypointsEnabled: Boolean = true,
 	var compactWaypoints: Boolean = true,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarCommand.kt
@@ -1,0 +1,93 @@
+package net.horizonsend.ion.server.features.sidebar.command
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.Default
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_ORANGE
+import net.horizonsend.ion.common.utils.text.lineBreak
+import net.horizonsend.ion.common.utils.text.lineBreakWithCenterText
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.features.sidebar.Sidebar
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.BOOKMARK_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.COMPASS_NEEDLE_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.GENERIC_STARSHIP_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.GUNSHIP_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.HYPERSPACE_BEACON_ENTER_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.LIST_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.PLANET_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.ROUTE_SEGMENT_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.STAR_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.STATION_ICON
+import net.kyori.adventure.text.Component.newline
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.NamedTextColor.AQUA
+import net.kyori.adventure.text.format.NamedTextColor.GOLD
+import net.kyori.adventure.text.format.NamedTextColor.GRAY
+import net.kyori.adventure.text.format.NamedTextColor.GREEN
+import net.kyori.adventure.text.format.NamedTextColor.WHITE
+import org.bukkit.entity.Player
+
+@CommandAlias("sidebar")
+object SidebarCommand : SLCommand() {
+    @Default
+    @Suppress("unused")
+    fun defaultCase(sender: Player) {
+        val starshipsComponentsEnabled = PlayerCache[sender.uniqueId].starshipsEnabled
+        val advancedStarshipInfo = PlayerCache[sender.uniqueId].advancedStarshipInfo
+        val rotateCompass = PlayerCache[sender.uniqueId].rotateCompass
+
+        val contactsComponentsEnabled = PlayerCache[sender.uniqueId].contactsEnabled
+        val starshipsEnabled = PlayerCache[sender.uniqueId].contactsStarships
+        val lastStarshipEnabled = PlayerCache[sender.uniqueId].lastStarshipEnabled
+        val planetsEnabled = PlayerCache[sender.uniqueId].planetsEnabled
+        val starsEnabled = PlayerCache[sender.uniqueId].starsEnabled
+        val beaconsEnabled = PlayerCache[sender.uniqueId].beaconsEnabled
+        val stationsEnabled = PlayerCache[sender.uniqueId].stationsEnabled
+        val bookmarksEnabled = PlayerCache[sender.uniqueId].bookmarksEnabled
+
+        val waypointsComponentsEnabled = PlayerCache[sender.uniqueId].waypointsEnabled
+        val compactWaypoints = PlayerCache[sender.uniqueId].compactWaypoints
+
+        sender.sendMessage(ofChildren(
+            lineBreakWithCenterText(text("Starship - Information about your current starship", HE_LIGHT_ORANGE), width=1), newline(),
+            text("Starship information visible: $starshipsComponentsEnabled", WHITE), newline(),
+            text("\\ N /", GRAY).append(text(" Cruise Compass", WHITE)), newline(),
+            text("W ^ E", GRAY).append(text(" Indicates current and desired cruise direction", WHITE)), newline(),
+            text("/ S \\", GRAY).append(text(" GOLD", GOLD)).append(text(" - Current cruise direction vector, ", WHITE))
+                .append(text("AQUA", AQUA)).append(text(" - Desired cruise direction vector, ", WHITE))
+                .append(text("GREEN", GREEN)).append(text(" - Current and desired cruise direction vectors matching", WHITE)), newline(), newline(),
+            text("HULL: ", GRAY).append(text("Current hull percentage and block count", WHITE)), newline(),
+            text("SPD: ", GRAY).append(text("Current speed, maximum speed, acceleration, and cruise/DC status", WHITE)), newline(),
+            text("PM: ", GRAY).append(text("Current power mode for shields, weapons, and thrusters", WHITE)), newline(),
+            text("CAP: ", GRAY).append(text("Current light weapons energy within ship capacitor", WHITE)), newline(),
+            text("HVY: ", GRAY).append(text("Cooldown for heavy weapons", WHITE)), newline(),
+            text("ACTIVE: ", GRAY).append(text("Active weapon sets and ship modules", WHITE)), newline(),
+            newline(),
+            text("Settings: "), newline(),
+            text(LIST_ICON.text, getColor(advancedStarshipInfo)).font(Sidebar.fontKey), text(" advanced - Displays advanced information: $advancedStarshipInfo", WHITE), newline(),
+            text(COMPASS_NEEDLE_ICON.text, getColor(rotateCompass)).font(Sidebar.fontKey), text(" rotatecompass - Top of compass faces direction that ship is facing: $rotateCompass", WHITE), newline(),
+            lineBreak(47), newline(),
+            newline(),
+            lineBreakWithCenterText(text("Contacts - View nearby objects and their status", HE_LIGHT_ORANGE), width=3), newline(),
+            text("Contacts information visible: $contactsComponentsEnabled", WHITE), newline(),
+            text(GUNSHIP_ICON.text, getColor(starshipsEnabled)).font(Sidebar.fontKey), text(" starship - Other starships visible: $starshipsEnabled", WHITE), newline(),
+            text(GENERIC_STARSHIP_ICON.text, getColor(lastStarshipEnabled)).font(Sidebar.fontKey), text(" laststarship - Last piloted starship visible: $lastStarshipEnabled", WHITE), newline(),
+            text(PLANET_ICON.text, getColor(planetsEnabled)).font(Sidebar.fontKey), text(" planet - Planets visible: $planetsEnabled", WHITE), newline(),
+            text(STAR_ICON.text, getColor(starsEnabled)).font(Sidebar.fontKey), text(" stars - Stars visible: $starsEnabled", WHITE), newline(),
+            text(HYPERSPACE_BEACON_ENTER_ICON.text, getColor(beaconsEnabled)).font(Sidebar.fontKey), text(" beacons - Hyperspace beacons visible: $beaconsEnabled", WHITE), newline(),
+            text(STATION_ICON.text, getColor(stationsEnabled)).font(Sidebar.fontKey), text(" stations - Stations and siege stations visible: $stationsEnabled", WHITE), newline(),
+            text(BOOKMARK_ICON.text, getColor(bookmarksEnabled)).font(Sidebar.fontKey), text(" bookmarks - Bookmarks visible: $bookmarksEnabled", WHITE), newline(),
+            lineBreak(47), newline(),
+            newline(),
+            lineBreakWithCenterText(text("Route - Current plotted route", HE_LIGHT_ORANGE), width=9), newline(),
+            text("Route information visible: $waypointsComponentsEnabled", WHITE), newline(),
+            text(ROUTE_SEGMENT_ICON.text, getColor(compactWaypoints)).font(Sidebar.fontKey), text(" compactwaypoints - Display route segments between destinations: $compactWaypoints"), newline(),
+        ))
+    }
+
+    private fun getColor(enabled: Boolean) : NamedTextColor {
+        return if (enabled) AQUA else GRAY
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarCommand.kt
@@ -2,7 +2,9 @@ package net.horizonsend.ion.server.features.sidebar.command
 
 import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.Default
+import co.aikar.commands.annotation.Optional
 import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_ORANGE
+import net.horizonsend.ion.common.utils.text.formatPaginatedMenu
 import net.horizonsend.ion.common.utils.text.lineBreak
 import net.horizonsend.ion.common.utils.text.lineBreakWithCenterText
 import net.horizonsend.ion.common.utils.text.ofChildren
@@ -19,6 +21,7 @@ import net.horizonsend.ion.server.features.sidebar.SidebarIcon.PLANET_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.ROUTE_SEGMENT_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.STAR_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.STATION_ICON
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.newline
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
@@ -33,61 +36,125 @@ import org.bukkit.entity.Player
 object SidebarCommand : SLCommand() {
     @Default
     @Suppress("unused")
-    fun defaultCase(sender: Player) {
-        val starshipsComponentsEnabled = PlayerCache[sender.uniqueId].starshipsEnabled
-        val advancedStarshipInfo = PlayerCache[sender.uniqueId].advancedStarshipInfo
-        val rotateCompass = PlayerCache[sender.uniqueId].rotateCompass
+    fun defaultCase(sender: Player, @Optional page: Int?) {
+        val body = formatPaginatedMenu(
+            entries = listOf(starshipComponents(sender), contactsComponents(sender), routeComponents(sender)),
+            command = "/sidebar",
+            currentPage = page ?: 1,
+            maxPerPage = 1,
+        )
 
-        val contactsComponentsEnabled = PlayerCache[sender.uniqueId].contactsEnabled
-        val starshipsEnabled = PlayerCache[sender.uniqueId].contactsStarships
-        val lastStarshipEnabled = PlayerCache[sender.uniqueId].lastStarshipEnabled
-        val planetsEnabled = PlayerCache[sender.uniqueId].planetsEnabled
-        val starsEnabled = PlayerCache[sender.uniqueId].starsEnabled
-        val beaconsEnabled = PlayerCache[sender.uniqueId].beaconsEnabled
-        val stationsEnabled = PlayerCache[sender.uniqueId].stationsEnabled
-        val bookmarksEnabled = PlayerCache[sender.uniqueId].bookmarksEnabled
-
-        val waypointsComponentsEnabled = PlayerCache[sender.uniqueId].waypointsEnabled
-        val compactWaypoints = PlayerCache[sender.uniqueId].compactWaypoints
-
-        sender.sendMessage(ofChildren(
-            lineBreakWithCenterText(text("Starship - Information about your current starship", HE_LIGHT_ORANGE), width=1), newline(),
-            text("Starship information visible: $starshipsComponentsEnabled", WHITE), newline(),
-            text("\\ N /", GRAY).append(text(" Cruise Compass", WHITE)), newline(),
-            text("W ^ E", GRAY).append(text(" Indicates current and desired cruise direction", WHITE)), newline(),
-            text("/ S \\", GRAY).append(text(" GOLD", GOLD)).append(text(" - Current cruise direction vector, ", WHITE))
-                .append(text("AQUA", AQUA)).append(text(" - Desired cruise direction vector, ", WHITE))
-                .append(text("GREEN", GREEN)).append(text(" - Current and desired cruise direction vectors matching", WHITE)), newline(), newline(),
-            text("HULL: ", GRAY).append(text("Current hull percentage and block count", WHITE)), newline(),
-            text("SPD: ", GRAY).append(text("Current speed, maximum speed, acceleration, and cruise/DC status", WHITE)), newline(),
-            text("PM: ", GRAY).append(text("Current power mode for shields, weapons, and thrusters", WHITE)), newline(),
-            text("CAP: ", GRAY).append(text("Current light weapons energy within ship capacitor", WHITE)), newline(),
-            text("HVY: ", GRAY).append(text("Cooldown for heavy weapons", WHITE)), newline(),
-            text("ACTIVE: ", GRAY).append(text("Active weapon sets and ship modules", WHITE)), newline(),
-            newline(),
-            text("Settings: "), newline(),
-            text(LIST_ICON.text, getColor(advancedStarshipInfo)).font(Sidebar.fontKey), text(" advanced - Displays advanced information: $advancedStarshipInfo", WHITE), newline(),
-            text(COMPASS_NEEDLE_ICON.text, getColor(rotateCompass)).font(Sidebar.fontKey), text(" rotatecompass - Top of compass faces direction that ship is facing: $rotateCompass", WHITE), newline(),
-            lineBreak(47), newline(),
-            newline(),
-            lineBreakWithCenterText(text("Contacts - View nearby objects and their status", HE_LIGHT_ORANGE), width=3), newline(),
-            text("Contacts information visible: $contactsComponentsEnabled", WHITE), newline(),
-            text(GUNSHIP_ICON.text, getColor(starshipsEnabled)).font(Sidebar.fontKey), text(" starship - Other starships visible: $starshipsEnabled", WHITE), newline(),
-            text(GENERIC_STARSHIP_ICON.text, getColor(lastStarshipEnabled)).font(Sidebar.fontKey), text(" laststarship - Last piloted starship visible: $lastStarshipEnabled", WHITE), newline(),
-            text(PLANET_ICON.text, getColor(planetsEnabled)).font(Sidebar.fontKey), text(" planet - Planets visible: $planetsEnabled", WHITE), newline(),
-            text(STAR_ICON.text, getColor(starsEnabled)).font(Sidebar.fontKey), text(" stars - Stars visible: $starsEnabled", WHITE), newline(),
-            text(HYPERSPACE_BEACON_ENTER_ICON.text, getColor(beaconsEnabled)).font(Sidebar.fontKey), text(" beacons - Hyperspace beacons visible: $beaconsEnabled", WHITE), newline(),
-            text(STATION_ICON.text, getColor(stationsEnabled)).font(Sidebar.fontKey), text(" stations - Stations and siege stations visible: $stationsEnabled", WHITE), newline(),
-            text(BOOKMARK_ICON.text, getColor(bookmarksEnabled)).font(Sidebar.fontKey), text(" bookmarks - Bookmarks visible: $bookmarksEnabled", WHITE), newline(),
-            lineBreak(47), newline(),
-            newline(),
-            lineBreakWithCenterText(text("Route - Current plotted route", HE_LIGHT_ORANGE), width=9), newline(),
-            text("Route information visible: $waypointsComponentsEnabled", WHITE), newline(),
-            text(ROUTE_SEGMENT_ICON.text, getColor(compactWaypoints)).font(Sidebar.fontKey), text(" compactwaypoints - Display route segments between destinations: $compactWaypoints"), newline(),
-        ))
+        sender.sendMessage(body)
     }
 
-    private fun getColor(enabled: Boolean) : NamedTextColor {
+    private fun starshipComponents(player: Player) : Component {
+        val starshipsComponentsEnabled = PlayerCache[player.uniqueId].starshipsEnabled
+        val advancedStarshipInfo = PlayerCache[player.uniqueId].advancedStarshipInfo
+        val rotateCompass = PlayerCache[player.uniqueId].rotateCompass
+
+        return ofChildren(
+            lineBreakWithCenterText(
+                text("Starship - Information about your current starship", HE_LIGHT_ORANGE),
+                width = 1
+            ),
+            newline(),
+            text("Starship information visible: $starshipsComponentsEnabled", WHITE),
+            newline(),
+            text("\\ N /", GRAY).append(text(" Cruise Compass", WHITE)),
+            newline(),
+            text("W ^ E", GRAY).append(text(" Indicates current and desired cruise direction", WHITE)),
+            newline(),
+            text("/ S \\", GRAY).append(text(" GOLD", GOLD)).append(text(" - Current cruise direction vector, ", WHITE))
+                .append(text("AQUA", AQUA)).append(text(" - Desired cruise direction vector, ", WHITE))
+                .append(text("GREEN", GREEN))
+                .append(text(" - Current and desired cruise direction vectors matching", WHITE)),
+            newline(),
+            newline(),
+            text("HULL: ", GRAY).append(text("Current hull percentage and block count", WHITE)),
+            newline(),
+            text("SPD: ", GRAY).append(text("Current speed, maximum speed, acceleration, and cruise/DC status", WHITE)),
+            newline(),
+            text("PM: ", GRAY).append(text("Current power mode for shields, weapons, and thrusters", WHITE)),
+            newline(),
+            text("CAP: ", GRAY).append(text("Current light weapons energy within ship capacitor", WHITE)),
+            newline(),
+            text("HVY: ", GRAY).append(text("Cooldown for heavy weapons", WHITE)),
+            newline(),
+            text("ACTIVE: ", GRAY).append(text("Active weapon sets and ship modules", WHITE)),
+            newline(),
+            newline(),
+            text("Settings: "),
+            newline(),
+            text(LIST_ICON.text, getColor(advancedStarshipInfo)).font(Sidebar.fontKey),
+            text(" advanced - Displays advanced information: $advancedStarshipInfo", WHITE),
+            newline(),
+            text(COMPASS_NEEDLE_ICON.text, getColor(rotateCompass)).font(Sidebar.fontKey),
+            text(" rotatecompass - Top of compass faces direction that ship is facing: $rotateCompass", WHITE),
+            newline(),
+            lineBreak(47),
+        )
+    }
+
+    private fun contactsComponents(player: Player) : Component {
+        val contactsComponentsEnabled = PlayerCache[player.uniqueId].contactsEnabled
+        val starshipsEnabled = PlayerCache[player.uniqueId].contactsStarships
+        val lastStarshipEnabled = PlayerCache[player.uniqueId].lastStarshipEnabled
+        val planetsEnabled = PlayerCache[player.uniqueId].planetsEnabled
+        val starsEnabled = PlayerCache[player.uniqueId].starsEnabled
+        val beaconsEnabled = PlayerCache[player.uniqueId].beaconsEnabled
+        val stationsEnabled = PlayerCache[player.uniqueId].stationsEnabled
+        val bookmarksEnabled = PlayerCache[player.uniqueId].bookmarksEnabled
+
+        return ofChildren(
+        lineBreakWithCenterText(
+            text("Contacts - View nearby objects and their status", HE_LIGHT_ORANGE),
+            width = 3
+        ),
+        newline(),
+        text("Contacts information visible: $contactsComponentsEnabled", WHITE),
+        newline(),
+        text(GUNSHIP_ICON.text, getColor(starshipsEnabled)).font(Sidebar.fontKey),
+        text(" starship - Other starships visible: $starshipsEnabled", WHITE),
+        newline(),
+        text(GENERIC_STARSHIP_ICON.text, getColor(lastStarshipEnabled)).font(Sidebar.fontKey),
+        text(" laststarship - Last piloted starship visible: $lastStarshipEnabled", WHITE),
+        newline(),
+        text(PLANET_ICON.text, getColor(planetsEnabled)).font(Sidebar.fontKey),
+        text(" planet - Planets visible: $planetsEnabled", WHITE),
+        newline(),
+        text(STAR_ICON.text, getColor(starsEnabled)).font(Sidebar.fontKey),
+        text(" stars - Stars visible: $starsEnabled", WHITE),
+        newline(),
+        text(HYPERSPACE_BEACON_ENTER_ICON.text, getColor(beaconsEnabled)).font(Sidebar.fontKey),
+        text(" beacons - Hyperspace beacons visible: $beaconsEnabled", WHITE),
+        newline(),
+        text(STATION_ICON.text, getColor(stationsEnabled)).font(Sidebar.fontKey),
+        text(" stations - Stations and siege stations visible: $stationsEnabled", WHITE),
+        newline(),
+        text(BOOKMARK_ICON.text, getColor(bookmarksEnabled)).font(Sidebar.fontKey),
+        text(" bookmarks - Bookmarks visible: $bookmarksEnabled", WHITE),
+        newline(),
+        lineBreak(47),
+        )
+    }
+
+    private fun routeComponents(player: Player) : Component {
+        val waypointsComponentsEnabled = PlayerCache[player.uniqueId].waypointsEnabled
+        val compactWaypoints = PlayerCache[player.uniqueId].compactWaypoints
+
+        return ofChildren(
+            lineBreakWithCenterText(text("Route - Current plotted route", HE_LIGHT_ORANGE), width = 9),
+            newline(),
+            text("Route information visible: $waypointsComponentsEnabled", WHITE),
+            newline(),
+            text(ROUTE_SEGMENT_ICON.text, getColor(compactWaypoints)).font(Sidebar.fontKey),
+            text(" compactwaypoints - Display route segments between destinations: $compactWaypoints"),
+            newline(),
+            lineBreak(47),
+        )
+    }
+
+    private fun getColor(enabled: Boolean): NamedTextColor {
         return if (enabled) AQUA else GRAY
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
@@ -1,7 +1,6 @@
 package net.horizonsend.ion.server.features.sidebar.command
 
 import co.aikar.commands.annotation.CommandAlias
-import co.aikar.commands.annotation.Default
 import co.aikar.commands.annotation.Optional
 import co.aikar.commands.annotation.Subcommand
 import net.horizonsend.ion.common.database.schema.misc.SLPlayer
@@ -17,7 +16,6 @@ import org.litote.kmongo.setValue
 
 @CommandAlias("sidebar")
 object SidebarContactsCommand : SLCommand() {
-	@Default
 	@Subcommand("contacts")
 	@Suppress("unused")
 	fun defaultCase(

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarStarshipsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarStarshipsCommand.kt
@@ -1,7 +1,6 @@
 package net.horizonsend.ion.server.features.sidebar.command
 
 import co.aikar.commands.annotation.CommandAlias
-import co.aikar.commands.annotation.Default
 import co.aikar.commands.annotation.Optional
 import co.aikar.commands.annotation.Subcommand
 import net.horizonsend.ion.common.database.schema.misc.SLPlayer
@@ -15,7 +14,6 @@ import org.litote.kmongo.setValue
 
 @CommandAlias("sidebar")
 object SidebarStarshipsCommand : SLCommand() {
-    @Default
     @Subcommand("starship")
     @Suppress("unused")
     fun defaultCase(

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarWaypointsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarWaypointsCommand.kt
@@ -1,7 +1,6 @@
 package net.horizonsend.ion.server.features.sidebar.command
 
 import co.aikar.commands.annotation.CommandAlias
-import co.aikar.commands.annotation.Default
 import co.aikar.commands.annotation.Description
 import co.aikar.commands.annotation.Optional
 import co.aikar.commands.annotation.Subcommand
@@ -16,7 +15,6 @@ import org.litote.kmongo.setValue
 
 @CommandAlias("sidebar")
 object SidebarWaypointsCommand : SLCommand() {
-    @Default
     @Suppress("unused")
     @Subcommand("route")
     fun defaultCase(

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/component/StarshipsHeaderSidebarComponent.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/component/StarshipsHeaderSidebarComponent.kt
@@ -18,7 +18,7 @@ import net.megavex.scoreboardlibrary.api.sidebar.component.SidebarComponent
 import org.bukkit.entity.Player
 
 class StarshipsHeaderSidebarComponent(starship: ActiveControlledStarship, player: Player) : SidebarComponent {
-    private val starshipName = starship.data.name ?: starship.type.displayName
+    private val starshipName = starship.getDisplayNamePlain()
     private val starshipIcon = starship.type.icon
     private val advancedStarshipInfo = PlayerCache[player.uniqueId].advancedStarshipInfo
     private val rotateCompass = PlayerCache[player.uniqueId].rotateCompass

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -65,6 +65,7 @@ import net.horizonsend.ion.server.features.client.whereisit.SearchCommand
 import net.horizonsend.ion.server.features.customitems.commands.ConvertCommand
 import net.horizonsend.ion.server.features.misc.NewPlayerProtection
 import net.horizonsend.ion.server.features.sidebar.command.BookmarkCommand
+import net.horizonsend.ion.server.features.sidebar.command.SidebarCommand
 import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsCommand
 import net.horizonsend.ion.server.features.sidebar.command.SidebarStarshipsCommand
 import net.horizonsend.ion.server.features.sidebar.command.SidebarWaypointsCommand
@@ -147,6 +148,7 @@ val commands: List<SLCommand> = listOf(
 
 	AchievementsCommand,
 	BlastResistanceCommand,
+	SidebarCommand,
 	SidebarContactsCommand,
 	SidebarWaypointsCommand,
 	SidebarStarshipsCommand,


### PR DESCRIPTION
- Use plain name for starships instead of MiniMessage name
- Station contacts disabled by default (existing users need to change this themselves)
- General info on the sidebar command: `/sidebar`