### PR TITLE
increase rainbowweapons saturation and rename back to rainbowweapons instead of gaymode

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/RainbowProjectileCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/RainbowProjectileCommand.kt
@@ -8,12 +8,12 @@ import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
 object RainbowProjectileCommand : SLCommand() {
-	@CommandAlias("gaymode")
+	@CommandAlias("rainbowweapons")
 	@CommandPermission("ioncore.rainbow")
 	fun onExecute(sender: CommandSender, p: Player) = asyncCommand(sender) {
 		val ship = getStarshipPiloting(p)
 
 		ship.rainbowToggle = !ship.rainbowToggle
-		sender.success("${if (ship.rainbowToggle) "Dea" else "A"}activated gay mode")
+		sender.success("${if (ship.rainbowToggle) "Dea" else "A"}activated rainbow weapons")
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Miscellaneous.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Miscellaneous.kt
@@ -51,9 +51,9 @@ val gayColors = arrayOf(
 	Color.fromRGB(255, 0, 24),
 	Color.fromRGB(255, 165, 44),
 	Color.fromRGB(255, 255, 65),
-	Color.fromRGB(0, 128, 24),
+	Color.fromRGB(0, 255, 51),
 	Color.fromRGB(0, 0, 249),
-	Color.fromRGB(134, 0, 125)
+	Color.fromRGB(255, 0, 239)
 )
 
 /** Used for catching when a function that is not designed to be used async is being used async. */


### PR DESCRIPTION
Gaymode is really noticeable when people type /g and isn't very descriptive of what it does, leading people to ask questions. You can search in global and check, there is a pretty ridiculous proportion of people asking what it is when we could just have a normal descriptive command. 
Anyway more importantly I made the colors more saturated.