### PR TITLE
itemsearch bugfixes & code cleanup

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/SearchCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/SearchCommand.kt
@@ -19,8 +19,10 @@ import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import net.horizonsend.ion.server.miscellaneous.utils.minecraft
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.World
 import org.bukkit.block.Block
+import org.bukkit.block.data.type.Chest
 import org.bukkit.entity.Player
 import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.InventoryHolder
@@ -33,46 +35,47 @@ object SearchCommand : SLCommand() {
 	@Default
 	@CommandCompletion("@anyItem")
 	fun default( player: Player, vararg itemStrList: String) {
+		// key: <Block> (for location)
+		// value: <Inventory> (for inventory contents)
+		val containers = mutableMapOf<Block, Inventory>()
+
 		val strList = itemStrList.toList()
-		val containers = mutableSetOf<InventoryHolder>()
-		val containerBlocks = mutableSetOf<Block>()
-		for(str in strList) {
-			val item = GlobalCompletions.stringToItem(str) ?: player.inventory.itemInMainHand
-			val tempContainers = findContainers(player.world, player.location, item, str) //<InventoryHolder> (for inventory contents)
-			containers.addAll(tempContainers)
 
-			//This is just so I stop trying to cast block state stuff async
-			//(I know there's a better way to do it, but I don't know what it is)
-			val tempContainerBlocks = findContainerBlocks(player.world, player.location, item, str) //<Block> (for location)
-			containerBlocks.addAll(tempContainerBlocks)
+		if(strList.isEmpty()) {
+			val item = player.inventory.itemInMainHand
+			val str = GlobalCompletions.toItemString(item)
+			containers.putAll(findContainers(player.world,player.location,item,str))
+		} else {
+			for(str in strList) {
+				val item = GlobalCompletions.stringToItem(str) ?: continue
+				containers.putAll(findContainers(player.world,player.location,item,str))
+			}
 		}
+		val blocks = containers.keys
+		val inventories = containers.values.toMutableSet()
+
 		Tasks.async {
-			for (str in strList) {
-				val item = GlobalCompletions.stringToItem(str) ?: player.inventory.itemInMainHand
-				for (block in containerBlocks.withIndex()) {
-					val loc = Location( player.world, block.value.x.toDouble(), block.value.y.toDouble(), block.value.z.toDouble() )
-
-					if(!containsItem(containers.elementAt(block.index).inventory, item)) continue //necessary check for multi-item searches to prevent false positives
-
-					if (twoOrMoreMatches(containers.elementAt(block.index), strList) || // if container has 2+ of the searched items
-						(item.type.isBlock && item.type.isSolid) || // Billboarding blocks looks so messed up, so this mostly prevents that
-						str == "AIR" || // display if item is air, otherwise it would show up as an invisible item
-						!PlayerCache[player].showItemSearchItem) // toggleable setting
-					{
-						sendEntityPacket(player, displayCurrentBlock(player.world.minecraft, loc.toVector()), 10 * 20) // show block
-					} else {
-						sendEntityPacket(player, displayItem(player, item, loc.toVector()), 10 * 20) // show item
-					}
+			if(itemStrList.isEmpty()) { // player typed "/itemsearch"
+				if (player.inventory.itemInMainHand.type == Material.AIR) { // empty hand
+					player.userError("Specify which item to search.")
+					return@async
+				} else {
+					val item = player.inventory.itemInMainHand // non-empty hand
+					searchItem(item, player, blocks, inventories, strList)
+				}
+			} else {
+				for (str in strList) { // strList isn't empty
+					val item = GlobalCompletions.stringToItem(str) ?: continue
+					searchItem(item, player, blocks, inventories, strList)
 				}
 			}
-			if (itemStrList.isEmpty()) {
-				player.userError("Specify which item to search.")
-			} else if (containers.size == 0) {
+
+			if (inventories.size == 0) {
 				player.userError("Couldn't find any item in a 20 block range.")
 			} else {
 				player.sendRichMessage(
-					"<hover:show_text:\"${containerBlocks.joinToString("\n") { "<gray>X: ${it.x} Y: ${it.y} Z: ${it.z}" }}\">" +
-						"<#7f7fff>Found ${containerBlocks.size} containers. [Hover]"
+					"<hover:show_text:\"${blocks.joinToString("\n") { "<gray>X: ${it.x} Y: ${it.y} Z: ${it.z}" }}\">" +
+						"<#7f7fff>Found ${blocks.size} inventories. [Hover]"
 				)
 			}
 		}
@@ -87,69 +90,111 @@ object SearchCommand : SLCommand() {
 	}
 
 	/**
-	 * Finds all containers that are holding the specified item, in a radius of 20 blocks around a center point.
-	 * @param world The world that the containers are in.
-	 * @param loc The Location of the center block
-	 * @param item The item being searched
-	 * @param radius The search radius
+	 * Searches for an item in a list of containers and displays the results as display entities
+	 */
+	private fun searchItem(item: ItemStack, player: Player, blocks: MutableSet<Block>, inventories: MutableSet<Inventory>, strList: List<String>) {
+		for (block in blocks.withIndex()) {
+			val loc = Location( player.world, block.value.x.toDouble(), block.value.y.toDouble(), block.value.z.toDouble() )
+
+			if(!containsItem(inventories.elementAt(block.index), item)) continue //necessary check for multi-item searches to prevent false positives
+
+			if ( (twoOrMoreMatches(inventories.elementAt(block.index), strList)) || // if container has 2+ of the searched items
+				(item.type.isBlock && item.type.isSolid) || // Billboarding blocks looks so messed up, so this mostly prevents that
+				item.type == Material.AIR || // display if item is air, otherwise it would show up as an invisible item
+				!PlayerCache[player].showItemSearchItem) // toggleable setting
+			{
+				sendEntityPacket(player, displayCurrentBlock(player.world.minecraft, loc.toVector()), 10 * 20) // show block
+			} else {
+				sendEntityPacket(player, displayItem(player, item, loc.toVector()), 10 * 20) // show item
+			}
+		}
+	}
+
+	/**
+	 * Finds all inventories that are holding the specified item, in a specified distance around a center point.
 	 */
 	private fun findContainers(
 		world: World,
 		loc: Location,
 		item: ItemStack,
 		itemStr: String,
-		radius: Int = 20
-	) : MutableSet<InventoryHolder> {
-		val blockSet = mutableSetOf<InventoryHolder>()
-		for(x in loc.x.toInt() - radius..loc.x.toInt() + radius){
-			for(y in loc.y.toInt()-radius .. loc.y.toInt()+radius){
-				for(z in loc.z.toInt()-radius .. loc.z.toInt()+radius){
+		dist: Int = 20
+	): MutableMap<Block, Inventory> {
+		val map = mutableMapOf<Block, Inventory>()
+		for(x in loc.x.toInt() - dist..loc.x.toInt() + dist) {
+			for(y in loc.y.toInt() - dist..loc.y.toInt() + dist) {
+				for(z in loc.z.toInt() - dist..loc.z.toInt() + dist) {
 					val block = world.getBlockAt(x, y, z)
-					val inv = block.state as? InventoryHolder ?: continue
-					//added second conditional cause there are no "AIR" item stacks
-					if( containsItem(inv.inventory, item) || (itemStr == "AIR" && containsAir(inv.inventory))) {
-						blockSet.add(inv)
+					val inv = (block.state as? InventoryHolder)?.inventory ?: continue
+					if(block.type == Material.CHEST) { // one of the blocks of a double chest
+						val data = (block.blockData as Chest).type
+						if(chestContainsItem(inv, item, data) || (itemStr == "AIR" && containsAir(inv))) {
+							map[block] = inv
+						}
+					} else if( containsItem(inv, item) || (itemStr == "AIR" && containsAir(inv))) {
+						map[block] = inv
 					}
 				}
 			}
 		}
-		return blockSet
+		return map
 	}
 
 	/**
-	 * its literally just findContainer() but returns the block instead of the InventoryHolder so that you can access coordinates async
-	 * @param world The world that the containers are in.
-	 * @param loc The Location of the center block
-	 * @param item The item being searched
-	 * @param itemStr The inputted String of the item being searched
-	 * @param radius The search radius
+	 * Determines if 2 items match
 	 */
-	private fun findContainerBlocks(
-		world: World,
-		loc: Location,
-		item: ItemStack,
-		itemStr: String,
-		radius: Int = 20
-	) : MutableSet<Block> {
-		val blockSet = mutableSetOf<Block>()
-		for(x in loc.x.toInt() - radius..loc.x.toInt() + radius){
-			for(y in loc.y.toInt()-radius .. loc.y.toInt()+radius){
-				for(z in loc.z.toInt()-radius .. loc.z.toInt()+radius){
-					val block = world.getBlockAt(x, y, z)
-					val inv = block.state as? InventoryHolder ?: continue
-					if(containsItem(inv.inventory, item) || (itemStr == "AIR" && containsAir(inv.inventory))) {
-						blockSet.add(block)
-					}
-				}
+	private fun itemsMatch(item1: ItemStack, item2: ItemStack): Boolean {
+		if(item1.type == item2.type) {
+			if( !item1.itemMeta.hasCustomModelData() && !item2.itemMeta.hasCustomModelData() ) return true // if both don't have custom model data, return true
+
+			if ( (item1.itemMeta.hasCustomModelData() && item2.itemMeta.hasCustomModelData()) &&
+				item1.itemMeta.customModelData == item2.itemMeta.customModelData ) return true //if their custom model data both match, return true
+		}
+		return false
+	}
+
+	/**
+	 * Determines if a Chest contains a specified item
+	 * Also handles logic for double chests, returning the proper half
+	 */
+	private fun chestContainsItem(inventory: Inventory, item: ItemStack, type: Chest.Type): Boolean {
+		val startIndex: Int
+		val stopIndex: Int
+		when(type) {
+			Chest.Type.RIGHT -> {
+				startIndex = 0
+				stopIndex = 26
+			}
+			Chest.Type.LEFT -> {
+				startIndex = 27
+				stopIndex = 53
+			}
+			else -> {
+				return containsItem(inventory, item)
 			}
 		}
-		return blockSet
+		for(i in startIndex..stopIndex){
+			val invItem = inventory.getItem(i) ?: continue
+			if(itemsMatch(invItem, item)) return true
+		}
+		return false
+	}
+
+	/**
+	 * Function that compares the specified item's Material and Custom Model Data with every item in a searched inventory
+	 * (because comparing custom item stacks to modified custom items [like PA vs. PA with modules] will not work)
+	 */
+	private fun containsItem(inventory: Inventory, itemStack: ItemStack): Boolean {
+		for(item in inventory){
+			if(item == null) continue
+			if(itemsMatch(item, itemStack)) return true
+		}
+		return false
 	}
 
 	/**
 	 * Function that searches an Inventory and returns true if it contains any empty slots
 	 * basically just !isFull(inventory) if an isFull() function existed
-	 * @param inventory the inventory being searched
 	 */
 	private fun containsAir(inventory: Inventory): Boolean {
 		for (item in inventory) {
@@ -159,34 +204,13 @@ object SearchCommand : SLCommand() {
 	}
 
 	/**
-	 * Function that compares the specified item's Material and Custom Model Data with every item in a searched inventory
-	 * (because comparing custom item stacks to modified custom items [like PA vs. PA with modules] will not work)
-	 * @param inventory the inventory being searched
-	 * @param itemStack the item that's being searched
-	 */
-	private fun containsItem(inventory: Inventory, itemStack: ItemStack): Boolean {
-		for(item in inventory){
-			if(item == null) continue
-			if(item.type == itemStack.type) {
-				if( !item.itemMeta.hasCustomModelData() && !itemStack.itemMeta.hasCustomModelData() ) return true // if both don't have custom model data, return true
-
-				if ( (item.itemMeta.hasCustomModelData() && itemStack.itemMeta.hasCustomModelData()) &&
-					item.itemMeta.customModelData == itemStack.itemMeta.customModelData ) return true //if their custom model data both match, return true
-			}
-		}
-		return false
-	}
-
-	/**
 	 * Returns true if two or more items in the list of strings exist within the inventory
-	 * @param inventoryHolder the inventory being searched
-	 * @param strList the list of strings that are being compared
 	 */
-	private fun twoOrMoreMatches(inventoryHolder: InventoryHolder, strList: List<String>): Boolean {
+	private fun twoOrMoreMatches(inventory: Inventory, strList: List<String>): Boolean {
 		var counter = 0
 		for(str in strList){
 			val itemStack = GlobalCompletions.stringToItem(str) ?: continue
-			if(containsItem(inventoryHolder.inventory, itemStack)){
+			if(containsItem(inventory, itemStack)){
 				counter++
 			}
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/client/display/ClientDisplayEntities.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/client/display/ClientDisplayEntities.kt
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.monster.Slime
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.block.data.BlockData
+import org.bukkit.block.data.type.Chest
 import org.bukkit.entity.Display
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -228,6 +229,12 @@ object ClientDisplayEntities : IonServerComponent() {
 		val block = createBlockDisplay(level)
 		val offset = (-scale / 2) + 0.5
 		block.block = level.world.getBlockAt(pos.x.toInt(),pos.y.toInt(),pos.z.toInt()).blockData
+		try { // if searched container is a chest
+			val data = block.block as Chest
+			data.type = Chest.Type.SINGLE
+			block.block = data
+		}catch(_: ClassCastException) {}
+
 		block.isGlowing = true
 		block.transformation = Transformation(Vector3f(0f), Quaternionf(), Vector3f(scale), Quaternionf())
 


### PR DESCRIPTION
new features:
* typing `/itemsearch` with no parameters will now search for the item in the player's main hand

bugfixes:
* searching double chests will now display a normal chest with the type `SINGLE` instead of the `LEFT` and `RIGHT` types
 * this fixes weird culling issues with the Display Entities
* double chests are now treated as unconnected chests
 * if an item is in the top half of the inventory, it exists within the LEFT chest
 * if an item is in the bottom half of the inventory, it exists within the RIGHT chest
 * this fixes the issue of "2 containers found" always triggering for double chests