### PR TITLE
Settings Menu

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
@@ -40,6 +40,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 
 		var contactsDistance: Int = 6000,
 		var contactsMaxNameLength: Int = 64,
+		var contactsSort: Int = 0,
 		var contactsEnabled: Boolean = true,
 		var contactsStarships: Boolean = true,
 		var lastStarshipEnabled: Boolean = true,
@@ -156,6 +157,15 @@ abstract class AbstractPlayerCache : ManualCache() {
 
 					val contactsMaxNameLength = it.int()
 					data.contactsMaxNameLength = contactsMaxNameLength
+				}
+			}
+
+			change[SLPlayer::contactsSort]?.let {
+				synced {
+					val data = PLAYER_DATA[id.uuid] ?: return@synced
+
+					val contactsSort = it.int()
+					data.contactsSort = contactsSort
 				}
 			}
 
@@ -383,6 +393,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 			blockedPlayerIDs = data.blockedPlayerIDs,
 			contactsDistance = data.contactsDistance,
 			contactsMaxNameLength = data.contactsMaxNameLength,
+			contactsSort = data.contactsSort,
 			contactsEnabled = data.contactsEnabled,
 			contactsStarships = data.contactsStarships,
 			lastStarshipEnabled = data.lastStarshipEnabled,

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
@@ -322,7 +322,8 @@ abstract class AbstractPlayerCache : ManualCache() {
 				synced {
 					val data = PLAYER_DATA[id.uuid] ?: return@synced
 
-					data.useAlternateDCCruise = it.boolean()
+					val useAlternateDcCruise = it.boolean()
+					data.useAlternateDCCruise = useAlternateDcCruise
 				}
 			}
 		}

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
@@ -39,6 +39,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 		var bounty: Double,
 
 		var contactsDistance: Int = 6000,
+		var contactsMaxNameLength: Int = 64,
 		var contactsEnabled: Boolean = true,
 		var contactsStarships: Boolean = true,
 		var lastStarshipEnabled: Boolean = true,
@@ -146,6 +147,15 @@ abstract class AbstractPlayerCache : ManualCache() {
 
 					val contactsDistance = it.int()
 					data.contactsDistance = contactsDistance
+				}
+			}
+
+			change[SLPlayer::contactsMaxNameLength]?.let {
+				synced {
+					val data = PLAYER_DATA[id.uuid] ?: return@synced
+
+					val contactsMaxNameLength = it.int()
+					data.contactsMaxNameLength = contactsMaxNameLength
 				}
 			}
 
@@ -371,6 +381,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 			bounty = data.bounty,
 			blockedPlayerIDs = data.blockedPlayerIDs,
 			contactsDistance = data.contactsDistance,
+			contactsMaxNameLength = data.contactsMaxNameLength,
 			contactsEnabled = data.contactsEnabled,
 			contactsStarships = data.contactsStarships,
 			lastStarshipEnabled = data.lastStarshipEnabled,

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
@@ -41,6 +41,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 		var contactsDistance: Int = 6000,
 		var contactsMaxNameLength: Int = 64,
 		var contactsSort: Int = 0,
+		var contactsColoring: Int = 0,
 		var contactsEnabled: Boolean = true,
 		var contactsStarships: Boolean = true,
 		var lastStarshipEnabled: Boolean = true,
@@ -166,6 +167,15 @@ abstract class AbstractPlayerCache : ManualCache() {
 
 					val contactsSort = it.int()
 					data.contactsSort = contactsSort
+				}
+			}
+
+			change[SLPlayer::contactsColoring]?.let {
+				synced {
+					val data = PLAYER_DATA[id.uuid] ?: return@synced
+
+					val contactsColoring = it.int()
+					data.contactsColoring = contactsColoring
 				}
 			}
 
@@ -394,6 +404,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 			contactsDistance = data.contactsDistance,
 			contactsMaxNameLength = data.contactsMaxNameLength,
 			contactsSort = data.contactsSort,
