### PR TITLE
Fleets

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/utils/text/colors/ColorScheme.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/utils/text/colors/ColorScheme.kt
@@ -8,6 +8,7 @@ class HEColorScheme(override val adventure: TextColor): PresetColor {
 		val HE_LIGHT_GRAY = HEColorScheme(TextColor.fromHexString("#E1E1E1")!!)
 		val HE_LIGHT_BLUE = HEColorScheme(TextColor.fromHexString("#B8D7D7")!!)
 		val HE_LIGHT_ORANGE = HEColorScheme(TextColor.fromHexString("#F2AE67")!!)
+		val HE_DARK_ORANGE = HEColorScheme(TextColor.fromHexString("#CE6F0E")!!)
 		val HE_MEDIUM_GRAY = HEColorScheme(TextColor.fromHexString("#768A8A")!!)
 		val HE_DARK_GRAY = HEColorScheme(TextColor.fromHexString("#414C4C")!!)
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/chat/ChatChannel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/chat/ChatChannel.kt
@@ -27,9 +27,11 @@ import net.horizonsend.ion.server.features.progression.SLXP
 import net.horizonsend.ion.server.features.space.Space
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
 import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
+import net.horizonsend.ion.server.features.starship.fleet.Fleets
 import net.horizonsend.ion.server.miscellaneous.utils.PlayerWrapper.Companion.common
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.empty
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.NamedTextColor.AQUA
@@ -39,6 +41,7 @@ import net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY
 import net.kyori.adventure.text.format.NamedTextColor.DARK_GREEN
 import net.kyori.adventure.text.format.NamedTextColor.DARK_PURPLE
 import net.kyori.adventure.text.format.NamedTextColor.DARK_RED
+import net.kyori.adventure.text.format.NamedTextColor.GOLD
 import net.kyori.adventure.text.format.NamedTextColor.GREEN
 import net.kyori.adventure.text.format.NamedTextColor.LIGHT_PURPLE
 import net.kyori.adventure.text.format.NamedTextColor.RED
@@ -250,6 +253,21 @@ enum class ChatChannel(val displayName: Component, val commandAliases: List<Stri
 			}
 
 			starship.sendMessage(formatChatMessage(prefix, player, event, messageColor).buildChatComponent())
+		}
+	},
+
+	FLEET(text("Fleet", HEColorScheme.HE_DARK_ORANGE, TextDecoration.BOLD), listOf("fleetchat", "fc", "fchat"), HEColorScheme.HE_LIGHT_ORANGE) {
+		override fun onChat(player: Player, event: AsyncChatEvent) {
+			val fleet = Fleets.findByMember(player)
+				?: return player.userError("You're not in a fleet! <italic>(Hint: To get back to global, use /global)")
+
+			val prefix = ofChildren(
+				displayName,
+				Component.space(),
+				if (fleet.leaderId == player.uniqueId) text("[CMDR]", GOLD, TextDecoration.BOLD) else empty()
+			)
+
+			fleet.sendMessage(formatChatMessage(prefix, player, event, messageColor).buildChatComponent())
 		}
 	},
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/chat/ChatChannel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/chat/ChatChannel.kt
@@ -24,6 +24,7 @@ import net.horizonsend.ion.server.features.chat.messages.NationsChatMessage
 import net.horizonsend.ion.server.features.chat.messages.NormalChatMessage
 import net.horizonsend.ion.server.features.progression.Levels
 import net.horizonsend.ion.server.features.progression.SLXP
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon
 import net.horizonsend.ion.server.features.space.Space
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
 import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
