### PR TITLE
Update StarshipTypeBalancing.kt (AI Corvette speed balancing

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
@@ -371,8 +371,8 @@ data class StarshipTypeBalancing(
 	),
 	val aiGunship: StarshipBalancing = gunship,
 	val aiCorvette: StarshipBalancing = StarshipBalancing(
-		sneakFlyAccelDistance = 20,
-		maxSneakFlyAccel = 20,
+		sneakFlyAccelDistance = 5,
+		maxSneakFlyAccel = 5,
 		interdictionRange = 1800,
 		hyperspaceRangeMultiplier = 1.7,
 		weapons = corvette.weapons


### PR DESCRIPTION
Changed AI Corvette shift speed and shift accel from 20 -> 5

This will allow AI Corvettes to have a speed of between 5-35, as opposed to the previous 40-80.