### PR TITLE
Towing

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
@@ -37,6 +37,7 @@ import net.horizonsend.ion.server.features.starship.event.StarshipUnpilotedEvent
 import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
 import net.horizonsend.ion.server.features.starship.subsystem.misc.LandingGearSubsystem
 import net.horizonsend.ion.server.features.starship.subsystem.misc.MiningLaserSubsystem
+import net.horizonsend.ion.server.features.starship.subsystem.reactor.ReactorSubsystem
 import net.horizonsend.ion.server.features.starship.subsystem.shield.ShieldSubsystem
 import net.horizonsend.ion.server.features.starship.subsystem.shield.StarshipShields
 import net.horizonsend.ion.server.features.transport.Extractors
@@ -464,6 +465,10 @@ object PilotedStarships : IonServerComponent() {
 					.append(Component.text(" with ${activePlayerStarship.initialBlockCount} blocks."))
 			)
 
+			if (isOversized(activePlayerStarship)) {
+				player.userError("Ship is over max block count! Power output reduced by ${(ReactorSubsystem.OVERSIZE_POWER_PENALTY * 100).toInt()}%!")
+			}
+
 			if (carriedShips.any()) {
 				player.information(
 					"${carriedShips.size} carried ship${if (carriedShips.size != 1) "s" else ""}."
@@ -556,4 +561,6 @@ object PilotedStarships : IonServerComponent() {
 	}
 
 	fun getDisplayName(data: StarshipData): Component = data.name?.let { MiniMessage.miniMessage().deserialize(it) } ?: data.starshipType.actualType.displayNameComponent
+
+	fun isOversized(starship: Starship) = starship.initialBlockCount > (starship.type.maxSize * StarshipDetection.OVERSIZE_MODIFIER).toInt()
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/PilotedStarships.kt
@@ -465,7 +465,7 @@ object PilotedStarships : IonServerComponent() {
 					.append(Component.text(" with ${activePlayerStarship.initialBlockCount} blocks."))
 			)
 
-			if (isOversized(activePlayerStarship)) {
+			if (activePlayerStarship.isOversized()) {
 				player.userError("Ship is over max block count! Power output reduced by ${(ReactorSubsystem.OVERSIZE_POWER_PENALTY * 100).toInt()}%!")
 			}
 
@@ -562,5 +562,4 @@ object PilotedStarships : IonServerComponent() {
 
 	fun getDisplayName(data: StarshipData): Component = data.name?.let { MiniMessage.miniMessage().deserialize(it) } ?: data.starshipType.actualType.displayNameComponent
 
-	fun isOversized(starship: Starship) = starship.initialBlockCount > (starship.type.maxSize * StarshipDetection.OVERSIZE_MODIFIER).toInt()
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -644,6 +644,8 @@ class Starship (
 	fun getDisplayNamePlain(): String = getDisplayName().plainText()
 	//endregion
 
+	fun isOversized() = this.initialBlockCount > this.type.maxSize && (this.initialBlockCount <= (this.type.maxSize * StarshipDetection.OVERSIZE_MODIFIER).toInt())
+
 	init {
 		IonWorld[world].starships.add(this)
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipComputers.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipComputers.kt
@@ -39,6 +39,7 @@ import net.horizonsend.ion.server.features.starship.event.StarshipDetectedEvent
 import net.horizonsend.ion.server.miscellaneous.utils.MenuHelper
 import net.horizonsend.ion.server.miscellaneous.utils.PerPlayerCooldown
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.horizonsend.ion.server.miscellaneous.utils.actualType
 import net.horizonsend.ion.server.miscellaneous.utils.isPilot
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import net.kyori.adventure.text.Component.text
@@ -267,6 +268,9 @@ object StarshipComputers : IonServerComponent() {
 				DeactivatedPlayerStarships.updateState(data, state)
 
 				player.success("Re-detected! New size ${state.blockMap.size.toText()}")
+				if (state.blockMap.size > data.starshipType.actualType.maxSize) {
+					player.userError("Detected starship is oversized! It will suffer a performance penalty.")
+				}
 			}
 		}
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipDetection.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipDetection.kt
@@ -42,6 +42,8 @@ import kotlin.math.min
 import kotlin.math.sqrt
 
 object StarshipDetection : IonServerComponent() {
+	const val OVERSIZE_MODIFIER = 1.1
+
 	class DetectionFailedException(message: String) : Exception(message)
 
 	private val activeTasks = ConcurrentHashMap<Player, BukkitTask>()
@@ -199,9 +201,10 @@ object StarshipDetection : IonServerComponent() {
 			)
 		}
 
-		if (size > type.maxSize) {
+		// Allow ships that are slightly larger to detect. Changed to allow ships to tow 10% more than their detect capacity
+		if (size > (type.maxSize * OVERSIZE_MODIFIER).toInt()) {
 			throw DetectionFailedException(
-				"The ship's too big! Maximum size for '${type.displayName}' is ${type.maxSize}, " +
+				"The ship's too big! Maximum size for '${type.displayName}' is ${type.maxSize} (oversized ${(type.maxSize * OVERSIZE_MODIFIER).toInt()}), " +
 					"but there were $size blocks. Consider changing the ship's class."
 			)
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/SubsystemDetector.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/SubsystemDetector.kt
@@ -83,7 +83,8 @@ object SubsystemDetector {
 			if (type == Material.OBSERVER) potentialLandingGearBlocks.add(block)
 		}
 
-		starship.reactor = ReactorSubsystem(starship)
+		val oversizeModifier = if (starship.initialBlockCount > starship.type.maxSize) ReactorSubsystem.OVERSIZE_POWER_PENALTY else 1.0
+		starship.reactor = ReactorSubsystem(starship, oversizeModifier)
 		starship.subsystems += starship.reactor
 
 		for (block in potentialThrusterBlocks) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/reactor/ReactorSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/reactor/ReactorSubsystem.kt
@@ -8,10 +8,16 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 class ReactorSubsystem(
-	starship: ActiveStarship
+	starship: ActiveStarship,
+	powerModifier: Double
 ) : StarshipSubsystem(starship, starship.centerOfMass) {
+
+	companion object {
+		const val OVERSIZE_POWER_PENALTY = 0.5
+	}
+
 	val output: Double =
-		Math.cbrt(starship.initialBlockCount.coerceAtLeast(500).toDouble()) * 3000.0 * (starship.type.poweroverrider)
+		Math.cbrt(starship.initialBlockCount.coerceAtLeast(500).toDouble()) * 3000.0 * (starship.type.poweroverrider) * powerModifier
 	val powerDistributor = PowerDistributor()
 	val weaponCapacitor = WeaponCapacitor(this)
 	val heavyWeaponBooster = HeavyWeaponBooster(this)


### PR DESCRIPTION
- All ships can now detect an additional 10% of their maximum block count
- Exceeding the initial block count limit will reduce the ship's power output by 50%