### PR TITLE
qol dc and cruise changes

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/ActiveControlledStarship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/ActiveControlledStarship.kt
@@ -223,7 +223,9 @@ class ActiveControlledStarship(
 			val player: Player = (controller as? PlayerController)?.player ?: return
 
 			player.walkSpeed = 0.009f
-			directControlCenter = player.location.toBlockLocation().add(0.5, 0.0, 0.5)
+			val playerLoc = player.location
+			directControlCenter = playerLoc.toBlockLocation().add(0.5, playerLoc.y.rem(1)+0.001, 0.5)
+			player.teleport(directControlCenter!!)
 		} else {
 			sendMessage(
 				text()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
@@ -186,6 +186,8 @@ object StarshipCruising : IonServerComponent() {
 		maxSpeed /= 2
 		maxSpeed = (maxSpeed * starship.balancing.cruiseSpeedMultiplier).toInt()
 
+		val wasCruising = isCruising(starship)
+
 		starship.cruiseData.accel = accel
 		starship.cruiseData.targetSpeed = maxSpeed
 		starship.cruiseData.targetDir = Vector(dx, 0, dz).normalize()
@@ -193,10 +195,25 @@ object StarshipCruising : IonServerComponent() {
 		val realAccel = starship.cruiseData.getRealAccel(starship.reactor.powerDistributor.thrusterPortion)
 
 		val info = "<aqua>$dx,$dz <dark_gray>; <yellow>Accel<dark_gray>/<green>Speed<dark_gray>: <yellow>$realAccel<dark_gray>/<yellow>$maxSpeed"
-		if (!isCruising(starship)) {
+
+		if (!wasCruising) {
+			updateCruisingShip(starship)
 			starship.informationAction("Cruise started, dir<dark_gray>: $info")
 
-			updateCruisingShip(starship)
+			if (starship.isDirectControlEnabled) {
+				starship.setDirectControlEnabled(false)
+				starship.onlinePassengers.forEach { passenger ->
+					passenger.information(
+						"Stopping DC. Starting cruise..."
+					)
+				}
+			} else {
+				starship.onlinePassengers.forEach { passenger ->
+					passenger.information(
+						"Cruise started..."
+					)
+				}
+			}
 		} else {
 			starship.informationAction("Adjusted dir to $info <yellow>[Left click to stop]")
 		}


### PR DESCRIPTION
* Players can now stand on any block in dc without falling though the floor
* Players will not longer experience drift when starting dc
* When hitting cruise while in dc, instead of doing nothing, it will stop dc and start cruise (should help with dc cruise)
* Information about starting cruise displays properly now