### PR TITLE
Combat Timers

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/cache/nations/PlayerCache.kt
@@ -74,6 +74,8 @@ abstract class AbstractPlayerCache : ManualCache() {
 		var advancedStarshipInfo: Boolean = false,
 		var rotateCompass: Boolean = false,
 
+		var combatTimerEnabled: Boolean = true,
+
 		var hudPlanetsImage: Boolean = true,
 		var hudPlanetsSelector: Boolean = true,
 		var hudIconStars: Boolean = true,
@@ -88,6 +90,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 		var dcSpeedModifier: Int = 1,
 		var enableAdditionalSounds: Boolean = true,
 		var soundCruiseIndicator: Int = 0,
+		var enableCombatTimerAlerts: Boolean = true,
 
 		var blockedPlayerIDs: Set<SLPlayerId> = setOf(),
 	)
@@ -464,6 +467,15 @@ abstract class AbstractPlayerCache : ManualCache() {
 				}
 			}
 
+			change[SLPlayer::combatTimerEnabled]?.let {
+				synced {
+					val data = PLAYER_DATA[id.uuid] ?: return@synced
+
+					val combatTimerEnabled = it.boolean()
+					data.combatTimerEnabled = combatTimerEnabled
+				}
+			}
+
 			change[SLPlayer::hudPlanetsImage]?.let {
 				synced {
 					val data = PLAYER_DATA[id.uuid] ?: return@synced
@@ -585,6 +597,15 @@ abstract class AbstractPlayerCache : ManualCache() {
 					data.soundCruiseIndicator = soundCruiseIndicator
 				}
 			}
+
+			change[SLPlayer::enableCombatTimerAlerts]?.let {
+				synced {
+					val data = PLAYER_DATA[id.uuid] ?: return@synced
+
+					val enableCombatTimerAlerts = it.boolean()
+					data.enableCombatTimerAlerts = enableCombatTimerAlerts
+				}
+			}
 		}
 
 		val mutex = Any()
@@ -673,6 +694,7 @@ abstract class AbstractPlayerCache : ManualCache() {
 			starshipsEnabled = data.starshipsEnabled,
 			advancedStarshipInfo = data.advancedStarshipInfo,
 			rotateCompass = data.rotateCompass,
+			combatTimerEnabled = data.combatTimerEnabled,
 			hudPlanetsImage = data.hudPlanetsImage,
 			hudPlanetsSelector = data.hudPlanetsSelector,
 			hudIconStars = data.hudIconStars,
@@ -684,7 +706,8 @@ abstract class AbstractPlayerCache : ManualCache() {
 			useAlternateDCCruise = data.useAlternateDCCruise,
 			dcSpeedModifier = data.dcSpeedModifier,
 			enableAdditionalSounds = data.enableAdditionalSounds,
-			soundCruiseIndicator = data.soundCruiseIndicator
+			soundCruiseIndicator = data.soundCruiseIndicator,
+			enableCombatTimerAlerts = data.enableCombatTimerAlerts,
 		)
 	}
 

