### PR TITLE
Fix Combat NPC Gravity

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/misc/CombatNPCs.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/misc/CombatNPCs.kt
@@ -96,7 +96,7 @@ object CombatNPCs : IonServerComponent(true) {
 			npc.spawn(player.location)
 
 			npc.getOrAddTrait(Gravity::class.java).apply {
-				setEnabled(false)
+				setEnabled(true) // nogravity = true
 			}
 
 			inventories[npc.id] = inventoryCopy


### PR DESCRIPTION
- Combat NPCs should now float
- (For some reason, `Gravity.setEnabled(true)` removes gravity)