### PR TITLE
Settlement Zone Interactable Blocks

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/nations/SettlementZone.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/nations/SettlementZone.kt
@@ -36,7 +36,8 @@ class SettlementZone(
     var trustedNations: Set<Oid<Nation>>? = null,
     var trustedSettlements: Set<Oid<Settlement>>? = null,
     var minBuildAccess: Settlement.ForeignRelation? = null,
-	var allowFriendlyFire: Boolean? = null
+	var allowFriendlyFire: Boolean? = null,
+	var interactableBlocks: Set<String> = setOf()
 ) : DbObject {
 	companion object : OidDbObjectCompanion<SettlementZone>(SettlementZone::class, setup = {
 		ensureIndex(SettlementZone::settlement)
@@ -110,7 +111,8 @@ class SettlementZone(
 					org.litote.kmongo.setValue(SettlementZone::trustedNations, null),
 					org.litote.kmongo.setValue(SettlementZone::trustedSettlements, null),
 					org.litote.kmongo.setValue(SettlementZone::minBuildAccess, null),
-					org.litote.kmongo.setValue(SettlementZone::allowFriendlyFire, null)
+					org.litote.kmongo.setValue(SettlementZone::allowFriendlyFire, null),
+					org.litote.kmongo.setValue(SettlementZone::interactableBlocks, setOf())
 				)
 			} else {
 				// someone bought it -> set owner, unset price (not rent, as the rent must stay for them to be charged)
@@ -166,6 +168,16 @@ class SettlementZone(
 		fun setAllowFriendlyFire(zoneId: Oid<SettlementZone>, value: Boolean) = trx { sess ->
 			require(matches(sess, zoneId, SettlementZone::owner ne null)) { "Zone $zoneId has no owner" }
 			updateById(sess, zoneId, org.litote.kmongo.setValue(SettlementZone::allowFriendlyFire, value))
+		}
+
+		fun addInteractableBlock(zoneId: Oid<SettlementZone>, blockName: String) = trx { sess ->
+			require(matches(sess, zoneId, SettlementZone::owner ne null)) { "Zone $zoneId has no owner" }
+			updateById(sess, zoneId, addToSet(SettlementZone::interactableBlocks, blockName))
+		}
+
+		fun removeInteractableBlock(zoneId: Oid<SettlementZone>, blockName: String) = trx { sess ->
+			require(matches(sess, zoneId, SettlementZone::owner ne null)) { "Zone $zoneId has no owner" }
+			updateById(sess, zoneId, pull(SettlementZone::interactableBlocks, blockName))
 		}
 
 		fun setMinBuildAccess(zoneId: Oid<SettlementZone>, level: Settlement.ForeignRelation): Unit = trx { sess ->

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/GlobalCompletions.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/GlobalCompletions.kt
@@ -19,6 +19,7 @@ object GlobalCompletions {
 
 		manager.commandCompletions.registerAsyncCompletion( "anyItem") { Bazaars.strings }
 		manager.commandCompletions.setDefaultCompletion("anyItem", AnyItem::class.java)
+		manager.commandCompletions.registerAsyncCompletion("anyBlock") { Material.entries.filter { it.isBlock && !it.isLegacy }.map { it.name } }
 	}
 
 	fun toItemString(item: ItemStack): String {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/settlementZones/SettlementPlotCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/settlementZones/SettlementPlotCommand.kt
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Subcommand
 import net.horizonsend.ion.common.database.schema.nations.Settlement
 import net.horizonsend.ion.common.database.schema.nations.SettlementZone
 import net.horizonsend.ion.common.database.slPlayerId
+import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.utils.miscellaneous.toCreditsString
 import net.horizonsend.ion.server.features.nations.gui.playerClicker
 import net.horizonsend.ion.server.features.nations.region.Regions
@@ -224,10 +225,53 @@ internal object SettlementPlotCommand : net.horizonsend.ion.server.command.SLCom
 
 	@Subcommand("allowFriendlyFire")
 	@Description("Allow members of the same nation or allies to damage each other")
+	@CommandCompletion("@plots true|false")
+	@Suppress("unused")
 	fun onSetFriendlyFire(sender: Player, zone: RegionSettlementZone, state: Boolean) = asyncCommand(sender) {
 		requireOwnsZone(sender, zone)
 		SettlementZone.setAllowFriendlyFire(zone.id, state)
 		sender msg "&aChanged ${zone.name} to ${if (state) "allow" else "disallow"} friendly fire"
+	}
+
+	@Subcommand("interactableBlocks add")
+	@Description("Allow a block to be interacted with by any player")
+	@CommandCompletion("@plots @anyBlock")
+	@Suppress("unused")
+	fun onAddInteractableBlock(sender: Player, zone: RegionSettlementZone, blockString: String) {
+		requireOwnsZone(sender, zone)
+		val material = validateBlock(blockString)
+		SettlementZone.addInteractableBlock(zone.id, material.name)
+		sender msg "&aAdded $blockString to ${zone.name}'s list of interactable blocks"
+	}
+
+	@Subcommand("interactableBlocks remove")
+	@Description("Remove a block from the list of interactable blocks")
+	@CommandCompletion("@plots @anyBlock")
+	@Suppress("unused")
+	fun onRemoveInteractableBlock(sender: Player, zone: RegionSettlementZone, blockString: String) {
+		requireOwnsZone(sender, zone)
+		val material = validateBlock(blockString)
+		SettlementZone.removeInteractableBlock(zone.id, material.name)
+		sender msg "&aRemoved $blockString from ${zone.name}'s list of interactable blocks"
+	}
+
+	@Subcommand("interactableBlocks list")
+	@Description("Gets list of interactable blocks")
+	@CommandCompletion("@plots")
+	@Suppress("unused")
+	fun onListInteractableBlocks(sender: Player, zone: RegionSettlementZone) {
+		requireOwnsZone(sender, zone)
+		sender.information(zone.getInteractableBlocks())
+	}
+
+	private fun validateBlock(blockString: String): Material {
+		try {
+			val material = Material.matchMaterial(blockString)
+			failIf(material == null || !material.isBlock) { "$blockString is not a block" }
+			return material!! // fails if material is null
+		} catch (e: Exception) {
+			fail { "Invalid block string $blockString! To see a block's string, use /bazaar string" }
+		}
 	}
 
 	@Subcommand("minbuildaccess")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/nations/region/types/RegionSettlementZone.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/nations/region/types/RegionSettlementZone.kt
@@ -26,6 +26,7 @@ import net.horizonsend.ion.server.features.nations.region.Regions
 import net.horizonsend.ion.server.miscellaneous.utils.PerPlayerCooldown
 import net.horizonsend.ion.server.miscellaneous.utils.Vec3i
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
+import org.bukkit.Location
 import org.bukkit.entity.Player
 
 class RegionSettlementZone(zone: SettlementZone) : Region<SettlementZone>(zone) {
@@ -44,6 +45,7 @@ class RegionSettlementZone(zone: SettlementZone) : Region<SettlementZone>(zone) 
 	var trustedSettlements: Set<Oid<Settlement>>? = zone.trustedSettlements; private set
 	var minBuildAccess: Settlement.ForeignRelation? = zone.minBuildAccess; private set
 	var allowFriendlyFire: Boolean? = zone.allowFriendlyFire; private set
+	var interactableBlocks: Set<String> = zone.interactableBlocks; private set
 	override val world: String get() = Regions.get<RegionTerritory>(territory).world
 
 	private fun getRegionTerritory(): RegionTerritory {
@@ -87,6 +89,9 @@ class RegionSettlementZone(zone: SettlementZone) : Region<SettlementZone>(zone) 
 		}
 		delta[SettlementZone::allowFriendlyFire]?.let { bson ->
 			allowFriendlyFire = bson.nullable()?.boolean()
+		}
+		delta[SettlementZone::interactableBlocks]?.let { bson ->
+			interactableBlocks = bson.mappedSet { it.string() }
 		}
 	}
 
@@ -152,6 +157,22 @@ class RegionSettlementZone(zone: SettlementZone) : Region<SettlementZone>(zone) 
 
 			// this makes the mega lag
 			// SettlementZoneCommand.visualizeRegion(minPoint, maxPoint, player, name.hashCode())
+		}
+	}
+
+	fun getInteractableBlocks(): String {
+		return interactableBlocks.joinToString()
+	}
+
+	companion object {
+		fun getRegionSettlementZone(location: Location): RegionSettlementZone? {
+			val territory: RegionTerritory? = Regions.findFirstOf(location)
+
+			val zone = territory?.children?.firstOrNull { region ->
+				region is RegionSettlementZone && region.contains(location.blockX, location.blockY, location.blockZ)
+			} as? RegionSettlementZone
+
+			return zone
 		}
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/listener/misc/ProtectionListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/listener/misc/ProtectionListener.kt
@@ -79,7 +79,7 @@ object ProtectionListener : SLEventListener() {
 		// if there is a settlement zone and the clicked block is allowed on its list of interactable blocks,
 		// do not perform protection checks
 		if (zone != null && isInteractable(clickedBlock) &&
-			zone.interactableBlocks.contains(clickedBlock.blockData.material.toString())) {
+			zone.interactableBlocks.contains(clickedBlock.blockData.material.name)) {
 			return true
 		}
 
@@ -93,10 +93,10 @@ object ProtectionListener : SLEventListener() {
 
 	private fun isInteractable(block: Block): Boolean {
 		// Expand list of interactable blocks as needed
-		return (block !is Jukebox &&
-			(block is InventoryHolder ||
-			block is Openable ||
-			block is Powerable))
+		return (block.blockData !is Jukebox &&
+			(block.state is InventoryHolder ||
+			block.blockData is Openable ||
+			block.blockData is Powerable))
 	}
 
 	@EventHandler

--- a/server/src/main/kotlin/net/horizonsend/ion/server/listener/misc/ProtectionListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/listener/misc/ProtectionListener.kt
@@ -5,6 +5,7 @@ import net.horizonsend.ion.common.database.schema.starships.PlayerStarshipData
 import net.horizonsend.ion.common.utils.lpHasPermission
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.nations.region.Regions
+import net.horizonsend.ion.server.features.nations.region.types.RegionSettlementZone
 import net.horizonsend.ion.server.features.nations.region.types.RegionTerritory
 import net.horizonsend.ion.server.features.npcs.traits.CombatNPCTrait
 import net.horizonsend.ion.server.features.player.CombatNPCs
@@ -29,6 +30,9 @@ import net.horizonsend.ion.server.miscellaneous.utils.msg
 import org.bukkit.Location
 import org.bukkit.Particle
 import org.bukkit.block.Block
+import org.bukkit.block.Jukebox
+import org.bukkit.block.data.Openable
+import org.bukkit.block.data.Powerable
 import org.bukkit.block.data.type.Door
 import org.bukkit.block.data.type.Switch
 import org.bukkit.block.data.type.TrapDoor
@@ -70,12 +74,29 @@ object ProtectionListener : SLEventListener() {
 		// If something ends up getting checked that shouldn't
 		// (e.g. clicking the glass in your cockpit), it could break firing weapons.
 
+		val zone = RegionSettlementZone.getRegionSettlementZone(clickedBlock.location)
+
+		// if there is a settlement zone and the clicked block is allowed on its list of interactable blocks,
+		// do not perform protection checks
+		if (zone != null && isInteractable(clickedBlock) &&
+			zone.interactableBlocks.contains(clickedBlock.blockData.material.toString())) {
+			return true
+		}
+
 		// Manually check these
 		if (clickedBlock.blockData is Switch) return false
 		if (clickedBlock.blockData is TrapDoor) return false
 		if (clickedBlock.blockData is Door) return false
 
 		return clickedBlock.state !is InventoryHolder
+	}
+
+	private fun isInteractable(block: Block): Boolean {
+		// Expand list of interactable blocks as needed
+		return (block !is Jukebox &&
+			(block is InventoryHolder ||
+			block is Openable ||
+			block is Powerable))
 	}
 
 	@EventHandler

--- a/server/src/main/kotlin/net/horizonsend/ion/server/listener/nations/FriendlyFireListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/listener/nations/FriendlyFireListener.kt
@@ -5,9 +5,7 @@ import net.horizonsend.ion.common.database.cache.nations.RelationCache
 import net.horizonsend.ion.common.database.schema.nations.Nation
 import net.horizonsend.ion.server.LegacySettings
 import net.horizonsend.ion.server.features.cache.PlayerCache
-import net.horizonsend.ion.server.features.nations.region.Regions
 import net.horizonsend.ion.server.features.nations.region.types.RegionSettlementZone
-import net.horizonsend.ion.server.features.nations.region.types.RegionTerritory
 import net.horizonsend.ion.server.listener.SLEventListener
 import org.bukkit.Bukkit
 import org.bukkit.entity.EntityType
@@ -35,12 +33,7 @@ object FriendlyFireListener : SLEventListener() {
 		val damager = event.damager as? Player ?: return
 
 		if (isFriendlyFire(damaged, damager)) {
-			val location = damaged.location
-			val territory: RegionTerritory? = Regions.findFirstOf(location)
-
-			val zone = territory?.children?.firstOrNull { region ->
-				region is RegionSettlementZone && region.contains(location.blockX, location.blockY, location.blockZ)
-			} as? RegionSettlementZone
+			val zone = RegionSettlementZone.getRegionSettlementZone(damaged.location)
 
 			if (zone != null && zone.allowFriendlyFire == true) return
 


### PR DESCRIPTION
Adds a feature to allow certain blocks within settlement zones to be interacted with by anyone
- `/splot interactableblocks add <zone> <block>` allows all blocks of the same type in the settlement zone to be interacted with by anyone
- `/splot interactableblocks remove <zone> <block>` removes the block
- `/splot interactableblocks list <zone>`
- Only blocks with the InventoryHolder, Openable, Switch, and Powerable property will be affected at this time