+			contactsColoring = data.contactsColoring,
 			contactsEnabled = data.contactsEnabled,
 			contactsStarships = data.contactsStarships,
 			lastStarshipEnabled = data.lastStarshipEnabled,

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
@@ -66,6 +66,7 @@ data class SLPlayer(
 
 	var contactsDistance: Int = 6000,
 	var contactsMaxNameLength: Int = 64,
+	var contactsSort: Int = 0,
 	var contactsEnabled: Boolean = true,
 	var contactsStarships: Boolean = true,
 	var lastStarshipEnabled: Boolean = true,

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
@@ -65,6 +65,7 @@ data class SLPlayer(
 	var bounty: Double = 0.0,
 
 	var contactsDistance: Int = 6000,
+	var contactsMaxNameLength: Int = 64,
 	var contactsEnabled: Boolean = true,
 	var contactsStarships: Boolean = true,
 	var lastStarshipEnabled: Boolean = true,

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
@@ -67,6 +67,7 @@ data class SLPlayer(
 	var contactsDistance: Int = 6000,
 	var contactsMaxNameLength: Int = 64,
 	var contactsSort: Int = 0,
+	var contactsColoring: Int = 0,
 	var contactsEnabled: Boolean = true,
 	var contactsStarships: Boolean = true,
 	var lastStarshipEnabled: Boolean = true,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/SearchCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/SearchCommand.kt
@@ -4,6 +4,7 @@ import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.CommandCompletion
 import co.aikar.commands.annotation.CommandPermission
 import co.aikar.commands.annotation.Default
+import co.aikar.commands.annotation.Optional
 import co.aikar.commands.annotation.Subcommand
 import net.horizonsend.ion.common.database.schema.misc.SLPlayer
 import net.horizonsend.ion.common.extensions.success
@@ -78,9 +79,10 @@ object SearchCommand : SLCommand() {
 	}
 
 	@Subcommand("_toggle")
-	fun itemSearchToggle(player: Player) {
-		val showItemDisplay = !PlayerCache[player].showItemSearchItem
+	fun itemSearchToggle(player: Player, @Optional toggle: Boolean?) {
+		val showItemDisplay = toggle ?: !PlayerCache[player].showItemSearchItem
 		SLPlayer.updateById(player.slPlayerId, setValue(SLPlayer::showItemSearchItem, showItemDisplay))
+		PlayerCache[player.uniqueId].showItemSearchItem = showItemDisplay
 		player.success("Changed showing searched item to $showItemDisplay")
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -746,7 +746,15 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 	@CommandAlias("enableAlternateDCCruise")
 	@CommandCompletion("true|false")
 	@Suppress("unused")
-	fun onUseAlternateDCCruise(sender: Player, newValue: Boolean) = asyncCommand(sender) {
-		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::useAlternateDCCruise, newValue))
+	fun onUseAlternateDCCruise(sender: Player, @Optional toggle: Boolean?) {
+		val useAlternateDcCruise = toggle ?: !PlayerCache[sender].useAlternateDCCruise
+		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::useAlternateDCCruise, useAlternateDcCruise))
+		PlayerCache[sender.uniqueId].useAlternateDCCruise = useAlternateDcCruise
+		sender.success("Changed alternate DC cruise to $useAlternateDcCruise")
+		if (useAlternateDcCruise) {
+			sender.success("Activating cruise while in direct control will override DC")
+		} else {
+			sender.success("Direct control will not be overriden by cruise")
+		}
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/achievements/Achievements.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/achievements/Achievements.kt
@@ -6,6 +6,7 @@ import net.horizonsend.ion.common.utils.text.SPECIAL_FONT_KEY
 import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.server.LegacySettings
 import net.horizonsend.ion.server.features.custom.items.CustomItems.CHETHERITE
+import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.features.progression.SLXP
@@ -37,11 +38,11 @@ import xyz.xenondevs.invui.item.impl.SimpleItem
 import kotlin.math.ceil
 import kotlin.math.min
 
-object Achievements {
+object Achievements : AbstractBackgroundPagedGui {
 	private const val ACHIEVEMENTS_PER_PAGE = 5
 	private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
 
-	fun createAchievementGui(): PagedGui<Item> {
+	override fun createGui(): PagedGui<Item> {
 		val gui = PagedGui.items()
 		val achievementIcons = mutableListOf<Item>()
 
@@ -76,7 +77,7 @@ object Achievements {
 		return gui.build()
 	}
 
-	fun createAchievementText(player: Player, currentPage: Int): Component {
+	override fun createText(player: Player, currentPage: Int): Component {
 
 		val obtainedAchievements = SLPlayer[player].achievements.map { Achievement.valueOf(it) }.toList()
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/achievements/AchievementsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/achievements/AchievementsCommand.kt
@@ -134,17 +134,17 @@ object AchievementsCommand : SLCommand() {
 	 */
 
 	private fun openAchievementWindow(viewer: Player, player: Player = viewer) {
-		val gui = Achievements.createAchievementGui()
+		val gui = Achievements.createGui()
 
 		val window = Window.single()
 			.setViewer(viewer)
-			.setTitle(AdventureComponentWrapper(Achievements.createAchievementText(player, 0)))
+			.setTitle(AdventureComponentWrapper(Achievements.createText(player, 0)))
 			.setGui(gui)
 			.build()
 
 		fun updateTitle(): (Int, Int) -> Unit {
 			return { _, currentPage ->
-				window.changeTitle(AdventureComponentWrapper(Achievements.createAchievementText(player, currentPage)))
+				window.changeTitle(AdventureComponentWrapper(Achievements.createText(player, currentPage)))
 			}
 		}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/client/commands/HudCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/client/commands/HudCommand.kt
@@ -21,6 +21,7 @@ object HudCommand : SLCommand() {
     ) {
         val hudPlanetsImage = toggle ?: !PlayerCache[sender].hudPlanetsImage
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::hudPlanetsImage, hudPlanetsImage))
+        PlayerCache[sender].hudPlanetsImage = hudPlanetsImage
         sender.success("Changed planet visibility in HUD to $hudPlanetsImage")
     }
 
@@ -32,6 +33,7 @@ object HudCommand : SLCommand() {
     ) {
         val hudPlanetsSelector = toggle ?: !PlayerCache[sender].hudPlanetsSelector
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::hudPlanetsSelector, hudPlanetsSelector))
+        PlayerCache[sender].hudPlanetsSelector = hudPlanetsSelector
         sender.success("Changed planet selector visibility in HUD to $hudPlanetsSelector")
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/AbstractBackgroundPagedGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/AbstractBackgroundPagedGui.kt
@@ -1,0 +1,35 @@
+package net.horizonsend.ion.server.features.gui
+
+import net.kyori.adventure.text.Component
+import org.bukkit.entity.Player
+import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
+import xyz.xenondevs.invui.gui.PagedGui
+import xyz.xenondevs.invui.item.Item
+import xyz.xenondevs.invui.window.Window
+
+interface AbstractBackgroundPagedGui {
+
+    fun createGui(): PagedGui<Item>
+
+    fun createText(player: Player, currentPage: Int): Component
+
+    fun open(player: Player) {
+        val gui = createGui()
+
+        val window = Window.single()
+            .setViewer(player)
+            .setTitle(AdventureComponentWrapper(createText(player, 0)))
+            .setGui(gui)
+            .build()
+
+        fun updateTitle(): (Int, Int) -> Unit {
+            return { _, currentPage ->
+                window.changeTitle(AdventureComponentWrapper(createText(player, currentPage)))
+            }
+        }
+
+        gui.addPageChangeHandler(updateTitle())
+
+        window.open()
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/AbstractBackgroundPagedGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/AbstractBackgroundPagedGui.kt
@@ -9,9 +9,9 @@ import xyz.xenondevs.invui.window.Window
 
 interface AbstractBackgroundPagedGui {
 
-    fun createGui(): PagedGui<Item>
+    fun createGui(): PagedGui<Item> = PagedGui.items().build()
 
-    fun createText(player: Player, currentPage: Int): Component
+    fun createText(player: Player, currentPage: Int): Component = Component.empty()
 
     fun open(player: Player) {
         val gui = createGui()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
@@ -2,11 +2,14 @@ package net.horizonsend.ion.server.features.gui
 
 import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.TextDecoration.ITALIC
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.item.ItemProvider
 import xyz.xenondevs.invui.item.builder.ItemBuilder
+import xyz.xenondevs.invui.item.impl.AbstractItem
 import xyz.xenondevs.invui.item.impl.controlitem.PageItem
 
 object GuiItems {
@@ -15,22 +18,29 @@ object GuiItems {
     private const val UI_RIGHT = 103
 
     class LeftItem : PageItem(false) {
-
         override fun getItemProvider(gui: PagedGui<*>): ItemProvider {
-            val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+            val builder = if (gui.hasPreviousPage()) ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
                 it.setCustomModelData(UI_LEFT)
-                it.displayName(Component.empty())
-            })
+                it.displayName(text("Previous Page").decoration(ITALIC, false))
+            }) else ItemBuilder(ItemStack(Material.AIR))
             return builder
         }
     }
 
     class RightItem : PageItem(true) {
-
         override fun getItemProvider(gui: PagedGui<*>): ItemProvider {
-            val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+            val builder = if (gui.hasNextPage()) ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
                 it.setCustomModelData(UI_RIGHT)
-                it.displayName(Component.empty())
+                it.displayName(text("Next Page").decoration(ITALIC, false))
+            }) else ItemBuilder(ItemStack(Material.AIR))
+            return builder
+        }
+    }
+
+    abstract class AbstractButtonItem(val text: Component, val itemStack: ItemStack) : AbstractItem() {
+        override fun getItemProvider(): ItemProvider {
+            val builder = ItemBuilder(itemStack.updateMeta {
+                it.displayName(text)
             })
             return builder
         }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
@@ -9,7 +9,7 @@ import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.item.ItemProvider
 import xyz.xenondevs.invui.item.builder.ItemBuilder
-import xyz.xenondevs.invui.item.impl.AbstractItem
+import xyz.xenondevs.invui.item.impl.controlitem.ControlItem
 import xyz.xenondevs.invui.item.impl.controlitem.PageItem
 
 object GuiItems {
@@ -37,8 +37,8 @@ object GuiItems {
         }
     }
 
-    abstract class AbstractButtonItem(val text: Component, val itemStack: ItemStack) : AbstractItem() {
-        override fun getItemProvider(): ItemProvider {
+    abstract class AbstractButtonItem(val text: Component, val itemStack: ItemStack) : ControlItem<PagedGui<*>>() {
+        override fun getItemProvider(gui: PagedGui<*>): ItemProvider {
             val builder = ItemBuilder(itemStack.updateMeta {
                 it.displayName(text)
             })

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
@@ -14,13 +14,10 @@ import xyz.xenondevs.invui.item.impl.controlitem.PageItem
 
 object GuiItems {
 
-    private const val UI_LEFT = 105
-    private const val UI_RIGHT = 103
-
     class LeftItem : PageItem(false) {
         override fun getItemProvider(gui: PagedGui<*>): ItemProvider {
             val builder = if (gui.hasPreviousPage()) ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-                it.setCustomModelData(UI_LEFT)
+                it.setCustomModelData(GuiItem.LEFT.customModelData)
                 it.displayName(text("Previous Page").decoration(ITALIC, false))
             }) else ItemBuilder(ItemStack(Material.AIR))
             return builder
@@ -30,7 +27,7 @@ object GuiItems {
     class RightItem : PageItem(true) {
         override fun getItemProvider(gui: PagedGui<*>): ItemProvider {
             val builder = if (gui.hasNextPage()) ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-                it.setCustomModelData(UI_RIGHT)
+                it.setCustomModelData(GuiItem.RIGHT.customModelData)
                 it.displayName(text("Next Page").decoration(ITALIC, false))
             }) else ItemBuilder(ItemStack(Material.AIR))
             return builder
@@ -45,4 +42,34 @@ object GuiItems {
             return builder
         }
     }
+}
+
+enum class GuiItem(val customModelData: Int) {
+    EMPTY(101),
+    UP(102),
+    RIGHT(103),
+    DOWN(104),
+    LEFT(105),
+    STARFIGHTER(6000),
+    GUNSHIP(6001),
+    CORVETTE(6002),
+    FRIGATE(6003),
+    DESTROYER(6004),
+    CRUISER(6005),
+    BATTLECRUISER(6006),
+    SHUTTLE(6008),
+    TRANSPORT(6009),
+    LIGHT_FREIGHTER(6010),
+    MEDIUM_FREIGHTER(6011),
+    HEAVY_FREIGHTER(6012),
+    BARGE(6013),
+    PLANET(6016),
+    STAR(6017),
+    BEACON(6018),
+    STATION(6019),
+    GENERIC_STARSHIP(6026),
+    ROUTE_SEGMENT(6030),
+    LIST(6034),
+    COMPASS_NEEDLE(6035),
+    BOOKMARK(6036)
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/GuiItems.kt
@@ -5,8 +5,13 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.TextDecoration.ITALIC
 import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
+import xyz.xenondevs.invui.gui.Gui
 import xyz.xenondevs.invui.gui.PagedGui
+import xyz.xenondevs.invui.item.Item
 import xyz.xenondevs.invui.item.ItemProvider
 import xyz.xenondevs.invui.item.builder.ItemBuilder
 import xyz.xenondevs.invui.item.impl.controlitem.ControlItem
@@ -41,6 +46,17 @@ object GuiItems {
             })
             return builder
         }
+    }
+
+    class BlankItem(val item: Item) : ControlItem<Gui>() {
+        override fun getItemProvider(gui: Gui): ItemProvider {
+            return ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+                it.setCustomModelData(GuiItem.EMPTY.customModelData)
+                it.displayName(item.itemProvider.get().displayName().decoration(ITALIC, false))
+            })
+        }
+
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) = item.handleClick(clickType, player, event)
     }
 }
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsCommand.kt
@@ -1,0 +1,16 @@
+package net.horizonsend.ion.server.features.gui.custom.settings
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.Default
+import net.horizonsend.ion.server.command.SLCommand
+import org.bukkit.entity.Player
+
+@CommandAlias("settings")
+object SettingsCommand : SLCommand() {
+
+    @Default
+    @Suppress("unused")
+    fun onSettings(sender: Player) {
+        SettingsMainMenuGui.open(sender)
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
@@ -4,13 +4,15 @@ import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
-import net.horizonsend.ion.server.features.gui.custom.settings.SettingsSidebarGui.ReturnToMainMenuButton
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.ClickType
 import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
 import xyz.xenondevs.invui.item.Item
@@ -39,7 +41,7 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
-            .addIngredient('v', ReturnToMainMenuButton())
+            .addIngredient('v', SettingsMainMenuGui.ReturnToMainMenuButton())
             .setContent(BUTTONS_LIST)
 
         return gui.build()
@@ -48,7 +50,7 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
     override fun createText(player: Player, currentPage: Int): Component {
 
         // create a new GuiText builder
-        val header = "Planet Settings"
+        val header = "HUD Settings"
         val guiText = GuiText(header)
         guiText.addBackground()
 
@@ -77,6 +79,22 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
         CustomItems.CHANDRA.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+        }
+    }
+
+    class ReturnToHudButton : GuiItems.AbstractButtonItem(
+        text("Return to HUD Settings").decoration(ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+            it.setCustomModelData(UI_DOWN)
+            it.displayName(text("Return to HUD Settings").decoration(ITALIC, false))
+        }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarGui.open(player)
+        }
+
+        companion object {
+            private const val UI_DOWN = 104
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
@@ -32,19 +32,26 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< v . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
             .addIngredient('v', SettingsMainMenuGui.ReturnToMainMenuButton())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
@@ -1,0 +1,82 @@
+package net.horizonsend.ion.server.features.gui.custom.settings
+
+import net.horizonsend.ion.server.features.custom.items.CustomItems
+import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItems
+import net.horizonsend.ion.server.features.gui.GuiText
+import net.horizonsend.ion.server.features.gui.custom.settings.SettingsSidebarGui.ReturnToMainMenuButton
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
+import xyz.xenondevs.invui.gui.PagedGui
+import xyz.xenondevs.invui.gui.structure.Markers
+import xyz.xenondevs.invui.item.Item
+import kotlin.math.min
+
+object SettingsHudGui : AbstractBackgroundPagedGui {
+
+    private const val SETTINGS_PER_PAGE = 5
+
+    private val BUTTONS_LIST = listOf(
+        PlanetSettingsButton()
+    )
+
+    override fun createGui(): PagedGui<Item> {
+        val gui = PagedGui.items()
+
+        gui.setStructure(
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "< . . . v . . . >"
+        )
+
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+            .addIngredient('<', GuiItems.LeftItem())
+            .addIngredient('>', GuiItems.RightItem())
+            .addIngredient('v', ReturnToMainMenuButton())
+            .setContent(BUTTONS_LIST)
+
+        return gui.build()
+    }
+
+    override fun createText(player: Player, currentPage: Int): Component {
+
+        // create a new GuiText builder
+        val header = "Planet Settings"
+        val guiText = GuiText(header)
+        guiText.addBackground()
+
+        // get the index of the first setting to display for this page
+        val startIndex = currentPage * SETTINGS_PER_PAGE
+
+        for (buttonIndex in startIndex until min(startIndex + SETTINGS_PER_PAGE, BUTTONS_LIST.size)) {
+
+            val title = BUTTONS_LIST[buttonIndex].text
+            val line = (buttonIndex - startIndex) * 2
+
+            // setting title
+            guiText.add(
+                component = title,
+                line = line,
+                horizontalShift = 21,
+                verticalShift = 5
+            )
+        }
+
+        return guiText.build()
+    }
+
+    class PlanetSettingsButton : GuiItems.AbstractButtonItem(
+        text("Planet Settings").decoration(ITALIC, false),
+        CustomItems.CHANDRA.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+        }
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
@@ -16,11 +16,13 @@ import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
 import xyz.xenondevs.invui.item.Item
+import kotlin.math.ceil
 import kotlin.math.min
 
 object SettingsHudGui : AbstractBackgroundPagedGui {
 
     private const val SETTINGS_PER_PAGE = 5
+    private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
 
     private val BUTTONS_LIST = listOf(
         PlanetSettingsButton()
@@ -35,7 +37,7 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
             "x . . . . . . . .",
             "x . . . . . . . .",
             "x . . . . . . . .",
-            "< . . . v . . . >"
+            "< v . . . . . . >"
         )
 
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
@@ -71,6 +73,16 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
             )
         }
 
+        // page number
+        val pageNumberString =
+            "${currentPage + 1} / ${ceil((BUTTONS_LIST.size.toDouble() / SETTINGS_PER_PAGE)).toInt()}"
+        guiText.add(
+            text(pageNumberString),
+            line = 10,
+            GuiText.TextAlignment.CENTER,
+            verticalShift = PAGE_NUMBER_VERTICAL_SHIFT
+        )
+
         return guiText.build()
     }
 
@@ -79,6 +91,7 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
         CustomItems.CHANDRA.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsHudPlanetsGui.open(player)
         }
     }
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
@@ -1,7 +1,7 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
@@ -88,7 +88,7 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
 
     class PlanetSettingsButton : GuiItems.AbstractButtonItem(
         text("Planet Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsHudPlanetsGui.open(player)
@@ -98,16 +98,12 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
     class ReturnToHudButton : GuiItems.AbstractButtonItem(
         text("Return to HUD Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-            it.setCustomModelData(UI_DOWN)
+            it.setCustomModelData(GuiItem.DOWN.customModelData)
             it.displayName(text("Return to HUD Settings").decoration(ITALIC, false))
         }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarGui.open(player)
-        }
-
-        companion object {
-            private const val UI_DOWN = 104
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudGui.kt
@@ -93,7 +93,7 @@ object SettingsHudGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class PlanetSettingsButton : GuiItems.AbstractButtonItem(
+    private class PlanetSettingsButton : GuiItems.AbstractButtonItem(
         text("Planet Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudPlanetsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudPlanetsGui.kt
@@ -2,18 +2,21 @@ package net.horizonsend.ion.server.features.gui.custom.settings
 
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.client.commands.HudCommand
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor.GREEN
 import net.kyori.adventure.text.format.NamedTextColor.RED
 import net.kyori.adventure.text.format.TextDecoration
+import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.ClickType
 import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
@@ -103,7 +106,7 @@ object SettingsHudPlanetsGui : AbstractBackgroundPagedGui {
 
     class ImageButton : GuiItems.AbstractButtonItem(
         text("Toggle Planet Visibility").decoration(TextDecoration.ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             HudCommand.onTogglePlanetsImage(player, null)
@@ -114,7 +117,7 @@ object SettingsHudPlanetsGui : AbstractBackgroundPagedGui {
 
     class SelectorButton : GuiItems.AbstractButtonItem(
         text("Toggle Planet Selector").decoration(TextDecoration.ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             HudCommand.onTogglePlanetsSelector(player, null)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudPlanetsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudPlanetsGui.kt
@@ -38,19 +38,26 @@ object SettingsHudPlanetsGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< v . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
             .addIngredient('v', SettingsHudGui.ReturnToHudButton())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudPlanetsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsHudPlanetsGui.kt
@@ -111,7 +111,7 @@ object SettingsHudPlanetsGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class ImageButton : GuiItems.AbstractButtonItem(
+    private class ImageButton : GuiItems.AbstractButtonItem(
         text("Toggle Planet Visibility").decoration(TextDecoration.ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {
@@ -122,7 +122,7 @@ object SettingsHudPlanetsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class SelectorButton : GuiItems.AbstractButtonItem(
+    private class SelectorButton : GuiItems.AbstractButtonItem(
         text("Toggle Planet Selector").decoration(TextDecoration.ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -32,18 +32,25 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< . . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -92,7 +92,7 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class SidebarSettingsButton : GuiItems.AbstractButtonItem(
+    private class SidebarSettingsButton : GuiItems.AbstractButtonItem(
         text("Sidebar Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
@@ -101,7 +101,7 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class HudSettingsButton : GuiItems.AbstractButtonItem(
+    private class HudSettingsButton : GuiItems.AbstractButtonItem(
         text("HUD Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -1,7 +1,7 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
@@ -87,7 +87,7 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
 
     class SidebarSettingsButton : GuiItems.AbstractButtonItem(
         text("Sidebar Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarGui.open(player)
@@ -96,7 +96,7 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
 
     class HudSettingsButton : GuiItems.AbstractButtonItem(
         text("HUD Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsHudGui.open(player)
@@ -106,16 +106,12 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
     class ReturnToMainMenuButton : GuiItems.AbstractButtonItem(
         text("Return to Main Menu Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-            it.setCustomModelData(UI_DOWN)
+            it.setCustomModelData(GuiItem.DOWN.customModelData)
             it.displayName(text("Return to Main Menu Settings").decoration(ITALIC, false))
         }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsMainMenuGui.open(player)
-        }
-
-        companion object {
-            private const val UI_DOWN = 104
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -1,0 +1,102 @@
+package net.horizonsend.ion.server.features.gui.custom.settings
+
+import net.horizonsend.ion.server.features.custom.items.CustomItems
+import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItems
+import net.horizonsend.ion.server.features.gui.GuiText
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
+import xyz.xenondevs.invui.gui.PagedGui
+import xyz.xenondevs.invui.gui.structure.Markers
+import xyz.xenondevs.invui.item.Item
+import kotlin.math.ceil
+import kotlin.math.min
+
+object SettingsMainMenuGui : AbstractBackgroundPagedGui {
+    private const val SETTINGS_PER_PAGE = 5
+    private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
+
+    private val BUTTONS_LIST = listOf(
+        SidebarSettingsButton(),
+        HudSettingsButton()
+    )
+
+    override fun createGui(): PagedGui<Item> {
+        val gui = PagedGui.items()
+
+        gui.setStructure(
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "< . . . . . . . >"
+        )
+
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+            .addIngredient('<', GuiItems.LeftItem())
+            .addIngredient('>', GuiItems.RightItem())
+            .setContent(BUTTONS_LIST)
+
+        return gui.build()
+    }
+
+    override fun createText(player: Player, currentPage: Int): Component {
+
+        // create a new GuiText builder
+        val header = "Settings"
+        val guiText = GuiText(header)
+        guiText.addBackground()
+
+        // get the index of the first setting to display for this page
+        val startIndex = currentPage * SETTINGS_PER_PAGE
+
+        for (buttonIndex in startIndex until min(startIndex + SETTINGS_PER_PAGE, BUTTONS_LIST.size)) {
+
+            val title = BUTTONS_LIST[buttonIndex].text
+            val line = (buttonIndex - startIndex) * 2
+
+            // setting title
+            guiText.add(
+                component = title,
+                line = line,
+                horizontalShift = 21,
+                verticalShift = 5
+            )
+        }
+
+        // page number
+        val pageNumberString =
+            "${currentPage + 1} / ${ceil((BUTTONS_LIST.size.toDouble() / SETTINGS_PER_PAGE)).toInt()}"
+        guiText.add(
+            text(pageNumberString),
+            line = 10,
+            GuiText.TextAlignment.CENTER,
+            verticalShift = PAGE_NUMBER_VERTICAL_SHIFT
+        )
+
+        return guiText.build()
+    }
+
+    class SidebarSettingsButton : GuiItems.AbstractButtonItem(
+        text("Sidebar Settings").decoration(ITALIC, false),
+        CustomItems.CHANDRA.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarGui.open(player)
+        }
+    }
+
+    class HudSettingsButton : GuiItems.AbstractButtonItem(
+        text("HUD Settings").decoration(ITALIC, false),
+        CustomItems.CHANDRA.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsHudGui.open(player)
+        }
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -39,6 +39,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         ContactsDistanceButton(),
         ContactsMaxNameLengthButton(),
         ContactsSortOrderButton(),
+        ContactsColoringButton(),
         StarshipsButton(),
         LastStarshipsButton(),
         PlanetsButton(),
@@ -83,6 +84,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
             PlayerCache[player.uniqueId].contactsDistance,
             PlayerCache[player.uniqueId].contactsMaxNameLength,
             PlayerCache[player.uniqueId].contactsSort,
+            PlayerCache[player.uniqueId].contactsColoring,
             PlayerCache[player.uniqueId].contactsStarships,
             PlayerCache[player.uniqueId].lastStarshipEnabled,
             PlayerCache[player.uniqueId].planetsEnabled,
@@ -122,6 +124,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
                     1 -> text(PlayerCache[player.uniqueId].contactsDistance)
                     2 -> text(PlayerCache[player.uniqueId].contactsMaxNameLength)
                     3 -> text(ContactsSidebar.ContactsSorting.entries[PlayerCache[player.uniqueId].contactsSort].toString())
+                    4 -> text(ContactsSidebar.ContactsColoring.entries[PlayerCache[player.uniqueId].contactsColoring].toString())
                     else -> Component.empty()
                 },
                 line = line + 1,
@@ -180,6 +183,17 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onChangeContactsSortOrder(player)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    private class ContactsColoringButton : GuiItems.AbstractButtonItem(
+        text("Change Coloring").decoration(ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onChangeContactsColoring(player)
 
             windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
         }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -6,6 +6,7 @@ import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsCommand
+import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar
 import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
@@ -37,6 +38,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         EnableButton(),
         ContactsDistanceButton(),
         ContactsMaxNameLengthButton(),
+        ContactsSortOrderButton(),
         StarshipsButton(),
         LastStarshipsButton(),
         PlanetsButton(),
@@ -80,6 +82,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
             PlayerCache[player.uniqueId].contactsEnabled,
             PlayerCache[player.uniqueId].contactsDistance,
             PlayerCache[player.uniqueId].contactsMaxNameLength,
+            PlayerCache[player.uniqueId].contactsSort,
             PlayerCache[player.uniqueId].contactsStarships,
             PlayerCache[player.uniqueId].lastStarshipEnabled,
             PlayerCache[player.uniqueId].planetsEnabled,
@@ -118,6 +121,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
                     // Index values correlating to the Int setting
                     1 -> text(PlayerCache[player.uniqueId].contactsDistance)
                     2 -> text(PlayerCache[player.uniqueId].contactsMaxNameLength)
+                    3 -> text(ContactsSidebar.ContactsSorting.entries[PlayerCache[player.uniqueId].contactsSort].toString())
                     else -> Component.empty()
                 },
                 line = line + 1,
@@ -167,6 +171,17 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarContactsMaxNameLengthGui.open(player)
+        }
+    }
+
+    private class ContactsSortOrderButton : GuiItems.AbstractButtonItem(
+        text("Change Sort Order").decoration(ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onChangeContactsSortOrder(player)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
         }
     }
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -49,19 +49,26 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< v . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
             .addIngredient('v', SettingsSidebarGui.ReturnToSidebarButton())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -25,11 +25,13 @@ import xyz.xenondevs.invui.item.Item
 import xyz.xenondevs.invui.item.ItemProvider
 import xyz.xenondevs.invui.item.builder.ItemBuilder
 import xyz.xenondevs.invui.item.impl.controlitem.ControlItem
+import kotlin.math.ceil
 import kotlin.math.min
 
 object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     private const val SETTINGS_PER_PAGE = 5
+    private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
 
     private val BUTTONS_LIST = listOf(
         EnableButton(),
@@ -52,7 +54,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
             "x . . . . . . . .",
             "x . . . . . . . .",
             "x . . . . . . . .",
-            "< . . . v . . . >"
+            "< v . . . . . . >"
         )
 
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
@@ -107,6 +109,16 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
                 horizontalShift = 21
             )
         }
+
+        // page number
+        val pageNumberString =
+            "${currentPage + 1} / ${ceil((BUTTONS_LIST.size.toDouble() / SETTINGS_PER_PAGE)).toInt()}"
+        guiText.add(
+            text(pageNumberString),
+            line = 10,
+            GuiText.TextAlignment.CENTER,
+            verticalShift = PAGE_NUMBER_VERTICAL_SHIFT
+        )
 
         return guiText.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -1,8 +1,8 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
 import net.horizonsend.ion.server.features.cache.PlayerCache
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsCommand
@@ -125,7 +125,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class EnableButton : GuiItems.AbstractButtonItem(
         text("Enable Contacts Info").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             val contactsEnabled = PlayerCache[player.uniqueId].contactsEnabled
@@ -139,7 +139,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class ContactsDistanceButton : GuiItems.AbstractButtonItem(
         text("Change Contacts Range").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.ROUTE_SEGMENT.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarContactsRangeGui.open(player)
@@ -148,7 +148,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class StarshipsButton : GuiItems.AbstractButtonItem(
         text("Enable Starships").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.GUNSHIP.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onToggleStarship(player, null)
@@ -159,7 +159,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class LastStarshipsButton : GuiItems.AbstractButtonItem(
         text("Enable Last Starship").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.GENERIC_STARSHIP.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onToggleLastStarship(player, null)
@@ -170,7 +170,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class PlanetsButton : GuiItems.AbstractButtonItem(
         text("Enable Planets").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onTogglePlanets(player, null)
@@ -181,7 +181,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class StarsButton : GuiItems.AbstractButtonItem(
         text("Enable Stars").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.STAR.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onToggleStars(player, null)
@@ -192,7 +192,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class BeaconsButton : GuiItems.AbstractButtonItem(
         text("Enable Beacons").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.BEACON.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onToggleBeacons(player, null)
@@ -203,7 +203,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class StationsButton : GuiItems.AbstractButtonItem(
         text("Enable Stations").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.STATION.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onToggleStations(player, null)
@@ -214,7 +214,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
     class BookmarksButton : GuiItems.AbstractButtonItem(
         text("Enable Bookmarks").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.BOOKMARK.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarContactsCommand.onToggleBookmarks(player, null)
@@ -230,14 +230,10 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
 
         override fun getItemProvider(gui: Gui): ItemProvider {
             val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-                it.setCustomModelData(UI_DOWN)
+                it.setCustomModelData(GuiItem.DOWN.customModelData)
                 it.displayName(text("Return to Sidebar Contacts Settings").decoration(ITALIC, false))
             })
             return builder
-        }
-
-        companion object {
-            private const val UI_DOWN = 104
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -36,6 +36,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
     private val BUTTONS_LIST = listOf(
         EnableButton(),
         ContactsDistanceButton(),
+        ContactsMaxNameLengthButton(),
         StarshipsButton(),
         LastStarshipsButton(),
         PlanetsButton(),
@@ -78,6 +79,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         val enabledSettings = listOf(
             PlayerCache[player.uniqueId].contactsEnabled,
             PlayerCache[player.uniqueId].contactsDistance,
+            PlayerCache[player.uniqueId].contactsMaxNameLength,
             PlayerCache[player.uniqueId].contactsStarships,
             PlayerCache[player.uniqueId].lastStarshipEnabled,
             PlayerCache[player.uniqueId].planetsEnabled,
@@ -111,7 +113,13 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
             guiText.add(
                 component = if (enabledSettings[buttonIndex] is Boolean) {
                     if (enabledSettings[buttonIndex] as Boolean) text("ENABLED", GREEN) else text("DISABLED", RED)
-                } else text(PlayerCache[player.uniqueId].contactsDistance),
+                } else when (buttonIndex) {
+                    // TODO: Find a better way to handle Boolean settings vs. Int settings
+                    // Index values correlating to the Int setting
+                    1 -> text(PlayerCache[player.uniqueId].contactsDistance)
+                    2 -> text(PlayerCache[player.uniqueId].contactsMaxNameLength)
+                    else -> Component.empty()
+                },
                 line = line + 1,
                 horizontalShift = 21
             )
@@ -130,7 +138,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class EnableButton : GuiItems.AbstractButtonItem(
+    private class EnableButton : GuiItems.AbstractButtonItem(
         text("Enable Contacts Info").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
@@ -144,7 +152,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class ContactsDistanceButton : GuiItems.AbstractButtonItem(
+    private class ContactsDistanceButton : GuiItems.AbstractButtonItem(
         text("Change Contacts Range").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.ROUTE_SEGMENT.customModelData) }
     ) {
@@ -153,7 +161,16 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class StarshipsButton : GuiItems.AbstractButtonItem(
+    private class ContactsMaxNameLengthButton : GuiItems.AbstractButtonItem(
+        text("Change Max Name Length").decoration(ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarContactsMaxNameLengthGui.open(player)
+        }
+    }
+
+    private class StarshipsButton : GuiItems.AbstractButtonItem(
         text("Enable Starships").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.GUNSHIP.customModelData) }
     ) {
@@ -164,7 +181,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class LastStarshipsButton : GuiItems.AbstractButtonItem(
+    private class LastStarshipsButton : GuiItems.AbstractButtonItem(
         text("Enable Last Starship").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.GENERIC_STARSHIP.customModelData) }
     ) {
@@ -175,7 +192,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class PlanetsButton : GuiItems.AbstractButtonItem(
+    private class PlanetsButton : GuiItems.AbstractButtonItem(
         text("Enable Planets").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.PLANET.customModelData) }
     ) {
@@ -186,7 +203,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class StarsButton : GuiItems.AbstractButtonItem(
+    private class StarsButton : GuiItems.AbstractButtonItem(
         text("Enable Stars").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.STAR.customModelData) }
     ) {
@@ -197,7 +214,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class BeaconsButton : GuiItems.AbstractButtonItem(
+    private class BeaconsButton : GuiItems.AbstractButtonItem(
         text("Enable Beacons").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.BEACON.customModelData) }
     ) {
@@ -208,7 +225,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class StationsButton : GuiItems.AbstractButtonItem(
+    private class StationsButton : GuiItems.AbstractButtonItem(
         text("Enable Stations").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.STATION.customModelData) }
     ) {
@@ -219,7 +236,7 @@ object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class BookmarksButton : GuiItems.AbstractButtonItem(
+    private class BookmarksButton : GuiItems.AbstractButtonItem(
         text("Enable Bookmarks").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.BOOKMARK.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsGui.kt
@@ -1,0 +1,231 @@
+package net.horizonsend.ion.server.features.gui.custom.settings
+
+import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.features.custom.items.CustomItems
+import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItems
+import net.horizonsend.ion.server.features.gui.GuiText
+import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsCommand
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor.GREEN
+import net.kyori.adventure.text.format.NamedTextColor.RED
+import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
+import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
+import xyz.xenondevs.invui.gui.Gui
+import xyz.xenondevs.invui.gui.PagedGui
+import xyz.xenondevs.invui.gui.structure.Markers
+import xyz.xenondevs.invui.item.Item
+import xyz.xenondevs.invui.item.ItemProvider
+import xyz.xenondevs.invui.item.builder.ItemBuilder
+import xyz.xenondevs.invui.item.impl.controlitem.ControlItem
+import kotlin.math.min
+
+object SettingsSidebarContactsGui : AbstractBackgroundPagedGui {
+
+    private const val SETTINGS_PER_PAGE = 5
+
+    private val BUTTONS_LIST = listOf(
+        EnableButton(),
+        ContactsDistanceButton(),
+        StarshipsButton(),
+        LastStarshipsButton(),
+        PlanetsButton(),
+        StarsButton(),
+        BeaconsButton(),
+        StationsButton(),
+        BookmarksButton()
+    )
+
+    override fun createGui(): PagedGui<Item> {
+        val gui = PagedGui.items()
+
+        gui.setStructure(
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "< . . . v . . . >"
+        )
+
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+            .addIngredient('<', GuiItems.LeftItem())
+            .addIngredient('>', GuiItems.RightItem())
+            .addIngredient('v', SettingsSidebarGui.ReturnToSidebarButton())
+            .setContent(BUTTONS_LIST)
+
+        return gui.build()
+    }
+
+    override fun createText(player: Player, currentPage: Int): Component {
+
+        val enabledSettings = listOf(
+            PlayerCache[player.uniqueId].contactsEnabled,
+            PlayerCache[player.uniqueId].contactsDistance,
+            PlayerCache[player.uniqueId].contactsStarships,
+            PlayerCache[player.uniqueId].lastStarshipEnabled,
+            PlayerCache[player.uniqueId].planetsEnabled,
+            PlayerCache[player.uniqueId].starsEnabled,
+            PlayerCache[player.uniqueId].beaconsEnabled,
+            PlayerCache[player.uniqueId].stationsEnabled,
+            PlayerCache[player.uniqueId].bookmarksEnabled
+        )
+
+        // create a new GuiText builder
+        val header = "Sidebar Contacts Settings"
+        val guiText = GuiText(header)
+        guiText.addBackground()
+
+        // get the index of the first setting to display for this page
+        val startIndex = currentPage * SETTINGS_PER_PAGE
+
+        for (buttonIndex in startIndex until min(startIndex + SETTINGS_PER_PAGE, BUTTONS_LIST.size)) {
+
+            val title = BUTTONS_LIST[buttonIndex].text
+            val line = (buttonIndex - startIndex) * 2
+
+            // setting title
+            guiText.add(
+                component = title,
+                line = line,
+                horizontalShift = 21
+            )
+
+            // setting description
+            guiText.add(
+                component = if (enabledSettings[buttonIndex] is Boolean) {
+                    if (enabledSettings[buttonIndex] as Boolean) text("ENABLED", GREEN) else text("DISABLED", RED)
+                } else text(PlayerCache[player.uniqueId].contactsDistance),
+                line = line + 1,
+                horizontalShift = 21
+            )
+        }
+
+        return guiText.build()
+    }
+
+    class EnableButton : GuiItems.AbstractButtonItem(
+        text("Enable Contacts Info").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            val contactsEnabled = PlayerCache[player.uniqueId].contactsEnabled
+
+            if (contactsEnabled) SidebarContactsCommand.onDisableContacts(player)
+            else SidebarContactsCommand.onEnableContacts(player)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class ContactsDistanceButton : GuiItems.AbstractButtonItem(
+        text("Change Contacts Range").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarContactsRangeGui.open(player)
+        }
+    }
+
+    class StarshipsButton : GuiItems.AbstractButtonItem(
+        text("Enable Starships").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onToggleStarship(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class LastStarshipsButton : GuiItems.AbstractButtonItem(
+        text("Enable Last Starship").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onToggleLastStarship(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class PlanetsButton : GuiItems.AbstractButtonItem(
+        text("Enable Planets").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onTogglePlanets(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class StarsButton : GuiItems.AbstractButtonItem(
+        text("Enable Stars").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onToggleStars(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class BeaconsButton : GuiItems.AbstractButtonItem(
+        text("Enable Beacons").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onToggleBeacons(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class StationsButton : GuiItems.AbstractButtonItem(
+        text("Enable Stations").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onToggleStations(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class BookmarksButton : GuiItems.AbstractButtonItem(
+        text("Enable Bookmarks").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SidebarContactsCommand.onToggleBookmarks(player, null)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    class ReturnToSidebarContactsButton : ControlItem<Gui>() {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarContactsGui.open(player)
+        }
+
+        override fun getItemProvider(gui: Gui): ItemProvider {
+            val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+                it.setCustomModelData(UI_DOWN)
+                it.displayName(text("Return to Sidebar Contacts Settings").decoration(ITALIC, false))
+            })
+            return builder
+        }
+
+        companion object {
+            private const val UI_DOWN = 104
+        }
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsMaxNameLengthGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsMaxNameLengthGui.kt
@@ -19,14 +19,14 @@ import xyz.xenondevs.invui.item.impl.AbstractItem
 import xyz.xenondevs.invui.item.impl.controlitem.ControlItem
 import xyz.xenondevs.invui.window.AnvilWindow
 
-object SettingsSidebarContactsRangeGui {
+object SettingsSidebarContactsMaxNameLengthGui {
 
     private fun createGui(): Gui {
         val gui = Gui.normal()
 
         gui.setStructure(". v x")
 
-        gui.addIngredient('x', SetContactsDistanceButton())
+        gui.addIngredient('x', SetContactsMaxNameLengthButton())
             .addIngredient('.', RenameItem())
             .addIngredient('v', SettingsSidebarContactsGui.ReturnToSidebarContactsButton())
 
@@ -38,18 +38,18 @@ object SettingsSidebarContactsRangeGui {
 
         val window = AnvilWindow.single()
             .setViewer(player)
-            .setTitle(AdventureComponentWrapper(text("Set Contacts Distance")))
+            .setTitle(AdventureComponentWrapper(text("Set Max Name Length")))
             .setGui(gui)
             .build()
 
         window.open()
     }
 
-    private class SetContactsDistanceButton : ControlItem<Gui>() {
+    private class SetContactsMaxNameLengthButton : ControlItem<Gui>() {
         override fun getItemProvider(gui: Gui?): ItemProvider {
             val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
                 it.setCustomModelData(GuiItem.RIGHT.customModelData)
-                it.displayName(text("Set Contacts Distance").decoration(ITALIC, false))
+                it.displayName(text("Set Contacts Max Name Length").decoration(ITALIC, false))
             })
             return builder
         }
@@ -60,7 +60,7 @@ object SettingsSidebarContactsRangeGui {
             val currentText = anvilWindow.renameText ?: return
             val currentInt = currentText.toIntOrNull() ?: return
 
-            SidebarContactsCommand.onSetContactsDistance(player, currentInt)
+            SidebarContactsCommand.onSetContactsMaxNameLength(player, currentInt)
             SettingsSidebarContactsGui.open(player)
         }
     }
@@ -69,7 +69,7 @@ object SettingsSidebarContactsRangeGui {
         override fun getItemProvider(): ItemProvider {
             return ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
                 it.setCustomModelData(GuiItem.LIST.customModelData)
-                it.displayName(text("Enter Range (0-${MainSidebar.CONTACTS_RANGE})").decoration(ITALIC, false))
+                it.displayName(text("Enter Range (1-${MainSidebar.MAX_NAME_LENGTH})").decoration(ITALIC, false))
             })
         }
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsRangeGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsRangeGui.kt
@@ -1,0 +1,80 @@
+package net.horizonsend.ion.server.features.gui.custom.settings
+
+import net.horizonsend.ion.server.features.sidebar.MainSidebar
+import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsCommand
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
+import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
+import xyz.xenondevs.invui.gui.Gui
+import xyz.xenondevs.invui.item.ItemProvider
+import xyz.xenondevs.invui.item.builder.ItemBuilder
+import xyz.xenondevs.invui.item.impl.AbstractItem
+import xyz.xenondevs.invui.item.impl.controlitem.ControlItem
+import xyz.xenondevs.invui.window.AnvilWindow
+
+object SettingsSidebarContactsRangeGui {
+
+    private fun createGui(): Gui {
+        val gui = Gui.normal()
+
+        gui.setStructure(". v x")
+
+        gui.addIngredient('x', SetContactsDistanceButton())
+            .addIngredient('.', RenameItem())
+            .addIngredient('v', SettingsSidebarContactsGui.ReturnToSidebarContactsButton())
+
+        return gui.build()
+    }
+
+    fun open(player: Player) {
+        val gui = createGui()
+
+        val window = AnvilWindow.single()
+            .setViewer(player)
+            .setTitle(AdventureComponentWrapper(text("Set Contacts Distance")))
+            .setGui(gui)
+            .build()
+
+        window.open()
+    }
+
+    class SetContactsDistanceButton : ControlItem<Gui>() {
+        override fun getItemProvider(gui: Gui?): ItemProvider {
+            val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+                it.setCustomModelData(UI_RIGHT)
+                it.displayName(text("Set Contacts Distance").decoration(ITALIC, false))
+            })
+            return builder
+        }
+
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            val currentWindow = (windows.find { it.viewer == player })
+            val anvilWindow = if (currentWindow is AnvilWindow) currentWindow else return
+            val currentText = anvilWindow.renameText ?: return
+            val currentInt = currentText.toIntOrNull() ?: return
+
+            SidebarContactsCommand.onSetContactsDistance(player, currentInt)
+            SettingsSidebarContactsGui.open(player)
+        }
+
+        companion object {
+            private const val UI_RIGHT = 103
+        }
+    }
+
+    class RenameItem : AbstractItem() {
+        override fun getItemProvider(): ItemProvider {
+            return ItemBuilder(ItemStack(Material.PAPER).updateMeta {
+                it.displayName(text("Enter Range (0-${MainSidebar.CONTACTS_RANGE})").decoration(ITALIC, false))
+            })
+        }
+
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {}
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsRangeGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarContactsRangeGui.kt
@@ -1,5 +1,6 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.sidebar.MainSidebar
 import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsCommand
 import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
@@ -47,7 +48,7 @@ object SettingsSidebarContactsRangeGui {
     class SetContactsDistanceButton : ControlItem<Gui>() {
         override fun getItemProvider(gui: Gui?): ItemProvider {
             val builder = ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-                it.setCustomModelData(UI_RIGHT)
+                it.setCustomModelData(GuiItem.RIGHT.customModelData)
                 it.displayName(text("Set Contacts Distance").decoration(ITALIC, false))
             })
             return builder
@@ -62,15 +63,12 @@ object SettingsSidebarContactsRangeGui {
             SidebarContactsCommand.onSetContactsDistance(player, currentInt)
             SettingsSidebarContactsGui.open(player)
         }
-
-        companion object {
-            private const val UI_RIGHT = 103
-        }
     }
 
     class RenameItem : AbstractItem() {
         override fun getItemProvider(): ItemProvider {
-            return ItemBuilder(ItemStack(Material.PAPER).updateMeta {
+            return ItemBuilder(ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+                it.setCustomModelData(GuiItem.LIST.customModelData)
                 it.displayName(text("Enter Range (0-${MainSidebar.CONTACTS_RANGE})").decoration(ITALIC, false))
             })
         }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
@@ -33,19 +33,26 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< v . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
             .addIngredient('v', SettingsMainMenuGui.ReturnToMainMenuButton())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
@@ -42,7 +42,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
-            .addIngredient('v', ReturnToMainMenuButton())
+            .addIngredient('v', SettingsMainMenuGui.ReturnToMainMenuButton())
             .setContent(BUTTONS_LIST)
 
         return gui.build()
@@ -75,27 +75,12 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class ReturnToMainMenuButton : GuiItems.AbstractButtonItem(
-        text("Return to Main Menu").decoration(ITALIC, false),
-        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-            it.setCustomModelData(UI_DOWN)
-            it.displayName(text("Return to Main Menu").decoration(ITALIC, false))
-        }
-    ) {
-        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
-            SettingsMainMenuGui.open(player)
-        }
-
-        companion object {
-            private const val UI_DOWN = 104
-        }
-    }
-
     class StarshipsSettingsButton : GuiItems.AbstractButtonItem(
         text("Starships Settings").decoration(ITALIC, false),
         CustomItems.CHANDRA.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarStarshipsGui.open(player)
         }
     }
 
@@ -104,6 +89,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         CustomItems.CHANDRA.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarContactsGui.open(player)
         }
     }
 
@@ -112,6 +98,23 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         CustomItems.CHANDRA.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarRouteGui.open(player)
+        }
+    }
+
+    class ReturnToSidebarButton : GuiItems.AbstractButtonItem(
+        text("Return to Sidebar Settings").decoration(ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+            it.setCustomModelData(UI_DOWN)
+            it.displayName(text("Return to Sidebar Settings").decoration(ITALIC, false))
+        }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsSidebarGui.open(player)
+        }
+
+        companion object {
+            private const val UI_DOWN = 104
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
@@ -1,0 +1,117 @@
+package net.horizonsend.ion.server.features.gui.custom.settings
+
+import net.horizonsend.ion.server.features.custom.items.CustomItems
+import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItems
+import net.horizonsend.ion.server.features.gui.GuiText
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
+import xyz.xenondevs.invui.gui.PagedGui
+import xyz.xenondevs.invui.gui.structure.Markers
+import xyz.xenondevs.invui.item.Item
+import kotlin.math.min
+
+object SettingsSidebarGui : AbstractBackgroundPagedGui {
+    private const val SETTINGS_PER_PAGE = 5
+
+    private val BUTTONS_LIST = listOf(
+        StarshipsSettingsButton(),
+        ContactsSettingsButton(),
+        RouteSettingsButton()
+    )
+
+    override fun createGui(): PagedGui<Item> {
+        val gui = PagedGui.items()
+
+        gui.setStructure(
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "x . . . . . . . .",
+            "< . . . v . . . >"
+        )
+
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+            .addIngredient('<', GuiItems.LeftItem())
+            .addIngredient('>', GuiItems.RightItem())
+            .addIngredient('v', ReturnToMainMenuButton())
+            .setContent(BUTTONS_LIST)
+
+        return gui.build()
+    }
+
+    override fun createText(player: Player, currentPage: Int): Component {
+
+        // create a new GuiText builder
+        val header = "Sidebar Settings"
+        val guiText = GuiText(header)
+        guiText.addBackground()
+
+        // get the index of the first setting to display for this page
+        val startIndex = currentPage * SETTINGS_PER_PAGE
+
+        for (buttonIndex in startIndex until min(startIndex + SETTINGS_PER_PAGE, BUTTONS_LIST.size)) {
+
+            val title = BUTTONS_LIST[buttonIndex].text
+            val line = (buttonIndex - startIndex) * 2
+
+            // setting title
+            guiText.add(
+                component = title,
+                line = line,
+                horizontalShift = 21,
+                verticalShift = 5
+            )
+        }
+
+        return guiText.build()
+    }
+
+    class ReturnToMainMenuButton : GuiItems.AbstractButtonItem(
+        text("Return to Main Menu").decoration(ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
+            it.setCustomModelData(UI_DOWN)
+            it.displayName(text("Return to Main Menu").decoration(ITALIC, false))
+        }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            SettingsMainMenuGui.open(player)
+        }
+
+        companion object {
+            private const val UI_DOWN = 104
+        }
+    }
+
+    class StarshipsSettingsButton : GuiItems.AbstractButtonItem(
+        text("Starships Settings").decoration(ITALIC, false),
+        CustomItems.CHANDRA.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+        }
+    }
+
+    class ContactsSettingsButton : GuiItems.AbstractButtonItem(
+        text("Contacts Settings").decoration(ITALIC, false),
+        CustomItems.CHANDRA.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+        }
+    }
+
+    class RouteSettingsButton : GuiItems.AbstractButtonItem(
+        text("Route Settings").decoration(ITALIC, false),
+        CustomItems.CHANDRA.constructItemStack()
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+        }
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
@@ -1,7 +1,7 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
@@ -89,7 +89,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
 
     class StarshipsSettingsButton : GuiItems.AbstractButtonItem(
         text("Starships Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.GUNSHIP.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarStarshipsGui.open(player)
@@ -98,7 +98,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
 
     class ContactsSettingsButton : GuiItems.AbstractButtonItem(
         text("Contacts Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarContactsGui.open(player)
@@ -107,7 +107,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
 
     class RouteSettingsButton : GuiItems.AbstractButtonItem(
         text("Route Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.ROUTE_SEGMENT.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarRouteGui.open(player)
@@ -117,16 +117,12 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
     class ReturnToSidebarButton : GuiItems.AbstractButtonItem(
         text("Return to Sidebar Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-            it.setCustomModelData(UI_DOWN)
+            it.setCustomModelData(GuiItem.DOWN.customModelData)
             it.displayName(text("Return to Sidebar Settings").decoration(ITALIC, false))
         }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SettingsSidebarGui.open(player)
-        }
-
-        companion object {
-            private const val UI_DOWN = 104
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarGui.kt
@@ -94,7 +94,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class StarshipsSettingsButton : GuiItems.AbstractButtonItem(
+    private class StarshipsSettingsButton : GuiItems.AbstractButtonItem(
         text("Starships Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.GUNSHIP.customModelData) }
     ) {
@@ -103,7 +103,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class ContactsSettingsButton : GuiItems.AbstractButtonItem(
+    private class ContactsSettingsButton : GuiItems.AbstractButtonItem(
         text("Contacts Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
@@ -112,7 +112,7 @@ object SettingsSidebarGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class RouteSettingsButton : GuiItems.AbstractButtonItem(
+    private class RouteSettingsButton : GuiItems.AbstractButtonItem(
         text("Route Settings").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.ROUTE_SEGMENT.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
@@ -1,31 +1,32 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
+import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
-import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
+import net.horizonsend.ion.server.features.sidebar.command.SidebarWaypointsCommand
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor.GREEN
+import net.kyori.adventure.text.format.NamedTextColor.RED
 import net.kyori.adventure.text.format.TextDecoration.ITALIC
-import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.ClickType
 import org.bukkit.event.inventory.InventoryClickEvent
-import org.bukkit.inventory.ItemStack
+import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
 import xyz.xenondevs.invui.item.Item
-import kotlin.math.ceil
 import kotlin.math.min
 
-object SettingsMainMenuGui : AbstractBackgroundPagedGui {
+object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
+
     private const val SETTINGS_PER_PAGE = 5
-    private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
 
     private val BUTTONS_LIST = listOf(
-        SidebarSettingsButton(),
-        HudSettingsButton()
+        EnableButton(),
+        ExpandedWaypointsButton()
     )
 
     override fun createGui(): PagedGui<Item> {
@@ -37,12 +38,13 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
             "x . . . . . . . .",
             "x . . . . . . . .",
             "x . . . . . . . .",
-            "< . . . . . . . >"
+            "< . . . v . . . >"
         )
 
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
+            .addIngredient('v', SettingsSidebarGui.ReturnToSidebarButton())
             .setContent(BUTTONS_LIST)
 
         return gui.build()
@@ -50,8 +52,13 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
 
     override fun createText(player: Player, currentPage: Int): Component {
 
+        val enabledSettings = listOf(
+            PlayerCache[player.uniqueId].waypointsEnabled,
+            PlayerCache[player.uniqueId].compactWaypoints
+        )
+
         // create a new GuiText builder
-        val header = "Settings"
+        val header = "Sidebar Route Settings"
         val guiText = GuiText(header)
         guiText.addBackground()
 
@@ -67,55 +74,42 @@ object SettingsMainMenuGui : AbstractBackgroundPagedGui {
             guiText.add(
                 component = title,
                 line = line,
-                horizontalShift = 21,
-                verticalShift = 5
+                horizontalShift = 21
+            )
+
+            // setting description
+            guiText.add(
+                component = if (enabledSettings[buttonIndex]) text("ENABLED", GREEN) else text("DISABLED", RED),
+                line = line + 1,
+                horizontalShift = 21
             )
         }
-
-        // page number
-        val pageNumberString =
-            "${currentPage + 1} / ${ceil((BUTTONS_LIST.size.toDouble() / SETTINGS_PER_PAGE)).toInt()}"
-        guiText.add(
-            text(pageNumberString),
-            line = 10,
-            GuiText.TextAlignment.CENTER,
-            verticalShift = PAGE_NUMBER_VERTICAL_SHIFT
-        )
 
         return guiText.build()
     }
 
-    class SidebarSettingsButton : GuiItems.AbstractButtonItem(
-        text("Sidebar Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+    class EnableButton : GuiItems.AbstractButtonItem(
+        text("Enable Route Info").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
-            SettingsSidebarGui.open(player)
+            val routeEnabled = PlayerCache[player.uniqueId].waypointsEnabled
+
+            if (routeEnabled) SidebarWaypointsCommand.onDisableWaypoints(player)
+            else SidebarWaypointsCommand.onEnableWaypoints(player)
+
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
         }
     }
 
-    class HudSettingsButton : GuiItems.AbstractButtonItem(
-        text("HUD Settings").decoration(ITALIC, false),
-        CustomItems.CHANDRA.constructItemStack()
+    class ExpandedWaypointsButton: GuiItems.AbstractButtonItem(
+        text("Route Segments Enabled").decoration(ITALIC, false),
+        CustomItems.CANNON.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
-            SettingsHudGui.open(player)
-        }
-    }
+            SidebarWaypointsCommand.onToggleCompactWaypoints(player, null)
 
-    class ReturnToMainMenuButton : GuiItems.AbstractButtonItem(
-        text("Return to Main Menu Settings").decoration(ITALIC, false),
-        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta {
-            it.setCustomModelData(UI_DOWN)
-            it.displayName(text("Return to Main Menu Settings").decoration(ITALIC, false))
-        }
-    ) {
-        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
-            SettingsMainMenuGui.open(player)
-        }
-
-        companion object {
-            private const val UI_DOWN = 104
+            windows.find { it.viewer == player }?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
         }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
@@ -110,7 +110,7 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class EnableButton : GuiItems.AbstractButtonItem(
+    private class EnableButton : GuiItems.AbstractButtonItem(
         text("Enable Route Info").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
@@ -124,7 +124,7 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class ExpandedWaypointsButton: GuiItems.AbstractButtonItem(
+    private class ExpandedWaypointsButton: GuiItems.AbstractButtonItem(
         text("Route Segments Enabled").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.ROUTE_SEGMENT.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
@@ -1,19 +1,22 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
 import net.horizonsend.ion.server.features.cache.PlayerCache
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.features.sidebar.command.SidebarWaypointsCommand
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor.GREEN
 import net.kyori.adventure.text.format.NamedTextColor.RED
 import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.ClickType
 import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
@@ -102,7 +105,7 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
 
     class EnableButton : GuiItems.AbstractButtonItem(
         text("Enable Route Info").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             val routeEnabled = PlayerCache[player.uniqueId].waypointsEnabled
@@ -116,7 +119,7 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
 
     class ExpandedWaypointsButton: GuiItems.AbstractButtonItem(
         text("Route Segments Enabled").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.ROUTE_SEGMENT.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarWaypointsCommand.onToggleCompactWaypoints(player, null)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
@@ -38,19 +38,26 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< v . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
             .addIngredient('v', SettingsSidebarGui.ReturnToSidebarButton())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarRouteGui.kt
@@ -18,11 +18,13 @@ import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
 import xyz.xenondevs.invui.item.Item
+import kotlin.math.ceil
 import kotlin.math.min
 
 object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
 
     private const val SETTINGS_PER_PAGE = 5
+    private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
 
     private val BUTTONS_LIST = listOf(
         EnableButton(),
@@ -38,7 +40,7 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
             "x . . . . . . . .",
             "x . . . . . . . .",
             "x . . . . . . . .",
-            "< . . . v . . . >"
+            "< v . . . . . . >"
         )
 
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
@@ -84,6 +86,16 @@ object SettingsSidebarRouteGui : AbstractBackgroundPagedGui {
                 horizontalShift = 21
             )
         }
+
+        // page number
+        val pageNumberString =
+            "${currentPage + 1} / ${ceil((BUTTONS_LIST.size.toDouble() / SETTINGS_PER_PAGE)).toInt()}"
+        guiText.add(
+            text(pageNumberString),
+            line = 10,
+            GuiText.TextAlignment.CENTER,
+            verticalShift = PAGE_NUMBER_VERTICAL_SHIFT
+        )
 
         return guiText.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
@@ -39,19 +39,26 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
         val gui = PagedGui.items()
 
         gui.setStructure(
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
-            "x . . . . . . . .",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
+            "x x x x x x x x x",
             "< v . . . . . . >"
         )
 
-        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
+        gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_HORIZONTAL)
             .addIngredient('<', GuiItems.LeftItem())
             .addIngredient('>', GuiItems.RightItem())
             .addIngredient('v', SettingsSidebarGui.ReturnToSidebarButton())
-            .setContent(BUTTONS_LIST)
+
+        for (button in BUTTONS_LIST) {
+            gui.addContent(button)
+
+            for (i in 1..8) {
+                gui.addContent(GuiItems.BlankItem(button))
+            }
+        }
 
         return gui.build()
     }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
@@ -18,11 +18,13 @@ import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
 import xyz.xenondevs.invui.item.Item
+import kotlin.math.ceil
 import kotlin.math.min
 
 object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
 
     private const val SETTINGS_PER_PAGE = 5
+    private const val PAGE_NUMBER_VERTICAL_SHIFT = 4
 
     private val BUTTONS_LIST = listOf(
         EnableButton(),
@@ -39,7 +41,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
             "x . . . . . . . .",
             "x . . . . . . . .",
             "x . . . . . . . .",
-            "< . . . v . . . >"
+            "< v . . . . . . >"
         )
 
         gui.addIngredient('x', Markers.CONTENT_LIST_SLOT_VERTICAL)
@@ -87,6 +89,16 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
             )
         }
 
+        // page number
+        val pageNumberString =
+            "${currentPage + 1} / ${ceil((BUTTONS_LIST.size.toDouble() / SETTINGS_PER_PAGE)).toInt()}"
+        guiText.add(
+            text(pageNumberString),
+            line = 10,
+            GuiText.TextAlignment.CENTER,
+            verticalShift = PAGE_NUMBER_VERTICAL_SHIFT
+        )
+
         return guiText.build()
     }
 
@@ -116,7 +128,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
     }
 
     class CompassRotationButton : GuiItems.AbstractButtonItem(
-        text("Fixed Compass").decoration(ITALIC, false),
+        text("Rotating Compass").decoration(ITALIC, false),
         CustomItems.CANNON.constructItemStack()
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
@@ -1,19 +1,22 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
 import net.horizonsend.ion.server.features.cache.PlayerCache
-import net.horizonsend.ion.server.features.custom.items.CustomItems
 import net.horizonsend.ion.server.features.gui.AbstractBackgroundPagedGui
+import net.horizonsend.ion.server.features.gui.GuiItem
 import net.horizonsend.ion.server.features.gui.GuiItems
 import net.horizonsend.ion.server.features.gui.GuiText
 import net.horizonsend.ion.server.features.sidebar.command.SidebarStarshipsCommand
+import net.horizonsend.ion.server.miscellaneous.utils.updateMeta
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor.GREEN
 import net.kyori.adventure.text.format.NamedTextColor.RED
 import net.kyori.adventure.text.format.TextDecoration.ITALIC
+import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.ClickType
 import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
 import xyz.xenondevs.inventoryaccess.component.AdventureComponentWrapper
 import xyz.xenondevs.invui.gui.PagedGui
 import xyz.xenondevs.invui.gui.structure.Markers
@@ -104,7 +107,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
 
     class EnableButton : GuiItems.AbstractButtonItem(
         text("Enable Starship Info").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             val starshipsEnabled = PlayerCache[player.uniqueId].starshipsEnabled
@@ -118,7 +121,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
 
     class ShowAdvancedButton : GuiItems.AbstractButtonItem(
         text("Display Advanced Info").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarStarshipsCommand.onToggleAdvancedStarshipInfo(player, null)
@@ -129,7 +132,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
 
     class CompassRotationButton : GuiItems.AbstractButtonItem(
         text("Rotating Compass").decoration(ITALIC, false),
-        CustomItems.CANNON.constructItemStack()
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.COMPASS_NEEDLE.customModelData) }
     ) {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             SidebarStarshipsCommand.onToggleRotateCompass(player, null)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsSidebarStarshipsGui.kt
@@ -112,7 +112,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
         return guiText.build()
     }
 
-    class EnableButton : GuiItems.AbstractButtonItem(
+    private class EnableButton : GuiItems.AbstractButtonItem(
         text("Enable Starship Info").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
@@ -126,7 +126,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class ShowAdvancedButton : GuiItems.AbstractButtonItem(
+    private class ShowAdvancedButton : GuiItems.AbstractButtonItem(
         text("Display Advanced Info").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
     ) {
@@ -137,7 +137,7 @@ object SettingsSidebarStarshipsGui : AbstractBackgroundPagedGui {
         }
     }
 
-    class CompassRotationButton : GuiItems.AbstractButtonItem(
+    private class CompassRotationButton : GuiItems.AbstractButtonItem(
         text("Rotating Compass").decoration(ITALIC, false),
         ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.COMPASS_NEEDLE.customModelData) }
     ) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
@@ -1,8 +1,9 @@
-package net.horizonsend.ion.server.features.gui.custom.settings
+package net.horizonsend.ion.server.features.gui.custom.settings.commands
 
 import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.Default
 import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.gui.custom.settings.SettingsMainMenuGui
 import org.bukkit.entity.Player
 
 @CommandAlias("settings")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/MainSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/MainSidebar.kt
@@ -31,6 +31,7 @@ class MainSidebar(private val player: Player, val backingSidebar: Sidebar) {
 		const val MIN_LENGTH = 0
 		const val WAYPOINT_MAX_LENGTH = 30
 		const val CONTACTS_RANGE = 6000
+		const val MAX_NAME_LENGTH = 64
 		//const val CONTACTS_SQRANGE = CONTACTS_RANGE * CONTACTS_RANGE
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
@@ -10,6 +10,7 @@ import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import net.horizonsend.ion.server.command.SLCommand
 import net.horizonsend.ion.server.features.sidebar.MainSidebar
+import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar
 import org.bukkit.entity.Player
 import org.litote.kmongo.setValue
 
@@ -65,6 +66,18 @@ object SidebarContactsCommand : SLCommand() {
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsMaxNameLength, newLength))
 		PlayerCache[sender].contactsMaxNameLength = newLength
 		sender.success("Changed contacts max name length to $newLength")
+	}
+
+	@Suppress("unused")
+	@Subcommand("contacts sortOrder")
+	fun onChangeContactsSortOrder(sender: Player) {
+		val currentSetting = PlayerCache[sender.uniqueId].contactsSort
+
+		// Keep newSetting in the range of the number of sort options
+		val newSetting = if (currentSetting < ContactsSidebar.ContactsSorting.entries.size - 1) currentSetting + 1 else 0
+		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsSort, newSetting))
+		PlayerCache[sender].contactsSort = newSetting
+		sender.success("Changed contacts sorting method to ${ContactsSidebar.ContactsSorting.entries[newSetting]}")
 	}
 
 	@Suppress("unused")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
@@ -29,6 +29,7 @@ object SidebarContactsCommand : SLCommand() {
 		sender: Player
 	) {
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsEnabled, true))
+		PlayerCache[sender].contactsEnabled = true
 		sender.success("Enabled contacts on sidebar")
 	}
 
@@ -38,6 +39,7 @@ object SidebarContactsCommand : SLCommand() {
 		sender: Player
 	) {
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsEnabled, false))
+		PlayerCache[sender].contactsEnabled = false
 		sender.success("Disabled contacts on sidebar")
 	}
 
@@ -49,6 +51,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val newDistance = distance?.coerceIn(0, MainSidebar.CONTACTS_RANGE) ?: MainSidebar.CONTACTS_RANGE
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsDistance, newDistance))
+		PlayerCache[sender].contactsDistance = newDistance
 		sender.success(("Changed contacts distance to $newDistance"))
 	}
 
@@ -60,6 +63,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val contactsStarships = toggle ?: !PlayerCache[sender].contactsStarships
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsStarships, contactsStarships))
+		PlayerCache[sender].contactsStarships = contactsStarships
 		sender.success("Changed starship visibility to $contactsStarships")
 	}
 
@@ -71,6 +75,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val contactsLastStarship = toggle ?: !PlayerCache[sender].lastStarshipEnabled
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::lastStarshipEnabled, contactsLastStarship))
+		PlayerCache[sender].lastStarshipEnabled = contactsLastStarship
 		sender.success("Changed last starship visibility to $contactsLastStarship")
 	}
 
@@ -82,6 +87,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val contactsPlanets = toggle ?: !PlayerCache[sender].planetsEnabled
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::planetsEnabled, contactsPlanets))
+		PlayerCache[sender].planetsEnabled = contactsPlanets
 		sender.success("Changed planet visibility to $contactsPlanets")
 	}
 
@@ -93,6 +99,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val starsEnabled = toggle ?: !PlayerCache[sender].starsEnabled
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::starsEnabled, starsEnabled))
+		PlayerCache[sender].starsEnabled = starsEnabled
 		sender.success("Changed star visibility to $starsEnabled")
 	}
 
@@ -104,6 +111,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val beaconsEnabled = toggle ?: !PlayerCache[sender].beaconsEnabled
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::beaconsEnabled, beaconsEnabled))
+		PlayerCache[sender].beaconsEnabled = beaconsEnabled
 		sender.success("Changed beacon visibility to $beaconsEnabled")
 	}
 
@@ -115,6 +123,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val stationsEnabled = toggle ?: !PlayerCache[sender].stationsEnabled
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::stationsEnabled, stationsEnabled))
+		PlayerCache[sender].stationsEnabled = stationsEnabled
 		sender.success("Changed station visibility to $stationsEnabled")
 	}
 
@@ -126,6 +135,7 @@ object SidebarContactsCommand : SLCommand() {
 	) {
 		val bookmarksEnabled = toggle ?: !PlayerCache[sender].bookmarksEnabled
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::bookmarksEnabled, bookmarksEnabled))
+		PlayerCache[sender].bookmarksEnabled = bookmarksEnabled
 		sender.success("Changed bookmark visibility to $bookmarksEnabled")
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
@@ -52,7 +52,19 @@ object SidebarContactsCommand : SLCommand() {
 		val newDistance = distance?.coerceIn(0, MainSidebar.CONTACTS_RANGE) ?: MainSidebar.CONTACTS_RANGE
 		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsDistance, newDistance))
 		PlayerCache[sender].contactsDistance = newDistance
-		sender.success(("Changed contacts distance to $newDistance"))
+		sender.success("Changed contacts distance to $newDistance")
+	}
+
+	@Suppress("unused")
+	@Subcommand("contacts maxNameLength")
+	fun onSetContactsMaxNameLength(
+		sender: Player,
+		maxLength: Int?
+	) {
+		val newLength = maxLength?.coerceIn(1, MainSidebar.MAX_NAME_LENGTH) ?: MainSidebar.MAX_NAME_LENGTH
+		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsMaxNameLength, newLength))
+		PlayerCache[sender].contactsMaxNameLength = newLength
+		sender.success("Changed contacts max name length to $newLength")
 	}
 
 	@Suppress("unused")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarContactsCommand.kt
@@ -81,6 +81,18 @@ object SidebarContactsCommand : SLCommand() {
 	}
 
 	@Suppress("unused")
+	@Subcommand("contacts coloring")
+	fun onChangeContactsColoring(sender: Player) {
+		val currentSetting = PlayerCache[sender.uniqueId].contactsColoring
+
+		// Keep newSetting in the range of the number of sort options
+		val newSetting = if (currentSetting < ContactsSidebar.ContactsColoring.entries.size - 1) currentSetting + 1 else 0
+		SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::contactsColoring, newSetting))
+		PlayerCache[sender].contactsColoring = newSetting
+		sender.success("Changed contacts coloring to ${ContactsSidebar.ContactsColoring.entries[newSetting]}")
+	}
+
+	@Suppress("unused")
 	@Subcommand("contacts starship")
 	fun onToggleStarship(
 		sender: Player,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarStarshipsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarStarshipsCommand.kt
@@ -28,6 +28,7 @@ object SidebarStarshipsCommand : SLCommand() {
         sender: Player
     ) {
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::starshipsEnabled, true))
+        PlayerCache[sender].starshipsEnabled = true
         sender.success("Enabled starship info on sidebar")
     }
 
@@ -37,6 +38,7 @@ object SidebarStarshipsCommand : SLCommand() {
         sender: Player
     ) {
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::starshipsEnabled, false))
+        PlayerCache[sender].starshipsEnabled = false
         sender.success("Disabled starship info on sidebar")
     }
 
@@ -48,6 +50,7 @@ object SidebarStarshipsCommand : SLCommand() {
     ) {
         val advancedStarshipInfo = toggle ?: !PlayerCache[sender].advancedStarshipInfo
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::advancedStarshipInfo, advancedStarshipInfo))
+        PlayerCache[sender].advancedStarshipInfo = advancedStarshipInfo
         sender.success("Changed advanced starship info to $advancedStarshipInfo")
     }
 
@@ -59,6 +62,7 @@ object SidebarStarshipsCommand : SLCommand() {
     ) {
         val rotateCompass = toggle ?: !PlayerCache[sender].rotateCompass
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::rotateCompass, rotateCompass))
+        PlayerCache[sender].rotateCompass = rotateCompass
         sender.success("Changed rotating compass to $rotateCompass")
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarWaypointsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarWaypointsCommand.kt
@@ -29,6 +29,7 @@ object SidebarWaypointsCommand : SLCommand() {
         sender: Player
     ) {
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::waypointsEnabled, true))
+        PlayerCache[sender].waypointsEnabled = true
         sender.success("Enabled route on sidebar")
     }
 
@@ -38,6 +39,7 @@ object SidebarWaypointsCommand : SLCommand() {
         sender: Player
     ) {
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::waypointsEnabled, false))
+        PlayerCache[sender].waypointsEnabled = false
         sender.success("Disabled route on sidebar")
     }
 
@@ -50,6 +52,7 @@ object SidebarWaypointsCommand : SLCommand() {
     ) {
         val waypointsCompactWaypoints = toggle ?: !PlayerCache[sender].compactWaypoints
         SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::compactWaypoints, waypointsCompactWaypoints))
+        PlayerCache[sender].compactWaypoints = waypointsCompactWaypoints
         sender.success("Changed compact waypoints visibility to $waypointsCompactWaypoints")
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
@@ -199,15 +199,15 @@ object ContactsSidebar {
         }
 
         if (planetsEnabled) {
-            addPlanetContacts(planets, sourceVector, contactsList)
+            addPlanetContacts(planets, sourceVector, contactsList, player)
         }
 
         if (starsEnabled) {
-            addStarContacts(stars, sourceVector, contactsList)
+            addStarContacts(stars, sourceVector, contactsList, player)
         }
 
         if (beaconsEnabled) {
-            addBeaconContacts(beacons, sourceVector, contactsList)
+            addBeaconContacts(beacons, sourceVector, contactsList, player)
         }
 
         if (stationsEnabled) {
@@ -216,7 +216,7 @@ object ContactsSidebar {
         }
 
         if (bookmarksEnabled) {
-            addBookmarkContacts(bookmarks, sourceVector, contactsList)
+            addBookmarkContacts(bookmarks, sourceVector, contactsList, player)
         }
 
         // append spaces
@@ -236,6 +236,7 @@ object ContactsSidebar {
     ) {
         val currentStarship = PilotedStarships[player]
         val interdictionLocation = currentStarship?.centerOfMass?.toVector() ?: playerVector
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
 
         for (starship in starships) {
             val otherController = starship.controller
@@ -252,7 +253,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(starship.identifier, color),
+                    name = text(starship.identifier.take(maxLength), color),
                     prefix = constructPrefixTextComponent(starship.type.icon, playerRelationColor(player, otherController)),
                     suffix = constructSuffixTextComponent(
                         if (currentStarship != null) {
@@ -278,6 +279,7 @@ object ContactsSidebar {
         contactsList: MutableList<ContactsData>
     ) {
         val lastStarship = LastPilotedStarship.map[player.uniqueId]
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
 
         if (lastStarship != null &&
             lastStarship.world == player.world &&
@@ -291,7 +293,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text("Last Piloted Starship", color),
+                    name = text("Last Piloted Starship".take(maxLength), color),
                     prefix = constructPrefixTextComponent(GENERIC_STARSHIP_ICON.text, YELLOW),
                     suffix = Component.empty(),
                     heading = constructHeadingTextComponent(direction, color),
@@ -307,8 +309,11 @@ object ContactsSidebar {
     private fun addPlanetContacts(
         planets: List<CachedPlanet>,
         sourceVector: Vector,
-        contactsList: MutableList<ContactsData>
+        contactsList: MutableList<ContactsData>,
+        player: Player
     ) {
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
+
         for (planet in planets) {
             val vector = planet.location.toVector()
             val distance = vector.distance(sourceVector).toInt()
@@ -318,7 +323,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(planet.name, color),
+                    name = text(planet.name.take(maxLength), color),
                     prefix = constructPrefixTextComponent(PLANET_ICON.text, DARK_AQUA),
                     suffix = constructSuffixTextComponent(
                         interdictionTextComponent(
@@ -340,8 +345,11 @@ object ContactsSidebar {
     private fun addStarContacts(
         stars: List<CachedStar>,
         sourceVector: Vector,
-        contactsList: MutableList<ContactsData>
+        contactsList: MutableList<ContactsData>,
+        player: Player
     ) {
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
+
         for (star in stars) {
             val vector = star.location.toVector()
             val distance = vector.distance(sourceVector).toInt()
@@ -351,7 +359,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(star.name, color),
+                    name = text(star.name.take(maxLength), color),
                     prefix = constructPrefixTextComponent(STAR_ICON.text, YELLOW),
                     suffix = constructSuffixTextComponent(
                         interdictionTextComponent(
@@ -373,8 +381,11 @@ object ContactsSidebar {
     private fun addBeaconContacts(
         beacons: List<ServerConfiguration.HyperspaceBeacon>,
         sourceVector: Vector,
-        contactsList: MutableList<ContactsData>
+        contactsList: MutableList<ContactsData>,
+        player: Player
     ) {
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
+
         for (beacon in beacons) {
             val vector = beacon.spaceLocation.toVector()
             val distance = vector.distance(sourceVector).toInt()
@@ -384,7 +395,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(beacon.name, color),
+                    name = text(beacon.name.take(maxLength), color),
                     prefix = constructPrefixTextComponent(HYPERSPACE_BEACON_ENTER_ICON.text, BLUE),
                     suffix = constructSuffixTextComponent(beaconTextComponent(beacon.prompt)),
                     heading = constructHeadingTextComponent(direction, color),
@@ -403,6 +414,8 @@ object ContactsSidebar {
         contactsList: MutableList<ContactsData>,
         player: Player
     ) {
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
+
         for (station in stations) {
             val vector = Vector(station.x, 192, station.z)
             val distance = vector.distance(sourceVector).toInt()
@@ -412,7 +425,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(station.name, color),
+                    name = text(station.name.take(maxLength), color),
                     prefix = constructPrefixTextComponent(STATION_ICON.text, stationRelationColor(player, station)),
                     suffix = Component.empty(),
                     heading = constructHeadingTextComponent(direction, color),
@@ -431,6 +444,8 @@ object ContactsSidebar {
         contactsList: MutableList<ContactsData>,
         player: Player
     ) {
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
+
         for (station in capturableStations) {
             val vector = station.loc.toVector()
             val distance = vector.distance(sourceVector).toInt()
@@ -440,7 +455,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(station.name, color),
+                    name = text(station.name.take(maxLength), color),
                     prefix = constructPrefixTextComponent(
                         SidebarIcon.SIEGE_STATION_ICON.text,
                         capturableStationRelationColor(player, station)),
@@ -458,8 +473,11 @@ object ContactsSidebar {
     private fun addBookmarkContacts(
         bookmarks: List<Bookmark>,
         sourceVector: Vector,
-        contactsList: MutableList<ContactsData>
+        contactsList: MutableList<ContactsData>,
+        player: Player
     ) {
+        val maxLength = PlayerCache[player.uniqueId].contactsMaxNameLength
+
         for (bookmark in bookmarks) {
             val vector = Vector(bookmark.x, bookmark.y, bookmark.z)
             val distance = vector.distance(sourceVector).toInt()
@@ -469,7 +487,7 @@ object ContactsSidebar {
 
             contactsList.add(
                 ContactsData(
-                    name = text(bookmark.name, color),
+                    name = text(bookmark.name.take(maxLength), color),
                     prefix = constructPrefixTextComponent(BOOKMARK_ICON.text, DARK_PURPLE),
                     suffix = Component.empty(),
                     heading = constructHeadingTextComponent(direction, color),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -65,6 +65,7 @@ import net.horizonsend.ion.server.command.starship.ai.AIDebugCommand
 import net.horizonsend.ion.server.configuration.ConfigurationCommands
 import net.horizonsend.ion.server.features.achievements.AchievementsCommand
 import net.horizonsend.ion.server.features.client.commands.HudCommand
+import net.horizonsend.ion.server.features.gui.custom.settings.SettingsCommand
 import net.horizonsend.ion.server.features.misc.NewPlayerProtection
 import net.horizonsend.ion.server.features.sidebar.command.BookmarkCommand
 import net.horizonsend.ion.server.features.sidebar.command.SidebarCommand
@@ -161,5 +162,6 @@ val commands: List<SLCommand> = listOf(
 
 	IonBroadcastCommand,
 	BlockCommand,
-	ShipFactoryCommand
+	ShipFactoryCommand,
+	SettingsCommand
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -65,7 +65,7 @@ import net.horizonsend.ion.server.command.starship.ai.AIDebugCommand
 import net.horizonsend.ion.server.configuration.ConfigurationCommands
 import net.horizonsend.ion.server.features.achievements.AchievementsCommand
 import net.horizonsend.ion.server.features.client.commands.HudCommand
-import net.horizonsend.ion.server.features.gui.custom.settings.SettingsCommand
+import net.horizonsend.ion.server.features.gui.custom.settings.commands.SettingsCommand
 import net.horizonsend.ion.server.features.misc.NewPlayerProtection
 import net.horizonsend.ion.server.features.sidebar.command.BookmarkCommand
 import net.horizonsend.ion.server.features.sidebar.command.SidebarCommand


### PR DESCRIPTION
# Settings Menu
![image](https://github.com/HorizonsEndMC/Ion/assets/35514618/7996a77b-bd1b-4a81-a47e-f002414a22dd)
- New GUI-based method of changing per-player settings
- Access via `/settings`
- Old commands for changing settings (`/sidebar`) are still available

### Changes
- Added additional Sidebar Contacts settings
![image](https://github.com/HorizonsEndMC/Ion/assets/35514618/3f815e83-2cac-4c28-8740-e643e132e491)
  - Max contact name length displayed (between 1 and 64 characters long)
  - Method of sorting contacts (Sort by distance, type, and relation, ascending or descending. Distance is always used as a secondary sorting characteristic)
  - Contacts color setting (Default: icon shows relation status, text shows relative distance; Relation: icon shows relative distance, text shows relation status