@@ -264,7 +265,7 @@ enum class ChatChannel(val displayName: Component, val commandAliases: List<Stri
 			val prefix = ofChildren(
 				displayName,
 				Component.space(),
-				if (fleet.leaderId == player.uniqueId) text("[CMDR]", GOLD, TextDecoration.BOLD) else empty()
+				if (fleet.leaderId == player.uniqueId) text(SidebarIcon.FLEET_COMMANDER_ICON.text, GOLD, TextDecoration.BOLD) else empty()
 			)
 
 			fleet.sendMessage(formatChatMessage(prefix, player, event, messageColor).buildChatComponent())

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/SidebarIcon.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/SidebarIcon.kt
@@ -57,4 +57,6 @@ enum class SidebarIcon(val text: String) {
     AI_BARGE_ICON("\uE065"),
     AI_TANKER_ICON("\uE066"),
     AI_ARK_ICON("\uE067"),
+    FLEET_COMMANDER_ICON("\uE070"),
+    FLEET_ICON("\uE071")
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/tasks/ContactsSidebar.kt
@@ -14,6 +14,8 @@ import net.horizonsend.ion.server.features.misc.CapturableStationCache
 import net.horizonsend.ion.server.features.sidebar.Sidebar.fontKey
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.BOOKMARK_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.CROSSHAIR_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.FLEET_COMMANDER_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.FLEET_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.GENERIC_STARSHIP_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.HYPERSPACE_BEACON_ENTER_ICON
 import net.horizonsend.ion.server.features.sidebar.SidebarIcon.INTERDICTION_ICON
@@ -393,6 +395,10 @@ object ContactsSidebar {
             }
             val name = text(nameString, color)
 
+            val fleet = Fleets.findByMember(player)
+            val otherPlayer = if (otherController is ActivePlayerController) otherController.player else null
+            val inFleet = otherPlayer?.let { fleet?.get(it) } ?: false
+
             contactsList.add(
                 ContactsData(
                     name = name,
@@ -406,6 +412,11 @@ object ContactsSidebar {
                         } else Component.empty(),
                         if (starship.isInterdicting) {
                             interdictionTextComponent(interdictionDistance, starship.balancing.interdictionRange, true)
+                        } else Component.empty(),
+                        if (inFleet) {
+                            if (fleet != null && otherPlayer != null && fleet.leaderId == otherPlayer.uniqueId) {
+                                fleetCommanderTextComponent()
+                            } else fleetTextComponent()
                         } else Component.empty()
                     ),
                     heading = constructHeadingTextComponent(direction, color),
@@ -796,6 +807,10 @@ object ContactsSidebar {
         } else if (visibleOutOfRange) {
             text(INTERDICTION_ICON.text, GOLD).font(fontKey)
         } else Component.empty()
+
+    private fun fleetTextComponent() = text(FLEET_ICON.text, AQUA).font(fontKey)
+
+    private fun fleetCommanderTextComponent() = text(FLEET_COMMANDER_ICON.text, GOLD).font(fontKey)
 
     private fun beaconTextComponent(text: String?) =
         if (text?.contains("⚠") == true) text("⚠", RED)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
@@ -26,9 +26,12 @@ import java.util.UUID
 class Fleet(var leaderId: UUID) : ForwardingAudience {
 
     private val memberIds = mutableSetOf(leaderId)
+    private val invitedIds = mutableSetOf<UUID>()
     var lastBroadcast = ""
 
-    private fun add(playerId: UUID) = memberIds.add(playerId)
+    private fun add(playerId: UUID) {
+        memberIds.add(playerId)
+    }
 
     fun add(player: Player) = add(player.uniqueId)
 
@@ -50,10 +53,29 @@ class Fleet(var leaderId: UUID) : ForwardingAudience {
 
     fun get(player: Player) = get(player.uniqueId)
 
+    private fun invite(playerId: UUID) {
+        invitedIds.add(playerId)
+    }
+
+    fun invite(player: Player) = invite(player.uniqueId)
+
+    private fun removeInvite(playerId: UUID) {
+        if (invitedIds.contains(playerId)) invitedIds.remove(playerId)
+    }
+
+    fun removeInvite(player: Player) = removeInvite(player.uniqueId)
+
+    private fun getInvite(playerId: UUID) = invitedIds.contains(playerId)
+
+    fun getInvite(player: Player) = getInvite(player.uniqueId)
+
     fun delete() {
         this.userError("Your Fleet Commander has disbanded your fleet!")
         for (memberId in memberIds) {
             remove(memberId)
+        }
+        for (inviteId in invitedIds) {
+            removeInvite(inviteId)
         }
     }
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
@@ -68,14 +68,12 @@ class Fleet(var leaderId: UUID) : ForwardingAudience {
 
     fun switchLeader(player: Player): Boolean = switchLeader(player.uniqueId)
 
-    fun changeBroadcast(broadcast: String) {
+    fun broadcast(broadcast: String) {
         lastBroadcast = broadcast
-    }
 
-    fun broadcast() {
         for (memberId in memberIds) {
             val player = Bukkit.getPlayer(memberId) ?: continue
-            player.showTitle(Title.title(text("Fleet Broadcast", HE_DARK_ORANGE), text(lastBroadcast), Title.DEFAULT_TIMES))
+            player.showTitle(Title.title(text("Fleet Broadcast", HE_DARK_ORANGE), text(broadcast), Title.DEFAULT_TIMES))
         }
     }
 
@@ -102,8 +100,6 @@ class Fleet(var leaderId: UUID) : ForwardingAudience {
             MiscStarshipCommands.onJump(player, destination, null)
         }
     }
-
-    fun getBroadcastIdentifier() = lastBroadcast.split(' ', limit = 1).firstOrNull()
 
     fun list(player: Player) {
         player.sendMessage(lineBreakWithCenterText(text("Fleet Members", HE_LIGHT_ORANGE)))

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
@@ -1,0 +1,118 @@
+package net.horizonsend.ion.server.features.starship.fleet
+
+import net.horizonsend.ion.common.utils.text.bracketed
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_DARK_GRAY
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_GRAY
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_ORANGE
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_MEDIUM_GRAY
+import net.horizonsend.ion.common.utils.text.lineBreakWithCenterText
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.common.utils.text.template
+import net.horizonsend.ion.server.command.starship.MiscStarshipCommands
+import net.horizonsend.ion.server.features.starship.PilotedStarships
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.audience.ForwardingAudience
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor.WHITE
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import java.util.Locale
+import java.util.UUID
+
+class Fleet(var leaderId: UUID) : ForwardingAudience {
+
+    private val memberIds = mutableSetOf(leaderId)
+    var lastBroadcast = ""
+
+    private fun add(playerId: UUID) = memberIds.add(playerId)
+
+    fun add(player: Player) = add(player.uniqueId)
+
+    private fun remove(playerId: UUID) {
+        memberIds.remove(playerId)
+        if (leaderId == playerId && memberIds.isNotEmpty()) {
+            // if the first player id is not valid, delete the fleet (there is likely an error)
+            if (!switchLeader(memberIds.first())) {
+                delete()
+            }
+        }
+    }
+
+    fun remove(player: Player) = remove(player.uniqueId)
+
+    private fun get(playerId: UUID) = memberIds.contains(playerId)
+
+    fun get(player: Player) = get(player.uniqueId)
+
+    fun delete() {
+        for (memberId in memberIds) {
+            remove(memberId)
+        }
+    }
+
+    private fun switchLeader(newLeaderId: UUID): Boolean {
+        if (Bukkit.getPlayer(newLeaderId) == null) return false
+
+        leaderId = newLeaderId
+        return true
+    }
+
+    fun switchLeader(player: Player): Boolean = switchLeader(player.uniqueId)
+
+    fun jumpFleet() {
+        for (memberId in memberIds) {
+            val player = Bukkit.getPlayer(memberId) ?: continue
+
+            MiscStarshipCommands.onJump(player)
+        }
+    }
+
+    fun jumpFleet(x: Int, z: Int) {
+        for (memberId in memberIds) {
+            val player = Bukkit.getPlayer(memberId) ?: continue
+
+            MiscStarshipCommands.onJump(player, x.toString(), z.toString(), null)
+        }
+    }
+
+    fun jumpFleet(destination: String) {
+        for (memberId in memberIds) {
+            val player = Bukkit.getPlayer(memberId) ?: continue
+
+            MiscStarshipCommands.onJump(player, destination, null)
+        }
+    }
+
+    fun getBroadcastIdentifier() = lastBroadcast.split(' ', limit = 1).firstOrNull()
+
+    fun list(player: Player) {
+        player.sendMessage(lineBreakWithCenterText(text("Fleet Members", HE_LIGHT_ORANGE)))
+        player.sendMessage(ofChildren(
+            text("Fleet Commander", HE_MEDIUM_GRAY),
+            text(": ", HE_DARK_GRAY),
+            text(Bukkit.getPlayer(leaderId)?.name ?: "None")
+        ))
+
+        player.sendMessage(net.horizonsend.ion.common.utils.text.lineBreak(47))
+        for (memberId in memberIds) {
+            val memberPlayer = Bukkit.getPlayer(memberId) ?: continue
+            val starship = PilotedStarships[memberPlayer]
+
+            val line = template(
+                "{0} piloting {1} {2} in {3}",
+                color = HE_LIGHT_GRAY,
+                paramColor = WHITE,
+                useQuotesAroundObjects = true,
+                memberPlayer.name,
+                starship?.getDisplayName() ?: "nothing",
+                bracketed(text(starship?.initialBlockCount ?: 0, WHITE)),
+                memberPlayer.location.world.name.replaceFirstChar {
+                    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                }
+            )
+            player.sendMessage(line)
+        }
+    }
+
+    override fun audiences() : Iterable<Audience> = memberIds.mapNotNull(Bukkit::getPlayer)
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleet.kt
@@ -1,7 +1,6 @@
 package net.horizonsend.ion.server.features.starship.fleet
 
 import net.horizonsend.ion.common.extensions.information
-import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.utils.text.bracketed
 import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_DARK_GRAY
 import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_DARK_ORANGE
@@ -12,10 +11,15 @@ import net.horizonsend.ion.common.utils.text.lineBreakWithCenterText
 import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.common.utils.text.template
 import net.horizonsend.ion.server.command.starship.MiscStarshipCommands
+import net.horizonsend.ion.server.features.sidebar.Sidebar
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.FLEET_COMMANDER_ICON
+import net.horizonsend.ion.server.features.sidebar.SidebarIcon.FLEET_ICON
 import net.horizonsend.ion.server.features.starship.PilotedStarships
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.audience.ForwardingAudience
+import net.kyori.adventure.text.Component.space
 import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor.GOLD
 import net.kyori.adventure.text.format.NamedTextColor.WHITE
 import net.kyori.adventure.title.Title
 import org.bukkit.Bukkit
@@ -70,20 +74,18 @@ class Fleet(var leaderId: UUID) : ForwardingAudience {
     fun getInvite(player: Player) = getInvite(player.uniqueId)
 
     fun delete() {
-        this.userError("Your Fleet Commander has disbanded your fleet!")
-        for (memberId in memberIds) {
-            remove(memberId)
-        }
-        for (inviteId in invitedIds) {
-            removeInvite(inviteId)
-        }
+        memberIds.clear()
+        invitedIds.clear()
     }
 
     private fun switchLeader(newLeaderId: UUID): Boolean {
         val player = Bukkit.getPlayer(newLeaderId) ?: return false
 
         leaderId = newLeaderId
-        this.information("${player.name} is now the Fleet Commander of your fleet")
+        for (memberId in memberIds) {
+            val member = Bukkit.getPlayer(memberId) ?: continue
+            member.information("${player.name} is now the new Fleet Commander of your fleet")
+        }
 
         return true
     }
@@ -124,8 +126,14 @@ class Fleet(var leaderId: UUID) : ForwardingAudience {
     }
 
     fun list(player: Player) {
-        player.sendMessage(lineBreakWithCenterText(text("Fleet Members", HE_LIGHT_ORANGE)))
+        player.sendMessage(lineBreakWithCenterText(ofChildren(
+            text(FLEET_ICON.text, HE_LIGHT_ORANGE).font(Sidebar.fontKey),
+            space(),
+            text("Fleet Members", HE_LIGHT_ORANGE)))
+        )
         player.sendMessage(ofChildren(
+            text(FLEET_COMMANDER_ICON.text, GOLD).font(Sidebar.fontKey),
+            space(),
             text("Fleet Commander", HE_MEDIUM_GRAY),
             text(": ", HE_DARK_GRAY),
             text(Bukkit.getPlayer(leaderId)?.name ?: "None")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetCommand.kt
@@ -119,6 +119,21 @@ object FleetCommand : SLCommand() {
         sender.success("Switched fleet command to ${player.name}")
     }
 
+    @Subcommand("clearbroadcast|clearbc")
+    @Suppress("unused")
+    @CommandCompletion("@players")
+    fun onFleetClearBroadcast(sender: Player) {
+        val fleet = getFleet(sender) ?: return
+
+        if (!(isFleetCommand(sender) ?: return)) {
+            sender.userError("You are not the commander of this fleet")
+            return
+        }
+
+        fleet.lastBroadcast = ""
+        sender.success("Cleared broadcast message")
+    }
+
     @Subcommand("broadcast|bc")
     @Suppress("unused")
     @CommandCompletion("@players")
@@ -130,8 +145,7 @@ object FleetCommand : SLCommand() {
             return
         }
 
-        fleet.changeBroadcast(broadcast)
-        fleet.broadcast()
+        fleet.broadcast(broadcast)
         sender.success("Broadcast message \"$broadcast\"")
     }
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetCommand.kt
@@ -1,0 +1,55 @@
+package net.horizonsend.ion.server.features.starship.fleet
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.Subcommand
+import net.horizonsend.ion.common.extensions.success
+import net.horizonsend.ion.common.extensions.userError
+import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.starship.fleet.Fleets.fleet
+import org.bukkit.entity.Player
+
+@CommandAlias("fleet")
+object FleetCommand : SLCommand() {
+    @Subcommand("create")
+    @Suppress("unused")
+    fun onFleetCreate(sender: Player) {
+        if (sender.fleet() != null) {
+            sender.userError("You are already in a fleet")
+            return
+        }
+
+        Fleets.create(sender)
+        sender.success("Created fleet")
+    }
+
+    @Subcommand("delete")
+    @Suppress("unused")
+    fun onFleetDelete(sender: Player) {
+        val fleet = sender.fleet()
+
+        if (fleet == null) {
+            sender.userError("You are not in a fleet")
+            return
+        }
+
+        if (fleet.leaderId != sender.uniqueId) {
+            sender.userError("You are not the commander of this fleet")
+        }
+
+        Fleets.delete(fleet)
+        sender.success("Deleted fleet")
+    }
+
+    @Subcommand("list")
+    @Suppress("unused")
+    fun onFleetList(sender: Player) {
+        val fleet = sender.fleet()
+
+        if (fleet == null) {
+            sender.userError("You are not in a fleet")
+            return
+        }
+
+        fleet.list(sender)
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetCommand.kt
@@ -11,7 +11,7 @@ import net.horizonsend.ion.server.command.SLCommand
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
-@CommandAlias("fleet")
+@CommandAlias("fleet|f")
 object FleetCommand : SLCommand() {
     @Subcommand("create")
     @Suppress("unused")
@@ -34,6 +34,7 @@ object FleetCommand : SLCommand() {
             sender.userError("You are not the commander of this fleet")
         }
 
+        fleet.userError("Your Fleet Commander has disbanded your fleet!")
         Fleets.delete(fleet)
         sender.success("Disbanded fleet")
     }
@@ -57,6 +58,7 @@ object FleetCommand : SLCommand() {
         }
 
         fleet.remove(sender)
+        fleet.information("${sender.name} has left your fleet")
     }
 
     @Subcommand("kick")
@@ -87,6 +89,7 @@ object FleetCommand : SLCommand() {
         }
 
         fleet.remove(player)
+        player.userError("You were kicked from ${sender.name}'s fleet!")
         sender.success("Removed ${player.name} from fleet")
     }
 
@@ -199,6 +202,7 @@ object FleetCommand : SLCommand() {
             val inviter = Bukkit.getPlayer(inviterName) ?: continue
 
             if (fleet.leaderId == inviter.uniqueId) {
+                fleet.information(("${sender.name} has joined your fleet"))
                 fleet.add(sender)
                 fleet.removeInvite(sender)
                 sender.success("Joined ${inviter.name}'s fleet")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetListeners.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetListeners.kt
@@ -1,0 +1,6 @@
+package net.horizonsend.ion.server.features.starship.fleet
+
+import net.horizonsend.ion.server.listener.SLEventListener
+
+class FleetListeners : SLEventListener() {
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetListeners.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/FleetListeners.kt
@@ -1,6 +1,0 @@
-package net.horizonsend.ion.server.features.starship.fleet
-
-import net.horizonsend.ion.server.listener.SLEventListener
-
-class FleetListeners : SLEventListener() {
-}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleets.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleets.kt
@@ -9,7 +9,7 @@ object Fleets : IonServerComponent() {
 
     private val fleetList = mutableListOf<Fleet>()
 
-    fun Player.fleet() = fleetList.find { it.get(this) }
+    fun findByMember(player: Player) = fleetList.find { it.get(player) }
 
     fun create(player: Player) = fleetList.add(Fleet(player.uniqueId))
 
@@ -25,6 +25,6 @@ object Fleets : IonServerComponent() {
     fun onPlayerLeave(event: PlayerQuitEvent) {
         val player = event.player
 
-        player.fleet()?.remove(player) ?: return
+        findByMember(player)?.remove(player) ?: return
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleets.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleets.kt
@@ -11,6 +11,8 @@ object Fleets : IonServerComponent() {
 
     fun findByMember(player: Player) = fleetList.find { it.get(player) }
 
+    fun findInvitesByMember(player: Player) = fleetList.filter { it.getInvite(player) }
+
     fun create(player: Player) = fleetList.add(Fleet(player.uniqueId))
 
     fun delete(fleet: Fleet) {
@@ -26,5 +28,8 @@ object Fleets : IonServerComponent() {
         val player = event.player
 
         findByMember(player)?.remove(player) ?: return
+        for (fleet in findInvitesByMember(player)) {
+            fleet.removeInvite(player)
+        }
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleets.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/fleet/Fleets.kt
@@ -1,0 +1,30 @@
+package net.horizonsend.ion.server.features.starship.fleet
+
+import net.horizonsend.ion.server.IonServerComponent
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.player.PlayerQuitEvent
+
+object Fleets : IonServerComponent() {
+
+    private val fleetList = mutableListOf<Fleet>()
+
+    fun Player.fleet() = fleetList.find { it.get(this) }
+
+    fun create(player: Player) = fleetList.add(Fleet(player.uniqueId))
+
+    fun delete(fleet: Fleet) {
+        if (fleetList.contains(fleet)) {
+            fleet.delete()
+            fleetList.remove(fleet)
+        }
+    }
+
+    @Suppress("unused")
+    @EventHandler
+    fun onPlayerLeave(event: PlayerQuitEvent) {
+        val player = event.player
+
+        player.fleet()?.remove(player) ?: return
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -73,6 +73,7 @@ import net.horizonsend.ion.server.features.sidebar.command.SidebarContactsComman
 import net.horizonsend.ion.server.features.sidebar.command.SidebarStarshipsCommand
 import net.horizonsend.ion.server.features.sidebar.command.SidebarWaypointsCommand
 import net.horizonsend.ion.server.features.space.generation.SpaceGenCommand
+import net.horizonsend.ion.server.features.starship.fleet.FleetCommand
 import net.horizonsend.ion.server.features.waypoint.command.WaypointCommand
 
 val commands: List<SLCommand> = listOf(
@@ -163,5 +164,6 @@ val commands: List<SLCommand> = listOf(
 	IonBroadcastCommand,
 	BlockCommand,
 	ShipFactoryCommand,
-	SettingsCommand
+	SettingsCommand,
+	FleetCommand
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
@@ -72,6 +72,7 @@ import net.horizonsend.ion.server.features.starship.control.signs.StarshipSignCo
 import net.horizonsend.ion.server.features.starship.control.weaponry.PlayerStarshipWeaponry
 import net.horizonsend.ion.server.features.starship.control.weaponry.StarshipWeaponry
 import net.horizonsend.ion.server.features.starship.factory.StarshipFactories
+import net.horizonsend.ion.server.features.starship.fleet.Fleets
 import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
 import net.horizonsend.ion.server.features.starship.hyperspace.HyperspaceBeacons
 import net.horizonsend.ion.server.features.starship.subsystem.shield.StarshipShields
@@ -204,4 +205,5 @@ val components: List<IonComponent> = listOf(
 	UnusedSoldShipPurge,
 	ClientDisplayEntities,
 	HudIcons,
+	Fleets,
 )


### PR DESCRIPTION
# Fleets
Enter a shared group (party) with your friends for control and coordination.

New commands:
`/fleet` (alias `/f`)
`/fleet create` - create a fleet
`/fleet disband` - disband a fleet (fleet commander only)
`/fleet list` - lists players in your fleet and the ship they are flying
`/fleet leave` - leave a fleet
`/fleet kick <player>` - kick a player from your fleet (fleet commander only)
`/fleet transfer <player>` - transfer fleet command of your current fleet to another player (fleet commander only)
`/fleet invite <player>` - invite a player to your fleet (fleet commander only)
`/fleet removeinvite <player>` - remove a player's invite to your fleet (fleet commander only)
`/fleet join <fleetCommander>` - join the specified fleet commander's fleet
`/fleet broadcast <message>` - broadcast a message to your fleet (fleet commander only). If a contact (in the sidebar/scoreboard) matches a name in the broadcast message, the contact will be raised to the top of the priority list and begin flashing.
`/fleet clearbroadcast` - clear a fleet broadcast message
`/fleet jump | /fleet jump <x> <z> | /fleet jump <destination>` - jump all fleet members (if available) to the specified location
`/fleetchat | /fc` - access fleet chat