### PR TITLE
Auto Turret Improvement

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/AutoTurretTargeting.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/AutoTurretTargeting.kt
@@ -10,7 +10,20 @@ import org.bukkit.entity.Player
 
 object AutoTurretTargeting : IonServerComponent() {
 	sealed class TargetType<T>(val get: (String) -> Location?) {
-		data object PlayerTarget: TargetType<Player>({ name -> Bukkit.getPlayer(name)?.location })
+		data object PlayerTarget: TargetType<Player>({ name ->
+
+			val player = Bukkit.getPlayer(name)
+			if (player != null) {
+				val starship = ActiveStarships.findByPilot(player)
+				if (starship != null) {
+					starship.blocks.random()?.let { Vec3i(it).toLocation(starship.world) }
+				} else {
+					Bukkit.getPlayer(name)?.location
+				}
+			} else {
+				Bukkit.getPlayer(name)?.location
+			}
+		})
 		data object StarshipTarget: TargetType<ActiveStarship>({ identifier ->
 			val starship = ActiveStarships[identifier]
 


### PR DESCRIPTION
- If an auto turret is focused on a player piloting a starship, the turret will target random blocks on the starship instead of the player's location