--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/SLPlayer.kt
@@ -97,6 +97,7 @@ data class SLPlayer(
 	var starshipsEnabled: Boolean = true,
 	var advancedStarshipInfo: Boolean = false,
 	var rotateCompass: Boolean = false,
+	var combatTimerEnabled: Boolean = true,
 
 	var hudPlanetsImage: Boolean = true,
 	var hudPlanetsSelector: Boolean = true,
@@ -111,6 +112,7 @@ data class SLPlayer(
 	var dcSpeedModifier: Int = 1,
 	var enableAdditionalSounds: Boolean = true,
 	var soundCruiseIndicator: Int = 0,
+	var enableCombatTimerAlerts: Boolean = true,
 
 	var blockedPlayerIDs: Set<SLPlayerId> = setOf(),
 	var wasKilledOn: Set<String> = setOf(),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/admin/CombatTagCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/admin/CombatTagCommand.kt
@@ -1,0 +1,63 @@
+package net.horizonsend.ion.server.command.admin
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandCompletion
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Description
+import co.aikar.commands.annotation.Subcommand
+import net.horizonsend.ion.common.extensions.success
+import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.player.CombatTimer
+import org.bukkit.entity.Player
+
+@CommandAlias("combattag")
+object CombatTagCommand : SLCommand() {
+
+    @Subcommand("npc give")
+    @Suppress("unused")
+    @CommandPermission("ion.combattag")
+    @CommandCompletion("@players")
+    @Description("Apply an NPC combat tag to a player")
+    fun onGiveNpcCombatTag(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        CombatTimer.addNpcCombatTag(player)
+        sender.success("Gave $target an NPC combat tag")
+    }
+
+    @Subcommand("npc remove")
+    @Suppress("unused")
+    @CommandPermission("ion.combattag")
+    @CommandCompletion("@players")
+    @Description("Remove an NPC combat tag from a player")
+    fun onRemoveNpcCombatTag(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        CombatTimer.removeNpcCombatTag(player)
+        sender.success("Removed NPC combat tag from $target")
+    }
+
+    @Subcommand("pvp give")
+    @Suppress("unused")
+    @CommandPermission("ion.combattag")
+    @CommandCompletion("@players")
+    @Description("Apply a PvP combat tag to a player")
+    fun onGivePvpCombatTag(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        CombatTimer.addPvpCombatTag(player)
+        sender.success("Gave $target a PvP combat tag")
+    }
+
+    @Subcommand("pvp remove")
+    @Suppress("unused")
+    @CommandPermission("ion.combattag")
+    @CommandCompletion("@players")
+    @Description("Remove a PvP combat tag from a player")
+    fun onRemovePvpCombatTag(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        CombatTimer.removePvpCombatTag(player)
+        sender.success("Removed PvP combat tag from $target")
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/admin/CombatTimerCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/admin/CombatTimerCommand.kt
@@ -4,18 +4,39 @@ import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.CommandCompletion
 import co.aikar.commands.annotation.CommandPermission
 import co.aikar.commands.annotation.Description
+import co.aikar.commands.annotation.Optional
 import co.aikar.commands.annotation.Subcommand
+import net.horizonsend.ion.common.database.schema.misc.SLPlayer
 import net.horizonsend.ion.common.extensions.success
 import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.player.CombatTimer
+import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import org.bukkit.entity.Player
+import org.litote.kmongo.setValue
 
-@CommandAlias("combattag")
-object CombatTagCommand : SLCommand() {
+@CommandAlias("combattimer")
+object CombatTimerCommand : SLCommand() {
+
+    @Subcommand("toggle")
+    @Suppress("unused")
+    @CommandCompletion("true|false")
+    @Description("Toggle combat timer alerts")
+    fun onToggle(sender: Player, @Optional toggle: Boolean?) {
+        val enableCombatTimerAlerts = toggle ?: !PlayerCache[sender].enableCombatTimerAlerts
+        SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::enableCombatTimerAlerts, enableCombatTimerAlerts))
+        PlayerCache[sender.uniqueId].enableCombatTimerAlerts = enableCombatTimerAlerts
+        sender.success("Changed enabled combat timer alerts to $enableCombatTimerAlerts")
+        if (enableCombatTimerAlerts) {
+            sender.success("You will be notified when you gain a combat timer")
+        } else {
+            sender.success("You will no longer be notified when you gain a combat timer")
+        }
+    }
 
     @Subcommand("npc give")
     @Suppress("unused")
-    @CommandPermission("ion.combattag")
+    @CommandPermission("ion.combattimer")
     @CommandCompletion("@players")
     @Description("Apply an NPC combat tag to a player")
     fun onGiveNpcCombatTag(sender: Player, target: String) {
@@ -27,7 +48,7 @@ object CombatTagCommand : SLCommand() {
 
     @Subcommand("npc remove")
     @Suppress("unused")
-    @CommandPermission("ion.combattag")
+    @CommandPermission("ion.combattimer")
     @CommandCompletion("@players")
     @Description("Remove an NPC combat tag from a player")
     fun onRemoveNpcCombatTag(sender: Player, target: String) {
@@ -39,7 +60,7 @@ object CombatTagCommand : SLCommand() {
 
     @Subcommand("pvp give")
     @Suppress("unused")
-    @CommandPermission("ion.combattag")
+    @CommandPermission("ion.combattimer")
     @CommandCompletion("@players")
     @Description("Apply a PvP combat tag to a player")
     fun onGivePvpCombatTag(sender: Player, target: String) {
@@ -51,7 +72,7 @@ object CombatTagCommand : SLCommand() {
 
     @Subcommand("pvp remove")
     @Suppress("unused")
-    @CommandPermission("ion.combattag")
+    @CommandPermission("ion.combattimer")
     @CommandCompletion("@players")
     @Description("Remove a PvP combat tag from a player")
     fun onRemovePvpCombatTag(sender: Player, target: String) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/CombatTimerCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/CombatTimerCommand.kt
@@ -1,4 +1,4 @@
-package net.horizonsend.ion.server.command.admin
+package net.horizonsend.ion.server.command.misc
 
 import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.CommandCompletion

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/SuicideCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/SuicideCommand.kt
@@ -1,0 +1,34 @@
+package net.horizonsend.ion.server.command.misc
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.Default
+import net.horizonsend.ion.common.extensions.information
+import net.horizonsend.ion.common.extensions.userError
+import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.player.CombatTimer
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.EntityDamageEvent
+
+@CommandAlias("suicide|unalive")
+object SuicideCommand : SLCommand() {
+    @Default
+    @Suppress("unused")
+    fun onSuicide(sender: Player) {
+        // Prevent combat timer players from wimping out
+        if (CombatTimer.isNpcCombatTagged(sender) || CombatTimer.isPvpCombatTagged(sender)) {
+            sender.userError("Your iron will prevents you from giving up so soon. Fight with honor!")
+            return
+        }
+
+        // Force kill if this event is cancelled
+        EntityDamageEvent(sender, EntityDamageEvent.DamageCause.SUICIDE, Double.MAX_VALUE).callEvent()
+        sender.health = 0.0
+
+        // Notify everyone of this player's untimely demise
+        sender.information("Goodbye cruel world...")
+        for (otherPlayer in Bukkit.getOnlinePlayers()) {
+            otherPlayer.information("Player ${sender.name} took their own life")
+        }
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/NationCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/NationCommand.kt
@@ -36,6 +36,7 @@ import net.horizonsend.ion.server.features.nations.region.types.RegionTerritory
 import net.horizonsend.ion.server.features.nations.utils.isActive
 import net.horizonsend.ion.server.features.nations.utils.isInactive
 import net.horizonsend.ion.server.features.nations.utils.isSemiActive
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.achievements.Achievement
 import net.horizonsend.ion.server.features.progression.achievements.rewardAchievement
 import net.horizonsend.ion.server.miscellaneous.utils.*
@@ -389,6 +390,8 @@ internal object NationCommand : SLCommand() {
 	fun onClaim(sender: Player, @Optional cost: Int?) = asyncCommand(sender) {
 		val nationId = requireNationIn(sender)
 		requireNationPermission(sender, nationId, NationRole.Permission.CLAIM_CREATE)
+
+		failIf(CombatTimer.isNpcCombatTagged(sender) || CombatTimer.isPvpCombatTagged(sender)) { "You are currently in combat!" }
 
 		val territory = requireTerritoryIn(sender)
 		requireTerritoryUnclaimed(territory)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SettlementCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SettlementCommand.kt
@@ -34,6 +34,7 @@ import net.horizonsend.ion.server.features.nations.region.types.RegionTerritory
 import net.horizonsend.ion.server.features.nations.utils.isActive
 import net.horizonsend.ion.server.features.nations.utils.isInactive
 import net.horizonsend.ion.server.features.nations.utils.isSemiActive
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.achievements.Achievement
 import net.horizonsend.ion.server.features.progression.achievements.rewardAchievement
 import net.horizonsend.ion.server.miscellaneous.utils.*
@@ -95,6 +96,7 @@ internal object SettlementCommand : SLCommand() {
 		requireNotInSettlement(sender)
 
 // 		requireMinLevel(sender, NATIONS_BALANCE.settlement.minCreateLevel)
+		failIf(CombatTimer.isNpcCombatTagged(sender) || CombatTimer.isPvpCombatTagged(sender)) { "You are currently in combat!" }
 
 		validateName(name, null)
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SpaceStationCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SpaceStationCommand.kt
@@ -34,6 +34,7 @@ import net.horizonsend.ion.server.features.cache.trade.EcoStations
 import net.horizonsend.ion.server.features.nations.NATIONS_BALANCE
 import net.horizonsend.ion.server.features.nations.region.Regions
 import net.horizonsend.ion.server.features.nations.region.types.RegionCapturableStation
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.space.CachedPlanet
 import net.horizonsend.ion.server.features.space.CachedStar
 import net.horizonsend.ion.server.features.space.Space
@@ -55,7 +56,6 @@ import org.bukkit.entity.Player
 import org.litote.kmongo.Id
 import org.litote.kmongo.deleteOneById
 import org.litote.kmongo.setValue
-import java.util.*
 
 @CommandAlias("spacestation|nspacestation|nstation|sstation|station|nationspacestation")
 object SpaceStationCommand : net.horizonsend.ion.server.command.SLCommand() {
@@ -239,6 +239,8 @@ object SpaceStationCommand : net.horizonsend.ion.server.command.SLCommand() {
 		}
 
 		failIf(!sender.world.ion.hasFlag(WorldFlag.ALLOW_SPACE_STATIONS)) { "You can't create space stations in this world!" }
+
+		failIf(CombatTimer.isNpcCombatTagged(sender) || CombatTimer.isPvpCombatTagged(sender)) { "You are currently in combat!" }
 
 		validateName(name)
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/FeatureFlags.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/FeatureFlags.kt
@@ -7,5 +7,6 @@ data class FeatureFlags(
 	val economy: Boolean = true,
 	val bounties: Boolean = true,
 	val tutorials: Boolean = false,
-	val combatNPCs: Boolean = true
+	val combatNPCs: Boolean = true,
+	val combatTimers: Boolean = true,
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsOtherGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsOtherGui.kt
@@ -1,5 +1,6 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
+import net.horizonsend.ion.server.command.admin.CombatTimerCommand
 import net.horizonsend.ion.server.command.misc.EnableProtectionMessagesCommand
 import net.horizonsend.ion.server.command.qol.SearchCommand
 import net.horizonsend.ion.server.features.cache.PlayerCache
@@ -37,6 +38,7 @@ class SettingsOtherGui(val player: Player) : AbstractBackgroundPagedGui {
 
     private val buttonsList = listOf(
         ShowItemSearchItems(),
+        EnableCombatTimerAlert(),
         EnableProtectionMessages(),
     )
 
@@ -72,6 +74,7 @@ class SettingsOtherGui(val player: Player) : AbstractBackgroundPagedGui {
 
         val enabledSettings = listOf(
             PlayerCache[player.uniqueId].showItemSearchItem,
+            PlayerCache[player.uniqueId].enableCombatTimerAlerts,
             PlayerCache[player.uniqueId].protectionMessagesEnabled
         )
 
@@ -127,6 +130,18 @@ class SettingsOtherGui(val player: Player) : AbstractBackgroundPagedGui {
         override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
             val itemSearch = PlayerCache[player.uniqueId].showItemSearchItem
             SearchCommand.itemSearchToggle(player, !itemSearch)
+
+            currentWindow?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
+        }
+    }
+
+    private inner class EnableCombatTimerAlert : GuiItems.AbstractButtonItem(
+        text("Enable Combat Timer Alerts").decoration(TextDecoration.ITALIC, false),
+        ItemStack(Material.WARPED_FUNGUS_ON_A_STICK).updateMeta { it.setCustomModelData(GuiItem.LIST.customModelData) }
+    ) {
+        override fun handleClick(clickType: ClickType, player: Player, event: InventoryClickEvent) {
+            val enableCombatTimerAlerts = PlayerCache[player.uniqueId].enableCombatTimerAlerts
+            CombatTimerCommand.onToggle(player, !enableCombatTimerAlerts)
 
             currentWindow?.changeTitle(AdventureComponentWrapper(createText(player, gui.currentPage)))
         }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsOtherGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsOtherGui.kt
@@ -1,6 +1,6 @@
 package net.horizonsend.ion.server.features.gui.custom.settings
 
-import net.horizonsend.ion.server.command.admin.CombatTimerCommand
+import net.horizonsend.ion.server.command.misc.CombatTimerCommand
 import net.horizonsend.ion.server.command.misc.EnableProtectionMessagesCommand
 import net.horizonsend.ion.server.command.qol.SearchCommand
 import net.horizonsend.ion.server.features.cache.PlayerCache

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/npcs/NPCManager.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/npcs/NPCManager.kt
@@ -7,6 +7,7 @@ import net.horizonsend.ion.server.miscellaneous.utils.loadChunkAsync
 import org.bukkit.Location
 import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
+import org.bukkit.entity.Player
 import org.slf4j.Logger
 import java.util.UUID
 
@@ -49,6 +50,10 @@ class NPCManager(private val logger: Logger, val name: String) {
 			npc.spawn(location)
 			callback(npc)
 		}
+	}
+
+	fun getNPC(player: Player): NPC? {
+		return npcRegistry.getNPC(player)
 	}
 
 	fun allNPCs(): List<NPC> {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/npcs/traits/CombatNPCTrait.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/npcs/traits/CombatNPCTrait.kt
@@ -8,7 +8,6 @@ import net.citizensnpcs.api.trait.Trait
 import net.citizensnpcs.api.trait.TraitName
 import net.citizensnpcs.api.util.DataKey
 import net.horizonsend.ion.server.IonServer
-import net.horizonsend.ion.server.features.player.CombatNPCs.EXPIRED_NPC_CUTOFF
 import org.bukkit.Bukkit
 import org.bukkit.inventory.ItemStack
 import java.util.UUID
@@ -24,6 +23,12 @@ class CombatNPCTrait : Trait("ioncombatnpc") {
 	@DelegatePersistence(InventoryPersister::class)
 	lateinit var inventoryContents: Array<ItemStack?>
 
+	@Persist
+	var despawnTime: Long = 0
+
+	@Persist
+	var wasInCombat: Boolean = false
+
 	override fun run() {
 		if (!::owner.isInitialized) return
 
@@ -31,7 +36,7 @@ class CombatNPCTrait : Trait("ioncombatnpc") {
 		if (isExpired()) return destroy()
 	}
 
-	fun isExpired() = EXPIRED_NPC_CUTOFF > System.currentTimeMillis()
+	fun isExpired() = System.currentTimeMillis() > despawnTime
 
 	private fun destroy() {
 		if (npc.isSpawned) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatNPCs.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatNPCs.kt
@@ -94,6 +94,10 @@ object CombatNPCs : IonServerComponent(true) {
 				npc.getOrAddTrait(CombatNPCTrait::class.java).apply {
 					owner = event.player.uniqueId
 					inventoryContents = inventoryCopy
+					despawnTime = if (CombatTimer.isPvpCombatTagged(event.player))
+						CombatTimer.pvpTimerRemainingMillis(event.player).coerceAtLeast(TimeUnit.MINUTES.toMillis(4L)) + System.currentTimeMillis()
+					else TimeUnit.MINUTES.toMillis(4L) + System.currentTimeMillis()
+					wasInCombat = CombatTimer.isPvpCombatTagged(event.player)
 				}
 			}
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
@@ -1,0 +1,144 @@
+package net.horizonsend.ion.server.features.player
+
+import net.horizonsend.ion.common.database.cache.nations.RelationCache
+import net.horizonsend.ion.common.database.schema.nations.NationRelation
+import net.horizonsend.ion.server.IonServer
+import net.horizonsend.ion.server.IonServerComponent
+import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.features.nations.utils.toPlayersInRadius
+import net.horizonsend.ion.server.features.starship.PilotedStarships
+import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.horizonsend.ion.server.miscellaneous.utils.listen
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.PlayerDeathEvent
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+object CombatTimer : IonServerComponent() {
+
+	private const val PVP_TIMER_MINS = 10L
+	private const val NPC_TIMER_MINS = 5L
+	private const val SVP_ENTER_COMBAT_DIST = 500.0
+	private const val MAINTAIN_COMBAT_DIST = 1000.0
+
+	var enabled = false
+
+	private val npcTimer = mutableMapOf<UUID, Long>()
+	private val pvpTimer = mutableMapOf<UUID, Long>()
+
+	override fun onEnable() {
+		enabled = IonServer.configuration.serverName == "Survival"
+
+		if (!enabled) return
+
+		Tasks.syncRepeat(0L, 20L) {
+
+			// Remove combat tags if enough time has elapsed
+			for (entry in npcTimer) {
+				if (entry.value >= System.currentTimeMillis()) {
+					npcTimer.remove(entry.key)
+				}
+			}
+
+			for (entry in pvpTimer) {
+				if (entry.value >= System.currentTimeMillis()) {
+					pvpTimer.remove(entry.key)
+				}
+			}
+
+			Bukkit.getOnlinePlayers().forEach { player ->
+				val pilotedStarship = PilotedStarships[player]
+
+				if (pilotedStarship != null) {
+					// Piloted ships with active gravity wells will place combat tags on all passengers
+					if (pilotedStarship.isInterdicting) {
+						for (passenger in pilotedStarship.onlinePassengers) {
+							refreshPvpTimer(passenger)
+						}
+					}
+
+					val starshipCom  = pilotedStarship.centerOfMass.toLocation(player.world)
+
+					// Piloted ships will place combat tags on other players that are not piloting ships within 500 blocks if the pilot is unfriendly to them
+					toPlayersInRadius(starshipCom, SVP_ENTER_COMBAT_DIST) { otherPlayer ->
+						if (PilotedStarships[otherPlayer] == null) {
+							for (passenger in pilotedStarship.onlinePassengers) {
+								evaluatePvp(passenger, otherPlayer, neutralAndNoneTriggersCombat = false)
+							}
+						}
+					}
+
+					// Piloted ships will maintain combat tag on all players, within 1000 blocks if the pilot is unfriendly to them
+					toPlayersInRadius(starshipCom, MAINTAIN_COMBAT_DIST) { otherPlayer ->
+						for (passenger in pilotedStarship.onlinePassengers) {
+							evaluatePvp(passenger, otherPlayer, neutralAndNoneTriggersCombat = false)
+						}
+					}
+				}
+			}
+		}
+
+		// Remove all combat tags on death
+		listen<PlayerDeathEvent> { event ->
+			npcTimer.remove(event.player.uniqueId)
+			pvpTimer.remove(event.player.uniqueId)
+		}
+
+		// Apply combat tags in PvP
+		listen<EntityDamageByEntityEvent> { event ->
+			if (event.damager !is Player || event.entity !is Player) return@listen
+
+			evaluatePvp(event.damager as Player, event.entity as Player)
+		}
+	}
+
+	fun refreshNpcTimer(player: Player) {
+		if (!enabled) return
+		npcTimer[player.uniqueId] = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(NPC_TIMER_MINS)
+	}
+
+	fun refreshPvpTimer(player: Player) {
+		if (!enabled) return
+		pvpTimer[player.uniqueId] = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(PVP_TIMER_MINS)
+	}
+
+	fun evaluatePvp(attacker: Player, defender: Player, neutralAndNoneTriggersCombat: Boolean = true) {
+		if (!enabled) return
+
+		val attackerData = PlayerCache[attacker]
+		val attackerNation = attackerData.nationOid
+
+		val defenderData = PlayerCache[defender]
+		val defenderNation = defenderData.nationOid
+
+		if (attackerNation == defenderNation) return
+
+		if (neutralAndNoneTriggersCombat) {
+			if (attackerNation != null && defenderNation != null &&
+				RelationCache[attackerNation, defenderNation] >= NationRelation.Level.FRIENDLY) {
+				// Prevent combat tag if both players are in nations and the nations are friendly or better
+				return
+			}
+		} else {
+			if (attackerNation == null || defenderNation == null ||
+				RelationCache[attackerNation, defenderNation] > NationRelation.Level.UNFRIENDLY) {
+				// Prevent combat tag if either player is not in a nation, or the nations have better relations than unfriendly
+				return
+			}
+		}
+
+		// Fell through relation checks; refresh PvP timer
+		refreshPvpTimer(attacker)
+		refreshPvpTimer(defender)
+	}
+
+	fun isNpcCombatTagged(player: Player): Boolean {
+		return npcTimer[player.uniqueId] != null
+	}
+
+	fun isPvpCombatTagged(player: Player): Boolean {
+		return pvpTimer[player.uniqueId] != null
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
@@ -2,34 +2,58 @@ package net.horizonsend.ion.server.features.player
 
 import net.horizonsend.ion.common.database.cache.nations.RelationCache
 import net.horizonsend.ion.common.database.schema.nations.NationRelation
+import net.horizonsend.ion.common.extensions.success
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_BLUE
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_MEDIUM_GRAY
+import net.horizonsend.ion.common.utils.text.lineBreak
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.common.utils.text.repeatString
 import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.IonServerComponent
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.nations.utils.toPlayersInRadius
+import net.horizonsend.ion.server.features.player.NewPlayerProtection.hasProtection
 import net.horizonsend.ion.server.features.starship.PilotedStarships
+import net.horizonsend.ion.server.features.starship.active.ActiveStarship
+import net.horizonsend.ion.server.features.starship.control.controllers.ai.AIController
+import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
+import net.horizonsend.ion.server.features.starship.control.controllers.player.UnpilotedController
+import net.horizonsend.ion.server.features.starship.damager.AIShipDamager
+import net.horizonsend.ion.server.features.starship.damager.Damager
+import net.horizonsend.ion.server.features.starship.damager.PlayerDamager
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import net.horizonsend.ion.server.miscellaneous.utils.listen
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.newline
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor.DARK_RED
+import net.kyori.adventure.text.format.NamedTextColor.GOLD
+import net.kyori.adventure.text.format.TextDecoration.BOLD
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
-import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.PlayerDeathEvent
+import java.time.Duration
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 object CombatTimer : IonServerComponent() {
 
-	private const val PVP_TIMER_MINS = 10L
-	private const val NPC_TIMER_MINS = 5L
+	private val PVP_TIMER_MINS = Duration.ofMinutes(10)
+	private val NPC_TIMER_MINS = Duration.ofMinutes(2).plusSeconds(30)
 	private const val SVP_ENTER_COMBAT_DIST = 500.0
 	private const val MAINTAIN_COMBAT_DIST = 1000.0
+	private const val REASON_NPC_SVS_COMBAT = "Engaging in combat with an NPC starship"
+	private const val REASON_PVP_SVS_COMBAT = "Engaging in combat with another player's starship"
+	private const val REASON_PVP_WITHIN_GRAVITY_WELL = "Getting caught in non-friendly starship's gravity well"
+	const val REASON_PVP_GROUND_COMBAT = "Engaging in combat with another player on the ground"
+	private const val REASON_ENEMY_PROXIMITY = "Being in close proximity to a hostile starship"
 
-	var enabled = false
+	private var enabled = false
 
 	private val npcTimer = mutableMapOf<UUID, Long>()
 	private val pvpTimer = mutableMapOf<UUID, Long>()
 
 	override fun onEnable() {
-		enabled = IonServer.configuration.serverName == "Survival"
+		enabled = IonServer.featureFlags.combatTimers
 
 		if (!enabled) return
 
@@ -37,43 +61,64 @@ object CombatTimer : IonServerComponent() {
 
 			// Remove combat tags if enough time has elapsed
 			for (entry in npcTimer) {
-				if (entry.value >= System.currentTimeMillis()) {
+				if (entry.value <= System.currentTimeMillis()) {
 					npcTimer.remove(entry.key)
+					Bukkit.getPlayer(entry.key)?.success("You are no longer in combat (NPC)")
 				}
 			}
 
 			for (entry in pvpTimer) {
-				if (entry.value >= System.currentTimeMillis()) {
+				if (entry.value <= System.currentTimeMillis()) {
 					pvpTimer.remove(entry.key)
+					Bukkit.getPlayer(entry.key)?.success("You are no longer in combat (PvP)")
 				}
 			}
 
 			Bukkit.getOnlinePlayers().forEach { player ->
 				val pilotedStarship = PilotedStarships[player]
 
-				if (pilotedStarship != null) {
-					// Piloted ships with active gravity wells will place combat tags on all passengers
-					if (pilotedStarship.isInterdicting) {
-						for (passenger in pilotedStarship.onlinePassengers) {
-							refreshPvpTimer(passenger)
-						}
-					}
-
+				// Only actively controlled warships can cause proximity triggered combat tags
+				if (pilotedStarship != null && pilotedStarship.controller !is UnpilotedController &&
+					pilotedStarship.type.isWarship) {
 					val starshipCom  = pilotedStarship.centerOfMass.toLocation(player.world)
 
-					// Piloted ships will place combat tags on other players that are not piloting ships within 500 blocks if the pilot is unfriendly to them
-					toPlayersInRadius(starshipCom, SVP_ENTER_COMBAT_DIST) { otherPlayer ->
-						if (PilotedStarships[otherPlayer] == null) {
-							for (passenger in pilotedStarship.onlinePassengers) {
-								evaluatePvp(passenger, otherPlayer, neutralAndNoneTriggersCombat = false)
+					if (pilotedStarship.isInterdicting) {
+						// Interdicting ships will place combat tags on other player starships that are within the well range and are less than neutral
+						toPlayersInRadius(starshipCom, pilotedStarship.interdictionRange.toDouble()) { otherPlayer ->
+							if (PilotedStarships[otherPlayer] != null) {
+								evaluatePvp(
+									player,
+									otherPlayer,
+									REASON_PVP_WITHIN_GRAVITY_WELL,
+									neutralTriggersCombat = false
+								)
 							}
 						}
 					}
 
-					// Piloted ships will maintain combat tag on all players, within 1000 blocks if the pilot is unfriendly to them
+					// Piloted ships will place combat tags on other players that are not piloting ships within 500 blocks if the pilot is unfriendly to them
+					toPlayersInRadius(starshipCom, SVP_ENTER_COMBAT_DIST) { otherPlayer ->
+						if (PilotedStarships[otherPlayer] == null) {
+							evaluatePvp(
+								player,
+								otherPlayer,
+								REASON_ENEMY_PROXIMITY,
+								neutralTriggersCombat = false,
+								tagAttacker = false
+							)
+						}
+					}
+
+					// Piloted ships will maintain combat tag on all players, within 1000 blocks if the pilot is unfriendly to them and the other player was already tagged
 					toPlayersInRadius(starshipCom, MAINTAIN_COMBAT_DIST) { otherPlayer ->
-						for (passenger in pilotedStarship.onlinePassengers) {
-							evaluatePvp(passenger, otherPlayer, neutralAndNoneTriggersCombat = false)
+						if (isPvpCombatTagged(otherPlayer)) {
+							evaluatePvp(
+								player,
+								otherPlayer,
+								REASON_ENEMY_PROXIMITY,
+								neutralTriggersCombat = false,
+								tagAttacker = false
+							)
 						}
 					}
 				}
@@ -82,30 +127,56 @@ object CombatTimer : IonServerComponent() {
 
 		// Remove all combat tags on death
 		listen<PlayerDeathEvent> { event ->
-			npcTimer.remove(event.player.uniqueId)
-			pvpTimer.remove(event.player.uniqueId)
+			if (npcTimer[event.player.uniqueId] != null) {
+				event.player.success("You are no longer in combat (NPC)")
+				npcTimer.remove(event.player.uniqueId)
+			}
+			if (pvpTimer[event.player.uniqueId] != null) {
+				event.player.success("You are no longer in combat (PVP)")
+				pvpTimer.remove(event.player.uniqueId)
+			}
+		}
+	}
+
+
+	/**
+	 * Applies or refreshes an NPC combat tag to a player.
+	 */
+	fun refreshNpcTimer(player: Player, reason: String) {
+		if (!enabled) return
+
+		if (!isNpcCombatTagged(player)) {
+			player.sendMessage(npcTimerAlertComponent(reason))
 		}
 
-		// Apply combat tags in PvP
-		listen<EntityDamageByEntityEvent> { event ->
-			if (event.damager !is Player || event.entity !is Player) return@listen
+		npcTimer[player.uniqueId] = System.currentTimeMillis() + NPC_TIMER_MINS.toMillis()
+	}
 
-			evaluatePvp(event.damager as Player, event.entity as Player)
+	/**
+	 * Applies or refreshes a PvP combat tag to a player.
+	 */
+	fun refreshPvpTimer(player: Player, reason: String) {
+		if (!enabled) return
+
+		if (!isPvpCombatTagged(player)) {
+			player.sendMessage(pvpTimerAlertComponent(reason))
 		}
+
+		pvpTimer[player.uniqueId] = System.currentTimeMillis() + PVP_TIMER_MINS.toMillis()
 	}
 
-	fun refreshNpcTimer(player: Player) {
+	/**
+	 * Checks if PvP combat tags should be applied to two players in an interaction
+	 * @param neutralTriggersCombat if combat tags should be applied if the player relations are NEUTRAL or lower
+	 * (default is NONE or lower)
+	 * @param tagAttacker if combat tags should not be applied to the attacker
+	 */
+	fun evaluatePvp(attacker: Player, defender: Player, reason: String, neutralTriggersCombat: Boolean = true, tagAttacker: Boolean = true) {
 		if (!enabled) return
-		npcTimer[player.uniqueId] = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(NPC_TIMER_MINS)
-	}
+		if (attacker == defender) return
 
-	fun refreshPvpTimer(player: Player) {
-		if (!enabled) return
-		pvpTimer[player.uniqueId] = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(PVP_TIMER_MINS)
-	}
-
-	fun evaluatePvp(attacker: Player, defender: Player, neutralAndNoneTriggersCombat: Boolean = true) {
-		if (!enabled) return
+		// don't run for combat NPCs
+		if (defender.hasMetadata("NPC")) return
 
 		val attackerData = PlayerCache[attacker]
 		val attackerNation = attackerData.nationOid
@@ -115,33 +186,93 @@ object CombatTimer : IonServerComponent() {
 
 		if (attackerNation == defenderNation) return
 
-		if (neutralAndNoneTriggersCombat) {
+		if (neutralTriggersCombat) {
 			if (attackerNation != null && defenderNation != null &&
 				RelationCache[attackerNation, defenderNation] >= NationRelation.Level.FRIENDLY) {
 				// Prevent combat tag if both players are in nations and the nations are friendly or better
+				// Primarily for direct attack trigger
 				return
 			}
 		} else {
-			if (attackerNation == null || defenderNation == null ||
-				RelationCache[attackerNation, defenderNation] > NationRelation.Level.UNFRIENDLY) {
-				// Prevent combat tag if either player is not in a nation, or the nations have better relations than unfriendly
+			if ((attackerNation != null && defenderNation != null &&
+				RelationCache[attackerNation, defenderNation] >= NationRelation.Level.NEUTRAL) ||
+				defender.hasProtection()) {
+				// Prevent combat tag if relation is NEUTRAL or better, OR the defender has noob protection
+				// Primarily for proximity trigger
 				return
 			}
 		}
 
 		// Fell through relation checks; refresh PvP timer
-		refreshPvpTimer(attacker)
-		refreshPvpTimer(defender)
+		if (tagAttacker) refreshPvpTimer(attacker, reason)
+		refreshPvpTimer(defender, reason)
 	}
 
+	/**
+	 * Checks if PvP combat tags should be applied to two starships in an interaction
+	 */
+	fun evaluateSvs(shooter: Damager, defendingStarship: ActiveStarship) {
+		if (!enabled) return
+
+		if (shooter is AIShipDamager && defendingStarship.controller is PlayerController) {
+			// refresh NPC combat timer if attacker is AI and defender is player
+			refreshNpcTimer((defendingStarship.controller as PlayerController).player, REASON_NPC_SVS_COMBAT)
+		} else if (shooter is PlayerDamager) {
+			if (defendingStarship.controller is PlayerController) {
+				// evaluate PVP timer if both attacker and defender are players
+				evaluatePvp(shooter.player, (defendingStarship.controller as PlayerController).player, REASON_PVP_SVS_COMBAT)
+			} else if (defendingStarship.controller is AIController) {
+				// refresh NPC combat timer if attacker is player and defender is AI
+				refreshNpcTimer(shooter.player, REASON_NPC_SVS_COMBAT)
+			}
+		}
+	}
+
+	/**
+	 * Checks if the player is NPC combat tagged
+	 */
 	fun isNpcCombatTagged(player: Player): Boolean {
 		return npcTimer[player.uniqueId] != null
 	}
 
+	/**
+	 * Checks if the player is PvP combat tagged
+	 */
 	fun isPvpCombatTagged(player: Player): Boolean {
 		return pvpTimer[player.uniqueId] != null
 	}
 
+	/**
+	 * Adds or refreshes an NPC combat tag to a player UUID
+	 */
+	fun addNpcCombatTag(uuid: UUID) {
+		npcTimer[uuid] = System.currentTimeMillis() + NPC_TIMER_MINS.toMillis()
+	}
+
+	/**
+	 * Adds or refreshes a PvP combat tag to a player UUID
+	 */
+	fun addPvpCombatTag(uuid: UUID) {
+		pvpTimer[uuid] = System.currentTimeMillis() + PVP_TIMER_MINS.toMillis()
+	}
+
+	/**
+	 * Removes an NPC combat tag from a player UUID
+	 */
+	fun removeNpcCombatTag(uuid: UUID) {
+		npcTimer.remove(uuid)
+	}
+
+	/**
+	 * Removes a PvP combat tag from a player UUID
+	 */
+	fun removePvpCombatTag(uuid: UUID) {
+		pvpTimer.remove(uuid)
+	}
+
+	/**
+	 * Returns the amount of time remaining on a player's NPC combat tag in milliseconds
+	 */
 	fun npcTimerRemainingMillis(player: Player): Long {
 		val endTime = npcTimer[player.uniqueId]
 		return if (endTime == null) {
@@ -151,6 +282,9 @@ object CombatTimer : IonServerComponent() {
 		}
 	}
 
+	/**
+	 * Returns the amount of time remaining on a player's PvP combat tag in milliseconds
+	 */
 	fun pvpTimerRemainingMillis(player: Player): Long {
 		val endTime = pvpTimer[player.uniqueId]
 		return if (endTime == null) {
@@ -158,5 +292,71 @@ object CombatTimer : IonServerComponent() {
 		} else {
 			(endTime - System.currentTimeMillis()).coerceAtLeast(0L)
 		}
+	}
+
+	/**
+	 * Constructor for the alert message received when obtaining an NPC combat tag
+	 */
+	private fun npcTimerAlertComponent(reason: String): Component {
+		return ofChildren(
+			lineBreak(45),
+			newline(),
+			text(repeatString(" ", 8) + "YOU ARE NOW IN COMBAT (NPC)", GOLD).decorate(BOLD),
+			newline(),
+			text("Reason: ", HE_MEDIUM_GRAY),
+			text(reason, HE_LIGHT_BLUE),
+			newline(),
+			text("Expiry: ", HE_MEDIUM_GRAY),
+			text("5 minutes", GOLD),
+			newline(),
+			text("Consequences: ", HE_MEDIUM_GRAY),
+			text("[Hover]", HE_LIGHT_BLUE)
+				.hoverEvent(ofChildren(
+					text("- You cannot release your ship", HE_LIGHT_BLUE),
+					newline(),
+					text("- You cannot claim territories, create settlements, or create space stations", HE_LIGHT_BLUE),
+					newline(),
+					text("- You cannot kill yourself", HE_LIGHT_BLUE),
+					)),
+			newline(),
+			lineBreak(45),
+		)
+	}
+
+	/**
+	 * Constructor for the alert message received when obtaining a PvP combat tag
+	 */
+	private fun pvpTimerAlertComponent(reason: String): Component {
+		return ofChildren(
+			lineBreak(45),
+			newline(),
+			text(repeatString(" ", 8) + "YOU ARE NOW IN COMBAT (PVP)", DARK_RED).decorate(BOLD),
+			newline(),
+			text("Reason: ", HE_MEDIUM_GRAY),
+			text(reason, HE_LIGHT_BLUE),
+			newline(),
+			text("Expiry: ", HE_MEDIUM_GRAY),
+			text("10 minutes", DARK_RED),
+			newline(),
+			text("Consequences: ", HE_MEDIUM_GRAY),
+			text("[Hover]", HE_LIGHT_BLUE)
+				.hoverEvent(ofChildren(
+					text("- You cannot release your ship", HE_LIGHT_BLUE),
+					newline(),
+					text("- You cannot claim territories, create settlements, or create space stations", HE_LIGHT_BLUE),
+					newline(),
+					text("- You cannot kill yourself", HE_LIGHT_BLUE),
+					newline(),
+					text("- Any warship that you are piloting cannot enter safe zones", HE_LIGHT_BLUE),
+					newline(),
+					text("- You or your Combat NPC can be killed within safe zones", HE_LIGHT_BLUE),
+					newline(),
+					text("- Combat NPCs created when you log off will last for the duration of your combat tag", HE_LIGHT_BLUE),
+					newline(),
+					text("- Remaining within ${MAINTAIN_COMBAT_DIST.toInt()} blocks of unfriendly and enemy starships will refresh your combat tag", HE_LIGHT_BLUE),
+					)),
+			newline(),
+			lineBreak(45),
+		)
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
@@ -141,4 +141,22 @@ object CombatTimer : IonServerComponent() {
 	fun isPvpCombatTagged(player: Player): Boolean {
 		return pvpTimer[player.uniqueId] != null
 	}
+
+	fun npcTimerRemainingMillis(player: Player): Long {
+		val endTime = npcTimer[player.uniqueId]
+		return if (endTime == null) {
+			0L
+		} else {
+			(endTime - System.currentTimeMillis()).coerceAtLeast(0L)
+		}
+	}
+
+	fun pvpTimerRemainingMillis(player: Player): Long {
+		val endTime = pvpTimer[player.uniqueId]
+		return if (endTime == null) {
+			0L
+		} else {
+			(endTime - System.currentTimeMillis()).coerceAtLeast(0L)
+		}
+	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/MainSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/MainSidebar.kt
@@ -59,7 +59,8 @@ class MainSidebar(private val player: Player, val backingSidebar: Sidebar) {
 
 
 		// Combat tag
-		if (CombatTimer.isNpcCombatTagged(player) || CombatTimer.isPvpCombatTagged(player)) {
+		val combatTimerEnabled = PlayerCache[player.uniqueId].combatTimerEnabled
+		if (combatTimerEnabled && (CombatTimer.isNpcCombatTagged(player) || CombatTimer.isPvpCombatTagged(player))) {
 			val combatTagComponent: SidebarComponent = CombatTagSidebarComponent(player)
 			lines.addComponent(combatTagComponent)
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/MainSidebar.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/MainSidebar.kt
@@ -1,6 +1,8 @@
 package net.horizonsend.ion.server.features.sidebar
 
 import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.features.player.CombatTimer
+import net.horizonsend.ion.server.features.sidebar.component.CombatTagSidebarComponent
 import net.horizonsend.ion.server.features.sidebar.component.ContactsHeaderSidebarComponent
 import net.horizonsend.ion.server.features.sidebar.component.ContactsSidebarComponent
 import net.horizonsend.ion.server.features.sidebar.component.LocationSidebarComponent
@@ -18,10 +20,7 @@ import net.horizonsend.ion.server.features.sidebar.tasks.PlayerLocationSidebar
 import net.horizonsend.ion.server.features.sidebar.tasks.WaypointsSidebar
 import net.horizonsend.ion.server.features.starship.PilotedStarships
 import net.horizonsend.ion.server.features.waypoint.WaypointManager
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.Component.empty
 import net.kyori.adventure.text.Component.text
-import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.NamedTextColor.DARK_GREEN
 import net.kyori.adventure.text.format.NamedTextColor.GREEN
 import net.megavex.scoreboardlibrary.api.sidebar.Sidebar
@@ -57,6 +56,13 @@ class MainSidebar(private val player: Player, val backingSidebar: Sidebar) {
 		// Location
 		val locationComponent: SidebarComponent = LocationSidebarComponent(player)
 		lines.addComponent(locationComponent)
+
+
+		// Combat tag
+		if (CombatTimer.isNpcCombatTagged(player) || CombatTimer.isPvpCombatTagged(player)) {
+			val combatTagComponent: SidebarComponent = CombatTagSidebarComponent(player)
+			lines.addComponent(combatTagComponent)
+		}
 
 		// Starship
 		val starshipsEnabled = PlayerCache[player.uniqueId].starshipsEnabled

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarCombatTimerCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/command/SidebarCombatTimerCommand.kt
@@ -1,0 +1,43 @@
+package net.horizonsend.ion.server.features.sidebar.command
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.Subcommand
+import net.horizonsend.ion.common.database.schema.misc.SLPlayer
+import net.horizonsend.ion.common.extensions.success
+import net.horizonsend.ion.common.extensions.userError
+import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
+import org.bukkit.entity.Player
+import org.litote.kmongo.setValue
+
+@CommandAlias("sidebar")
+object SidebarCombatTimerCommand : SLCommand() {
+    @Subcommand("combattimer")
+    @Suppress("unused")
+    fun defaultCase(
+        sender: Player
+    ) {
+        sender.userError("Usage: /sidebar combattimer <option> [toggle]")
+    }
+
+    @Suppress("unused")
+    @Subcommand("combattimer enable")
+    fun onEnableCombatTimer(
+        sender: Player
+    ) {
+        SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::combatTimerEnabled, true))
+        PlayerCache[sender].combatTimerEnabled = true
+        sender.success("Enabled combat timer info on sidebar")
+    }
+
+    @Suppress("unused")
+    @Subcommand("combattimer disable")
+    fun onDisableCombatTimer(
+        sender: Player
+    ) {
+        SLPlayer.updateById(sender.slPlayerId, setValue(SLPlayer::combatTimerEnabled, false))
+        PlayerCache[sender].combatTimerEnabled = false
+        sender.success("Disabled combat timer info on sidebar")
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/component/CombatTagSidebarComponent.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/component/CombatTagSidebarComponent.kt
@@ -1,0 +1,47 @@
+package net.horizonsend.ion.server.features.sidebar.component
+
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.server.features.player.CombatTimer
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.megavex.scoreboardlibrary.api.sidebar.component.LineDrawable
+import net.megavex.scoreboardlibrary.api.sidebar.component.SidebarComponent
+import org.bukkit.entity.Player
+import java.util.concurrent.TimeUnit
+
+class CombatTagSidebarComponent(player: Player) : SidebarComponent {
+	private val npcCombatTagTime = CombatTimer.npcTimerRemainingMillis(player)
+	private val pvpCombatTagTime = CombatTimer.pvpTimerRemainingMillis(player)
+
+	private fun timeComponent(time: Long, color: NamedTextColor) : Component {
+		val minutes = TimeUnit.MILLISECONDS.toMinutes(time)
+		val seconds = TimeUnit.MILLISECONDS.toSeconds(time) - TimeUnit.MINUTES.toSeconds(minutes)
+		return text("${minutes.toString().padStart(2)}:${seconds.toString().padStart(2)}", color)
+	}
+
+	private fun displayCombatTimerInfo() : TextComponent {
+		return ofChildren(
+			if (npcCombatTagTime > 0) {
+				ofChildren(
+					text("NPC: ", NamedTextColor.GRAY),
+					timeComponent(npcCombatTagTime, NamedTextColor.GOLD),
+					Component.space()
+				)
+			} else Component.empty(),
+
+			if (pvpCombatTagTime > 0) {
+				ofChildren(
+					text("PvP: ", NamedTextColor.GRAY),
+					timeComponent(pvpCombatTagTime, NamedTextColor.DARK_RED),
+				)
+			} else Component.empty()
+		)
+	}
+
+	override fun draw(drawable: LineDrawable) {
+		val line = displayCombatTimerInfo()
+		drawable.drawLine(line)
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/component/CombatTagSidebarComponent.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sidebar/component/CombatTagSidebarComponent.kt
@@ -6,6 +6,10 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY
+import net.kyori.adventure.text.format.NamedTextColor.YELLOW
+import net.kyori.adventure.text.format.Style.style
+import net.kyori.adventure.text.format.TextDecoration.BOLD
 import net.megavex.scoreboardlibrary.api.sidebar.component.LineDrawable
 import net.megavex.scoreboardlibrary.api.sidebar.component.SidebarComponent
 import org.bukkit.entity.Player
@@ -15,14 +19,22 @@ class CombatTagSidebarComponent(player: Player) : SidebarComponent {
 	private val npcCombatTagTime = CombatTimer.npcTimerRemainingMillis(player)
 	private val pvpCombatTagTime = CombatTimer.pvpTimerRemainingMillis(player)
 
+	private fun headerComponent() : Component {
+		return ofChildren(
+			text("Combat").style(style(BOLD).color(YELLOW)),
+			text(" | ", DARK_GRAY)
+		)
+	}
+
 	private fun timeComponent(time: Long, color: NamedTextColor) : Component {
 		val minutes = TimeUnit.MILLISECONDS.toMinutes(time)
 		val seconds = TimeUnit.MILLISECONDS.toSeconds(time) - TimeUnit.MINUTES.toSeconds(minutes)
-		return text("${minutes.toString().padStart(2)}:${seconds.toString().padStart(2)}", color)
+		return text("${minutes}m ${seconds.toString().padStart(2, '0')}s", color)
 	}
 
 	private fun displayCombatTimerInfo() : TextComponent {
 		return ofChildren(
+			headerComponent(),
 			if (npcCombatTagTime > 0) {
 				ofChildren(
 					text("NPC: ", NamedTextColor.GRAY),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
@@ -16,11 +16,11 @@ import net.horizonsend.ion.common.extensions.userErrorAction
 import net.horizonsend.ion.common.extensions.userErrorActionMessage
 import net.horizonsend.ion.common.extensions.userErrorTitle
 import net.horizonsend.ion.common.utils.configuration.redis
-import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.IonServerComponent
 import net.horizonsend.ion.server.features.ai.spawning.SpawningException
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.nations.utils.playSoundInRadius
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.ShipKillXP
 import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
@@ -494,7 +494,8 @@ object PilotedStarships : IonServerComponent() {
 		unpilot(starship)
 
 		// Combat tag check
-		if (!bypassCombatTag && IonServer.configuration.serverName == "Survival" && (checkDamagers(starship) || checkSurroundingPlayers(starship))) {
+		if (!bypassCombatTag && oldController is PlayerController &&
+			(CombatTimer.isNpcCombatTagged(oldController.player) || CombatTimer.isPvpCombatTagged(oldController.player))) {
 			oldController.alert("Your starship is in combat! It will be unpiloted instead!")
 
 			return false

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
@@ -517,7 +517,7 @@ object PilotedStarships : IonServerComponent() {
 	 *
 	 * Returns true if any are found
 	 **/
-	private fun checkDamagers(starship: ActiveControlledStarship): Boolean {
+	fun checkDamagers(starship: ActiveControlledStarship): Boolean {
 		val playerPilot = (starship.controller as? PlayerController)?.player ?: return false
 		val pilotNation = PlayerCache[playerPilot].nationOid ?: return false
 
@@ -538,7 +538,7 @@ object PilotedStarships : IonServerComponent() {
 	/**
 	 * Checks for enemied players within 500 blocks
 	 **/
-	private fun checkSurroundingPlayers(starship: ActiveControlledStarship): Boolean {
+	fun checkSurroundingPlayers(starship: ActiveControlledStarship): Boolean {
 		val playerPilot = (starship.controller as? PlayerController)?.player ?: return false
 		val pilotNation = PlayerCache[playerPilot].nationOid ?: return false
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -21,6 +21,7 @@ import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.command.admin.debug
 import net.horizonsend.ion.server.configuration.ServerConfiguration
 import net.horizonsend.ion.server.features.multiblock.type.gravitywell.GravityWellMultiblock
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.ShipKillXP
 import net.horizonsend.ion.server.features.space.CachedPlanet
 import net.horizonsend.ion.server.features.starship.PilotedStarships.isPiloted
@@ -585,6 +586,8 @@ class Starship (
 		damager.debug("$damager added to $identifier's damagers")
 
 		controller.onDamaged(damager)
+
+		CombatTimer.evaluateSvs(damager, this)
 	}
 	//endregion
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/damager/Damager.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/damager/Damager.kt
@@ -9,12 +9,9 @@ import net.horizonsend.ion.server.features.ai.util.AITarget
 import net.horizonsend.ion.server.features.ai.util.PlayerTarget
 import net.horizonsend.ion.server.features.ai.util.StarshipTarget
 import net.horizonsend.ion.server.features.cache.PlayerCache
-import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.SLXP
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
-import net.horizonsend.ion.server.features.starship.control.controllers.ai.AIController
-import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
 import net.horizonsend.ion.server.features.starship.damager.event.ImpactStarshipEvent
 import net.horizonsend.ion.server.miscellaneous.utils.VAULT_ECO
 import net.kyori.adventure.audience.Audience
@@ -148,18 +145,5 @@ fun addToDamagers(world: World, block: Block, shooter: Damager) {
 		if (event.isCancelled) return
 
 		otherStarship.addDamager(shooter)
-
-		if (shooter is AIShipDamager && otherStarship.controller is PlayerController) {
-			// refresh NPC combat timer if attacker is AI and defender is player
-			CombatTimer.refreshNpcTimer((otherStarship.controller as PlayerController).player)
-		} else if (shooter is PlayerDamager) {
-			if (otherStarship.controller is PlayerController) {
-				// evaluate PVP timer if both attacker and defender are players
-				CombatTimer.evaluatePvp(shooter.player, (otherStarship.controller as PlayerController).player)
-			} else if (otherStarship.controller is AIController) {
-				// refresh NPC combat timer if attacker is player and defender is AI
-				CombatTimer.refreshNpcTimer(shooter.player)
-			}
-		}
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/damager/Damager.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/damager/Damager.kt
@@ -9,9 +9,12 @@ import net.horizonsend.ion.server.features.ai.util.AITarget
 import net.horizonsend.ion.server.features.ai.util.PlayerTarget
 import net.horizonsend.ion.server.features.ai.util.StarshipTarget
 import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.SLXP
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
+import net.horizonsend.ion.server.features.starship.control.controllers.ai.AIController
+import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
 import net.horizonsend.ion.server.features.starship.damager.event.ImpactStarshipEvent
 import net.horizonsend.ion.server.miscellaneous.utils.VAULT_ECO
 import net.kyori.adventure.audience.Audience
@@ -145,5 +148,18 @@ fun addToDamagers(world: World, block: Block, shooter: Damager) {
 		if (event.isCancelled) return
 
 		otherStarship.addDamager(shooter)
+
+		if (shooter is AIShipDamager && otherStarship.controller is PlayerController) {
+			// refresh NPC combat timer if attacker is AI and defender is player
+			CombatTimer.refreshNpcTimer((otherStarship.controller as PlayerController).player)
+		} else if (shooter is PlayerDamager) {
+			if (otherStarship.controller is PlayerController) {
+				// evaluate PVP timer if both attacker and defender are players
+				CombatTimer.evaluatePvp(shooter.player, (otherStarship.controller as PlayerController).player)
+			} else if (otherStarship.controller is AIController) {
+				// refresh NPC combat timer if attacker is player and defender is AI
+				CombatTimer.refreshNpcTimer(shooter.player)
+			}
+		}
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
@@ -226,7 +226,7 @@ abstract class StarshipMovement(val starship: ActiveStarship, val newWorld: Worl
 			if (ProtectionListener.isProtectedCity(point) && starship.type.isWarship &&
 				CombatTimer.isPvpCombatTagged((starship.controller as PlayerController).player)) {
 
-				throw StarshipOutOfBoundsException("Starship is currently combat tagged and cannot enter safe zones!")
+				throw StarshipOutOfBoundsException("The trade city denies your starship entry for your recent acts of aggression!")
 			}
 		}
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
@@ -32,6 +32,7 @@ import net.horizonsend.ion.server.miscellaneous.utils.blockKeyY
 import net.horizonsend.ion.server.miscellaneous.utils.blockKeyZ
 import net.horizonsend.ion.server.miscellaneous.utils.isShulkerBox
 import net.horizonsend.ion.server.miscellaneous.utils.nms
+import net.horizonsend.ion.server.miscellaneous.utils.rectangle
 import net.minecraft.world.level.block.state.BlockState
 import org.bukkit.Location
 import org.bukkit.World
@@ -216,13 +217,15 @@ abstract class StarshipMovement(val starship: ActiveStarship, val newWorld: Worl
 		val newMin = displacedVec(min).toLocation(world2)
 		val newMax = displacedVec(max).toLocation(world2)
 
-		val loc1 = newMin.toLocation(world2)
-		val loc2 = newMax.toLocation(world2)
+		val boundingBox = rectangle(newMin, newMax)
 
-		if ((ProtectionListener.isProtectedCity(loc1) || ProtectionListener.isProtectedCity(loc2)) &&
-			(IonServer.configuration.serverName == "Survival" &&
-				(checkDamagers(starship) || checkSurroundingPlayers(starship))))
-			throw StarshipOutOfBoundsException("Starship is currently combat tagged and cannot enter safe zones!")
+		for (point in boundingBox) {
+			if (ProtectionListener.isProtectedCity(point) && IonServer.configuration.serverName == "Survival" &&
+				(checkDamagers(starship) || checkSurroundingPlayers(starship))) {
+
+				throw StarshipOutOfBoundsException("Starship is currently combat tagged and cannot enter safe zones!")
+			}
+		}
 	}
 
 	private fun moveShipComputers(world2: World) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/projectile/SimpleProjectile.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/projectile/SimpleProjectile.kt
@@ -3,6 +3,7 @@ package net.horizonsend.ion.server.features.starship.subsystem.weapon.projectile
 import net.horizonsend.ion.server.command.admin.GracePeriod
 import net.horizonsend.ion.server.command.admin.debug
 import net.horizonsend.ion.server.features.machine.AreaShields
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.progression.ShipKillXP
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
@@ -198,6 +199,8 @@ abstract class SimpleProjectile(
 			}.incrementPoints(points)
 
 			onImpactStarship(otherStarship, block.location)
+
+			CombatTimer.evaluateSvs(shooter, otherStarship)
 		}
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/projectile/SimpleProjectile.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/projectile/SimpleProjectile.kt
@@ -11,6 +11,7 @@ import net.horizonsend.ion.server.features.starship.damager.Damager
 import net.horizonsend.ion.server.features.starship.damager.EntityDamager
 import net.horizonsend.ion.server.features.starship.damager.PlayerDamager
 import net.horizonsend.ion.server.features.starship.subsystem.shield.StarshipShields
+import net.horizonsend.ion.server.listener.misc.ProtectionListener
 import org.bukkit.FluidCollisionMode
 import org.bukkit.Location
 import org.bukkit.Material
@@ -200,7 +201,9 @@ abstract class SimpleProjectile(
 
 			onImpactStarship(otherStarship, block.location)
 
-			CombatTimer.evaluateSvs(shooter, otherStarship)
+			if (!ProtectionListener.isProtectedCity(block.location)) {
+				CombatTimer.evaluateSvs(shooter, otherStarship)
+			}
 		}
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/listener/misc/ProtectionListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/listener/misc/ProtectionListener.kt
@@ -6,6 +6,7 @@ import net.horizonsend.ion.common.utils.lpHasPermission
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.nations.region.Regions
 import net.horizonsend.ion.server.features.nations.region.types.RegionTerritory
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.starship.DeactivatedPlayerStarships
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
 import net.horizonsend.ion.server.features.world.IonWorld.Companion.ion
@@ -234,7 +235,11 @@ object ProtectionListener : SLEventListener() {
 			return
 		}
 
-		if (event.entity is Player && (isProtectedCity(event.entity.location) || isProtectedCity(event.damager.location))) {
+		// Prevent combat if defender is not combat tagged and is in a protected city, or attacker is not combat tagged and is in a protected city
+		if (event.entity is Player && (
+				(!CombatTimer.isPvpCombatTagged(event.entity as Player) && isProtectedCity(event.entity.location)) ||
+				(!CombatTimer.isPvpCombatTagged(event.damager as Player) && isProtectedCity(event.damager.location))
+			)) {
 			event.isCancelled = true
 		}
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -3,6 +3,7 @@ package net.horizonsend.ion.server.miscellaneous.registrations
 import net.horizonsend.ion.server.command.SLCommand
 import net.horizonsend.ion.server.command.admin.AdminCommands
 import net.horizonsend.ion.server.command.admin.BatteryCommand
+import net.horizonsend.ion.server.command.admin.CombatTagCommand
 import net.horizonsend.ion.server.command.admin.ConvertCommand
 import net.horizonsend.ion.server.command.admin.CustomItemCommand
 import net.horizonsend.ion.server.command.admin.ForbiddenBlocksCommand
@@ -181,6 +182,7 @@ val commands: List<SLCommand> = listOf(
 //	TutorialCommand,
 	CheckCryoCommand,
 	PersonalTransporterCommand,
-	ForbiddenBlocksCommand,
+	CombatTagCommand,
+    ForbiddenBlocksCommand,
 	EnableProtectionMessagesCommand
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -3,7 +3,7 @@ package net.horizonsend.ion.server.miscellaneous.registrations
 import net.horizonsend.ion.server.command.SLCommand
 import net.horizonsend.ion.server.command.admin.AdminCommands
 import net.horizonsend.ion.server.command.admin.BatteryCommand
-import net.horizonsend.ion.server.command.admin.CombatTagCommand
+import net.horizonsend.ion.server.command.admin.CombatTimerCommand
 import net.horizonsend.ion.server.command.admin.ConvertCommand
 import net.horizonsend.ion.server.command.admin.CustomItemCommand
 import net.horizonsend.ion.server.command.admin.ForbiddenBlocksCommand
@@ -182,7 +182,7 @@ val commands: List<SLCommand> = listOf(
 //	TutorialCommand,
 	CheckCryoCommand,
 	PersonalTransporterCommand,
-	CombatTagCommand,
+	CombatTimerCommand,
     ForbiddenBlocksCommand,
 	EnableProtectionMessagesCommand
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -3,7 +3,7 @@ package net.horizonsend.ion.server.miscellaneous.registrations
 import net.horizonsend.ion.server.command.SLCommand
 import net.horizonsend.ion.server.command.admin.AdminCommands
 import net.horizonsend.ion.server.command.admin.BatteryCommand
-import net.horizonsend.ion.server.command.admin.CombatTimerCommand
+import net.horizonsend.ion.server.command.misc.CombatTimerCommand
 import net.horizonsend.ion.server.command.admin.ConvertCommand
 import net.horizonsend.ion.server.command.admin.CustomItemCommand
 import net.horizonsend.ion.server.command.admin.ForbiddenBlocksCommand
@@ -34,6 +34,7 @@ import net.horizonsend.ion.server.command.misc.PlayerInfoCommand
 import net.horizonsend.ion.server.command.misc.RegenerateCommand
 import net.horizonsend.ion.server.command.misc.ShipFactoryCommand
 import net.horizonsend.ion.server.command.misc.ShuttleCommand
+import net.horizonsend.ion.server.command.misc.SuicideCommand
 import net.horizonsend.ion.server.command.misc.TransportDebugCommand
 import net.horizonsend.ion.server.command.nations.NationCommand
 import net.horizonsend.ion.server.command.nations.NationRelationCommand
@@ -184,5 +185,6 @@ val commands: List<SLCommand> = listOf(
 	PersonalTransporterCommand,
 	CombatTimerCommand,
     ForbiddenBlocksCommand,
-	EnableProtectionMessagesCommand
+	EnableProtectionMessagesCommand,
+	SuicideCommand
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
@@ -45,6 +45,7 @@ import net.horizonsend.ion.server.features.npcs.TutorialNPCs
 import net.horizonsend.ion.server.features.npcs.traits.NPCTraits
 import net.horizonsend.ion.server.features.ores.generation.OreGeneration
 import net.horizonsend.ion.server.features.player.CombatNPCs
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.player.DutyModeMonitor
 import net.horizonsend.ion.server.features.player.EventLogger
 import net.horizonsend.ion.server.features.progression.Levels
@@ -210,4 +211,5 @@ val components: List<IonComponent> = listOf(
 	HudIcons,
 	Fleets,
 	ContactsJammingSidebar,
+	CombatTimer
 )

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Coordinates.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Coordinates.kt
@@ -183,6 +183,31 @@ fun Location.alongVector(vector: Vector, points: Int): List<Location> {
 	return locationList
 }
 
+/**
+ * Returns a list of Locations forming a 2D rectangle bounded by two corner Locations
+ *
+ * @param minLoc: The northwestern corner of the rectangle
+ * @param maxLoc: The southeastern corner of the rectangle
+ */
+fun rectangle(minLoc: Location, maxLoc: Location): List<Location> {
+	if (minLoc.world != maxLoc.world) return emptyList()
+
+	val xAxisLength = (maxLoc.z - minLoc.z).toInt()
+	val zAxisLength = (maxLoc.x - minLoc.x).toInt()
+
+	val northVector = minLoc.toVector().apply { y = 0.0; x += xAxisLength }.subtract(minLoc.toVector().apply { y = 0.0 })
+	val eastVector = maxLoc.toVector().apply { y = 0.0; z -= zAxisLength }.subtract(maxLoc.toVector().apply { y = 0.0 })
+	val southVector = maxLoc.toVector().apply { y = 0.0; x -= xAxisLength }.subtract(maxLoc.toVector().apply { y = 0.0 })
+	val westVector = minLoc.toVector().apply { y = 0.0; z += zAxisLength }.subtract(minLoc.toVector().apply { y = 0.0 })
+
+	val northList = minLoc.alongVector(northVector, xAxisLength)
+	val eastList = maxLoc.alongVector(eastVector, zAxisLength)
+	val southList = maxLoc.alongVector(southVector, xAxisLength)
+	val westList = minLoc.alongVector(westVector, zAxisLength)
+
+	return (northList + eastList + southList + westList).distinct()
+}
+
 fun Location.iterateVector(vector: Vector, points: Int, function: (Location, Double) -> Unit) {
 	for (count in 0..points) {
 		val progress = count.toDouble() / points.toDouble()


### PR DESCRIPTION
Adds combat timers (combat tags) which prevent players from doing certain actions while in combat. This intends to make combat between NPCs and players more enjoyable.

On certain actions, players will be marked with an NPC combat timer, or a PvP combat timer:

- NPC combat timer:
  - Engage in SvS with an NPC ship
- PvP combat timer:
  - Engage in SvS with another player's ship
  - Engage in PvP with another player
  - Be close to an enemy player that is piloting a ship (within 500m)
  - Be caught in an enemy player's gravity well
  - Cannot be in a safe zone

While marked with a combat timer, certain restrictions are applied to a player:

- NPC combat timer:
  - Lasts 2m30s
  - Cannot release ship (will be unpiloted instead)
  - Cannot claim territory, settlements, or space stations
  - Cannot kill yourself

- PvP combat timer:
  - Lasts 10m
  - Cannot release ship (will be unpiloted instead)
  - Cannot claim territory, settlements, or space stations
  - Cannot kill yourself
  - If piloting a warship, cannot enter safe zones
  - Players and combat NPCs can be killed within safe zones by other players that are also combat tagged
  - Combat NPC duration is extended to the remaining time on the combat timer
  - Combat timer duration is refreshed if any enemy ship is within 1000 blocks

All combat timers are removed on player death