### PR TITLE
Deflate Player Heads on Discord

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Discord.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Discord.kt
@@ -86,7 +86,7 @@ fun Embed.jda(): MessageEmbed {
 	color?.let { builder.setColor(it) }
 	fields?.let { for (field in it) builder.addField(field.jda()) }
 	image?.let { builder.setImage(it) }
-	thumbnail?.let { builder.setImage(it) }
+	thumbnail?.let { builder.setThumbnail(it) }
 	author?.let { builder.setAuthor(it.name, it.url, it.icon_url) }
 	footer?.let { builder.setFooter(it.text, it.icon_url) }
 //	url?.let { builder.setUrl(url) }


### PR DESCRIPTION
In death messages, player heads are being displayed as images rather then thumbnails, this makes them rather big, distracting, and space consuming.

This PR fixes this by changing the thumbnail property to actually use `setThumbnail` rather then `setImage`, deflating player heads.