### PR TITLE
Balancing changes

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/CombatTimerCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/CombatTimerCommand.kt
@@ -11,6 +11,7 @@ import net.horizonsend.ion.common.extensions.success
 import net.horizonsend.ion.server.command.SLCommand
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.player.CombatTimer
+import net.horizonsend.ion.server.features.starship.movement.PlanetTeleportCooldown
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import org.bukkit.entity.Player
 import org.litote.kmongo.setValue
@@ -80,5 +81,53 @@ object CombatTimerCommand : SLCommand() {
 
         CombatTimer.removePvpCombatTag(player)
         sender.success("Removed PvP combat tag from $target")
+    }
+
+    @Subcommand("enterplanet give")
+    @Suppress("unused")
+    @CommandPermission("ion.combattimer")
+    @CommandCompletion("@players")
+    @Description("Restrict a player from entering planets")
+    fun onGiveEnterPlanetRestriction(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        PlanetTeleportCooldown.addEnterPlanetCooldown(player)
+        sender.success("Gave $target a planet entry cooldown")
+    }
+
+    @Subcommand("enterplanet remove")
+    @Suppress("unused")
+    @CommandPermission("ion.combattimer")
+    @CommandCompletion("@players")
+    @Description("Lift a restriction preventing a player from entering planets")
+    fun onRemoveEnterPlanetRestriction(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        PlanetTeleportCooldown.removeEnterPlanetCooldown(player)
+        sender.success("Removed planet entry cooldown from $target")
+    }
+
+    @Subcommand("exitplanet give")
+    @Suppress("unused")
+    @CommandPermission("ion.combattimer")
+    @CommandCompletion("@players")
+    @Description("Restrict a player from exiting planets")
+    fun onGiveExitPlanetRestriction(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        PlanetTeleportCooldown.addExitPlanetCooldown(player)
+        sender.success("Gave $target a planet exit cooldown")
+    }
+
+    @Subcommand("exitplanet remove")
+    @Suppress("unused")
+    @CommandPermission("ion.combattimer")
+    @CommandCompletion("@players")
+    @Description("Lift a restriction preventing a player from exiting planets")
+    fun onRemoveExitPlanetRestriction(sender: Player, target: String) {
+        val player = resolveOfflinePlayer(target)
+
+        PlanetTeleportCooldown.removeExitPlanetCooldown(player)
+        sender.success("Removed planet exit cooldown from $target")
     }
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SpaceStationCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SpaceStationCommand.kt
@@ -105,7 +105,7 @@ object SpaceStationCommand : net.horizonsend.ion.server.command.SLCommand() {
 
 		// Check conflicts with planet orbits
 		for (planet: CachedPlanet in Space.getPlanets().filter { it.spaceWorld == world }) {
-			val padding = 130
+			val padding = 500
 			val minDistance = planet.orbitDistance - padding - radius
 			val maxDistance = planet.orbitDistance + padding + radius
 			val distance = distance(x, y, z, planet.sun.location.x, y, planet.sun.location.z).toInt()
@@ -144,7 +144,7 @@ object SpaceStationCommand : net.horizonsend.ion.server.command.SLCommand() {
 			if (other.databaseId == cachedStation?.databaseId) continue
 			if (other.world != world.name) continue
 
-			val minDistance = other.radius + radius
+			val minDistance = other.radius + radius + 200
 			val distance = distance(x, y, z, other.x, y, other.z)
 
 			failIf(distance < minDistance) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SpaceStationCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/nations/SpaceStationCommand.kt
@@ -50,6 +50,7 @@ import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor.AQUA
 import net.kyori.adventure.text.format.NamedTextColor.GRAY
 import net.kyori.adventure.text.format.NamedTextColor.LIGHT_PURPLE
+import org.bukkit.Bukkit
 import org.bukkit.World
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
@@ -311,10 +312,9 @@ object SpaceStationCommand : net.horizonsend.ion.server.command.SLCommand() {
 		requirePermission(sender.slPlayerId, station, SpaceStationCache.SpaceStationPermission.MANAGE_STATION)
 		val stationName = station.name
 
-		val location = sender.location
-		val world = location.world
-		val x = location.blockX
-		val z = location.blockZ
+		val world = Bukkit.getWorld(station.world) ?: fail { "Could not find station world; please contact staff" }
+		val x = station.x
+		val z = station.z
 		checkDimensions(world, x, z, newRadius, station)
 
 		val realCost = calculateCost(station.radius, newRadius)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/StarshipInfoCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/StarshipInfoCommand.kt
@@ -1,6 +1,7 @@
 package net.horizonsend.ion.server.command.starship
 
 import co.aikar.commands.annotation.CommandAlias
+import net.horizonsend.ion.server.features.starship.Interdiction
 import net.horizonsend.ion.server.features.starship.StarshipDetection
 import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
 import net.horizonsend.ion.server.miscellaneous.utils.Vec3i
@@ -121,6 +122,7 @@ object StarshipInfoCommand : net.horizonsend.ion.server.command.SLCommand() {
 
 		sender.sendRichMessage("   <gray>Hull Integrity: <white>${ship.hullIntegrity.times(100).roundToInt()}%")
 		sender.sendRichMessage("   <gray>Center of Mass: <white>${ship.centerOfMass}")
+		sender.sendRichMessage("   <gray>Interdiction Range: <white>${Interdiction.starshipInterdictionRangeEquation(ship).toInt()}")
 
 //		val worth = blocks.values
 //			.sumOf { StarshipFactories.getPrice(it.blockData) ?: 0.0 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/powered/PowerDrill.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/powered/PowerDrill.kt
@@ -104,11 +104,6 @@ class PowerDrill(
 
 		val drops = mutableMapOf<Long, Collection<ItemStack>>()
 
-		if (CombatTimer.isPvpCombatTagged(livingEntity)) {
-			livingEntity.userError("Cannot use Power Drills while in combat")
-			return
-		}
-
 		for (block in blockList) {
 			if (availablePower < powerUse) {
 				livingEntity.alertAction("Out of power!")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/powered/PowerDrill.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/powered/PowerDrill.kt
@@ -1,6 +1,7 @@
 package net.horizonsend.ion.server.features.custom.items.powered
 
 import net.horizonsend.ion.common.extensions.alertAction
+import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.server.features.custom.blocks.CustomBlockListeners
 import net.horizonsend.ion.server.features.custom.blocks.CustomBlocks
 import net.horizonsend.ion.server.features.custom.items.CustomItem
@@ -12,6 +13,7 @@ import net.horizonsend.ion.server.features.custom.items.mods.tool.PowerUsageIncr
 import net.horizonsend.ion.server.features.custom.items.objects.CustomModeledItem
 import net.horizonsend.ion.server.features.custom.items.objects.LoreCustomItem
 import net.horizonsend.ion.server.features.custom.items.objects.ModdedCustomItem
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.miscellaneous.registrations.NamespacedKeys
 import net.horizonsend.ion.server.miscellaneous.utils.getNMSBlockData
 import net.horizonsend.ion.server.miscellaneous.utils.isShulkerBox
@@ -101,6 +103,11 @@ class PowerDrill(
 		var broken = 0
 
 		val drops = mutableMapOf<Long, Collection<ItemStack>>()
+
+		if (CombatTimer.isPvpCombatTagged(livingEntity)) {
+			livingEntity.userError("Cannot use Power Drills while in combat")
+			return
+		}
 
 		for (block in blockList) {
 			if (availablePower < powerUse) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/machine/decomposer/Decomposers.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/machine/decomposer/Decomposers.kt
@@ -7,6 +7,7 @@ import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.IonServerComponent
 import net.horizonsend.ion.server.features.multiblock.Multiblocks
 import net.horizonsend.ion.server.features.multiblock.type.misc.DecomposerMultiblock
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.miscellaneous.utils.CHISELED_TYPES
 import net.horizonsend.ion.server.miscellaneous.utils.Vec3i
 import net.horizonsend.ion.server.miscellaneous.utils.getFacing
@@ -56,6 +57,11 @@ object Decomposers : IonServerComponent() {
 			val offset = calculateOffset(origin, width, height, length, right, up, forward)
 
 			if (length == 0 || width == 0 || height == 0) return event.player.userError("Decomposer has zero volume! Make sure the chiseled blocks extend to the right of the multiblock.")
+
+			if (CombatTimer.isPvpCombatTagged(event.player)) {
+				event.player.userError("Cannot enable decomposers while in combat")
+				return
+			}
 
 //			if (offset > width) return event.player.userError("Decomposer empty!")
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/drills/DrillMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/drills/DrillMultiblock.kt
@@ -1,6 +1,7 @@
 package net.horizonsend.ion.server.features.multiblock.type.drills
 
 import net.horizonsend.ion.common.extensions.alertSubtitle
+import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.extensions.userErrorAction
 import net.horizonsend.ion.common.extensions.userErrorSubtitle
 import net.horizonsend.ion.server.features.custom.blocks.CustomBlocks
@@ -10,6 +11,7 @@ import net.horizonsend.ion.server.features.multiblock.MultiblockShape
 import net.horizonsend.ion.server.features.multiblock.type.FurnaceMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.InteractableMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.PowerStoringMultiblock
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.world.IonWorld.Companion.ion
 import net.horizonsend.ion.server.features.world.WorldFlag
 import net.horizonsend.ion.server.miscellaneous.registrations.NamespacedKeys.DRILL_USER
@@ -170,6 +172,11 @@ abstract class DrillMultiblock(tierText: String, val tierMaterial: Material) :
 			event.player.userErrorAction(
 				"You need Prismarine Crystals in both slots of the furnace!"
 			)
+			return
+		}
+
+		if (CombatTimer.isPvpCombatTagged(player)) {
+			player.userError("Cannot enable drills while in combat")
 			return
 		}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
@@ -362,6 +362,8 @@ object CombatTimer : IonServerComponent() {
 					newline(),
 					text("- Combat NPCs created when you log off will last for the duration of your combat tag", HE_LIGHT_BLUE),
 					newline(),
+					text("- Cannot use Power Drill, Drill, Mining Laser, Decomposer, or Ship Factory", HE_LIGHT_BLUE),
+					newline(),
 					text("- Remaining within ${MAINTAIN_COMBAT_DIST.toInt()} blocks of unfriendly and enemy starships will refresh your combat tag", HE_LIGHT_BLUE),
 					)),
 			newline(),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/player/CombatTimer.kt
@@ -13,6 +13,7 @@ import net.horizonsend.ion.server.IonServerComponent
 import net.horizonsend.ion.server.features.cache.PlayerCache
 import net.horizonsend.ion.server.features.nations.utils.toPlayersInRadius
 import net.horizonsend.ion.server.features.player.NewPlayerProtection.hasProtection
+import net.horizonsend.ion.server.features.starship.Interdiction
 import net.horizonsend.ion.server.features.starship.PilotedStarships
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.control.controllers.ai.AIController
@@ -85,7 +86,7 @@ object CombatTimer : IonServerComponent() {
 
 					if (pilotedStarship.isInterdicting) {
 						// Interdicting ships will place combat tags on other player starships that are within the well range, are less than neutral, and not in a protected city
-						toPlayersInRadius(starshipCom, pilotedStarship.interdictionRange.toDouble()) { otherPlayer ->
+						toPlayersInRadius(starshipCom, Interdiction.starshipInterdictionRangeEquation(pilotedStarship)) { otherPlayer ->
 							val otherStarship = PilotedStarships[otherPlayer]
 							if (otherStarship != null &&
 								!ProtectionListener.isProtectedCity(otherStarship.centerOfMass.toLocation(otherPlayer.world))) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Interdiction.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Interdiction.kt
@@ -163,5 +163,12 @@ object Interdiction : IonServerComponent() {
 		.filter { it.isIntact() }
 		.lastOrNull()
 
-	fun starshipInterdictionRangeEquation(starship: Starship) = 3000 / sqrt(12000.0) * sqrt(starship.initialBlockCount.toDouble())
+	fun starshipInterdictionRangeEquation(starship: Starship): Double {
+		if (starship.type == StarshipType.SPEEDER ||
+			starship.type == StarshipType.STARFIGHTER ||
+			starship.type == StarshipType.SHUTTLE ||
+			starship.type == StarshipType.PLATFORM) return 10.0
+		return if (starship.type.isWarship) 3000 / sqrt(12000.0) * sqrt(starship.initialBlockCount.toDouble())
+		else (3000 / sqrt(12000.0) * sqrt(starship.initialBlockCount.toDouble())) / 2
+	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Interdiction.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Interdiction.kt
@@ -24,6 +24,7 @@ import org.bukkit.block.Sign
 import org.bukkit.entity.Player
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
+import kotlin.math.sqrt
 
 object Interdiction : IonServerComponent() {
 	override fun onEnable() {
@@ -70,7 +71,7 @@ object Interdiction : IonServerComponent() {
 		when (starship.isInterdicting) {
 			true -> for (player in starship.world.getNearbyPlayers(
 				starship.centerOfMass.toLocation(starship.world),
-				starship.balancing.interdictionRange.toDouble()
+				starshipInterdictionRangeEquation(starship)
 			)) {
 				player.playSound(
 					Sound.sound(
@@ -84,7 +85,7 @@ object Interdiction : IonServerComponent() {
 
 			false -> for (player in starship.world.getNearbyPlayers(
 				starship.centerOfMass.toLocation(starship.world),
-				starship.balancing.interdictionRange.toDouble()
+				starshipInterdictionRangeEquation(starship)
 			)) {
 				player.playSound(
 					Sound.sound(
@@ -142,7 +143,7 @@ object Interdiction : IonServerComponent() {
 			val controlLoc = cruisingShip.playerPilot?.location ?: starship.centerOfMass.toLocation(starship.world)
 
 			if (controlLoc.world != sign.world) continue
-			if (controlLoc.distance(sign.location) > starship.balancing.interdictionRange) {
+			if (controlLoc.distance(sign.location) > starshipInterdictionRangeEquation(starship)) {
 				continue
 			}
 
@@ -161,4 +162,6 @@ object Interdiction : IonServerComponent() {
 	fun findGravityWell(starship: ActiveStarship): GravityWellSubsystem? = starship.gravityWells.asSequence()
 		.filter { it.isIntact() }
 		.lastOrNull()
+
+	fun starshipInterdictionRangeEquation(starship: Starship) = 3000 / sqrt(12000.0) * sqrt(starship.initialBlockCount.toDouble())
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipControl.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipControl.kt
@@ -295,7 +295,10 @@ object StarshipControl : IonServerComponent() {
 		val centerX = border?.center?.x ?: halfLength
 		val centerZ = border?.center?.z ?: halfLength
 
-		val distance = (halfLength - 250) * max(0.15, newCenter.y / starship.world.maxHeight)
+		//val distance = (halfLength - 250) * max(0.15, newCenter.y / starship.world.maxHeight)
+		// removed the y-height factor in determining the entering planet range. this should now result in
+		// planet enter positions being situated in a circle with a radius of 25% of the world border length.
+		val distance = (halfLength - 250) * 0.5
 		val offset = newCenter.toVector()
 			.subtract(planet.location.toVector())
 			.normalize().multiply(distance)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/StarshipFactories.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/StarshipFactories.kt
@@ -14,6 +14,7 @@ import net.horizonsend.ion.common.utils.text.toComponent
 import net.horizonsend.ion.server.IonServerComponent
 import net.horizonsend.ion.server.features.economy.bazaar.Merchants
 import net.horizonsend.ion.server.features.multiblock.type.misc.ShipFactoryMultiblock
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import net.horizonsend.ion.server.miscellaneous.utils.blockKey
 import net.horizonsend.ion.server.miscellaneous.utils.canAccess
@@ -63,6 +64,11 @@ object StarshipFactories : IonServerComponent() {
 
 		if (!blueprint.canAccess(player)) {
 			player.userError("You don't have access to that blueprint")
+			return
+		}
+
+		if (CombatTimer.isPvpCombatTagged(player)) {
+			player.userError("Cannot activate Ship Factories while in combat")
 			return
 		}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/hyperspace/MassShadows.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/hyperspace/MassShadows.kt
@@ -2,6 +2,7 @@ package net.horizonsend.ion.server.features.starship.hyperspace
 
 import net.horizonsend.ion.common.utils.miscellaneous.squared
 import net.horizonsend.ion.server.features.space.Space
+import net.horizonsend.ion.server.features.starship.Interdiction
 import net.horizonsend.ion.server.features.starship.PilotedStarships.getDisplayName
 import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
@@ -55,7 +56,7 @@ object MassShadows {
 			val otherZ = otherShip.centerOfMass.z
 			var dist = distanceSquared(x, 128.0, z, otherX.toDouble(), otherY.toDouble(), otherZ.toDouble())
 
-			if (dist > otherShip.interdictionRange.squared()) continue
+			if (dist > Interdiction.starshipInterdictionRangeEquation(otherShip).squared()) continue
 
 			dist = sqrt(dist)
 
@@ -70,7 +71,7 @@ object MassShadows {
 					.build(),
 				otherX,
 				otherZ,
-				otherShip.interdictionRange,
+				Interdiction.starshipInterdictionRangeEquation(otherShip).toInt(),
 				dist.toInt()
 			)
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/PlanetTeleportCooldown.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/PlanetTeleportCooldown.kt
@@ -17,8 +17,8 @@ import kotlin.collections.iterator
 
 object PlanetTeleportCooldown : IonServerComponent() {
 
-    private val ENTRY_COOLDOWN = Duration.ofMinutes(5)
-    private val EXIT_COOLDOWN = Duration.ofMinutes(5)
+    private val ENTRY_COOLDOWN = Duration.ofMinutes(2)
+    private val EXIT_COOLDOWN = Duration.ofMinutes(2)
 
     private val entryCooldown = mutableMapOf<UUID, Long>()
     private val exitCooldown = mutableMapOf<UUID, Long>()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/PlanetTeleportCooldown.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/PlanetTeleportCooldown.kt
@@ -1,0 +1,106 @@
+package net.horizonsend.ion.server.features.starship.movement
+
+import net.horizonsend.ion.common.extensions.information
+import net.horizonsend.ion.common.extensions.userError
+import net.horizonsend.ion.server.IonServer
+import net.horizonsend.ion.server.IonServerComponent
+import net.horizonsend.ion.server.features.player.CombatTimer
+import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.horizonsend.ion.server.miscellaneous.utils.listen
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.PlayerDeathEvent
+import java.lang.System
+import java.time.Duration
+import java.util.UUID
+import kotlin.collections.iterator
+
+object PlanetTeleportCooldown : IonServerComponent() {
+
+    private val ENTRY_COOLDOWN = Duration.ofMinutes(5)
+    private val EXIT_COOLDOWN = Duration.ofMinutes(5)
+
+    private val entryCooldown = mutableMapOf<UUID, Long>()
+    private val exitCooldown = mutableMapOf<UUID, Long>()
+
+    private var enabled = false
+
+    override fun onEnable() {
+        enabled = IonServer.featureFlags.combatTimers
+
+        if (!enabled) return
+
+        Tasks.syncRepeat(0L, 20L) {
+            // Remove planet entry/exit timers if enough time has elapsed
+            for (entry in entryCooldown) {
+                if (entry.value <= System.currentTimeMillis()) {
+                    entryCooldown.remove(entry.key)
+                    Bukkit.getPlayer(entry.key)?.information("You can now enter planets again")
+                }
+            }
+
+            for (entry in exitCooldown) {
+                if (entry.value <= System.currentTimeMillis()) {
+                    exitCooldown.remove(entry.key)
+                    Bukkit.getPlayer(entry.key)?.information("You can now exit planets again")
+                }
+            }
+        }
+
+        // Remove all combat tags on death
+        listen<PlayerDeathEvent> { event ->
+            if (entryCooldown[event.player.uniqueId] != null) {
+                event.player.information("You can now enter planets again")
+                entryCooldown.remove(event.player.uniqueId)
+            }
+            if (exitCooldown[event.player.uniqueId] != null) {
+                event.player.information("You can now exit planets again")
+                exitCooldown.remove(event.player.uniqueId)
+            }
+        }
+    }
+
+    fun cannotEnterPlanets(player: Player): Boolean {
+        return entryCooldown[player.uniqueId] != null
+    }
+
+    fun cannotExitPlanets(player: Player): Boolean {
+        return exitCooldown[player.uniqueId] != null
+    }
+
+    fun addEnterPlanetRestriction(player: Player) {
+        if (!enabled) return
+
+        // Only applies if the player is not in NPC combat or PVP combat
+        if (!CombatTimer.isNpcCombatTagged(player) && !CombatTimer.isPvpCombatTagged(player)) return
+
+        player.userError("You can no longer re-enter a planet for another ${ENTRY_COOLDOWN.toMinutes()} minutes")
+        addEnterPlanetCooldown(player.uniqueId)
+    }
+
+    fun addExitPlanetRestriction(player: Player) {
+        if (!enabled) return
+
+        // Only applies if the player is not in NPC combat or PVP combat
+        if (!CombatTimer.isNpcCombatTagged(player) && !CombatTimer.isPvpCombatTagged(player)) return
+
+        player.userError("You can no longer re-exit a planet for another ${EXIT_COOLDOWN.toMinutes()} minutes")
+        addExitPlanetCooldown(player.uniqueId)
+    }
+
+    fun addEnterPlanetCooldown(uuid: UUID) {
+        entryCooldown[uuid] = System.currentTimeMillis() + ENTRY_COOLDOWN.toMillis()
+    }
+
+    fun addExitPlanetCooldown(uuid: UUID) {
+        exitCooldown[uuid] = System.currentTimeMillis() + EXIT_COOLDOWN.toMillis()
+    }
+
+    fun removeEnterPlanetCooldown(uuid: UUID) {
+        entryCooldown.remove(uuid)
+    }
+
+    fun removeExitPlanetCooldown(uuid: UUID) {
+        exitCooldown.remove(uuid)
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
@@ -326,6 +326,14 @@ abstract class StarshipMovement(val starship: ActiveStarship, val newWorld: Worl
 			return false
 		}
 
+		// Don't allow players that have recently exited planets to re-exit again
+		val controller = starship.controller
+		if (controller is PlayerController) {
+			if (PlanetTeleportCooldown.cannotExitPlanets(controller.player)) return false
+			// Restrict planet exit if combat tagged
+			PlanetTeleportCooldown.addExitPlanetRestriction(controller.player)
+		}
+
 		val blockCountSquareRoot = sqrt(starship.initialBlockCount.toDouble())
 		val distance: Double = 15 + (planet.atmosphereRadius + blockCountSquareRoot) * 1.5
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
@@ -315,8 +315,16 @@ abstract class StarshipMovement(val starship: ActiveStarship, val newWorld: Worl
 		if (starship.isTeleporting) return false
 
 		val planet: CachedPlanet = Space.getPlanet(world) ?: return false
-		val pilot: Player = starship.playerPilot ?: return false
-		val direction: Vector = pilot.location.direction
+
+		val border = planet.planetWorld?.worldBorder
+			?.takeIf { it.size < 60_000_000 } // don't use if it's the default, giant border
+		val halfLength = if (border == null) 2500.0 else border.size / 2.0
+		val centerX = border?.center?.x ?: halfLength
+		val centerZ = border?.center?.z ?: halfLength
+
+		val shipCenter = starship.centerOfMass.toVector().setY(0)
+
+		val direction: Vector = shipCenter.clone().subtract(Vector(centerX, 0.0, centerZ))
 		direction.setY(0)
 		direction.normalize()
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/MiningLaserSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/MiningLaserSubsystem.kt
@@ -4,6 +4,7 @@ import fr.skytasul.guardianbeam.Laser.CrystalLaser
 import net.horizonsend.ion.common.extensions.alertSubtitle
 import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.extensions.informationAction
+import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.extensions.userErrorSubtitle
 import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.configuration.StarshipWeapons
@@ -11,8 +12,10 @@ import net.horizonsend.ion.server.features.machine.AreaShields
 import net.horizonsend.ion.server.features.machine.PowerMachines
 import net.horizonsend.ion.server.features.multiblock.type.drills.DrillMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.mininglasers.MiningLaserMultiblock
+import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
+import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
 import net.horizonsend.ion.server.features.starship.damager.Damager
 import net.horizonsend.ion.server.features.starship.event.build.StarshipBreakBlockEvent
 import net.horizonsend.ion.server.features.starship.subsystem.DirectionalSubsystem
@@ -225,6 +228,13 @@ class MiningLaserSubsystem(
 
 		if (power == 0) {
 			starship.alertSubtitle("Mining Laser at ${sign.block.x}, ${sign.block.y}, ${sign.block.z} ran out of power and was disabled!")
+
+			setFiring(false)
+			return
+		}
+
+		if (controller is PlayerController && CombatTimer.isPvpCombatTagged(controller.player)) {
+			starship.userError("Cannot enable Mining Lasers while in combat")
 
 			setFiring(false)
 			return

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/MiningLaserSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/MiningLaserSubsystem.kt
@@ -4,7 +4,6 @@ import fr.skytasul.guardianbeam.Laser.CrystalLaser
 import net.horizonsend.ion.common.extensions.alertSubtitle
 import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.extensions.informationAction
-import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.extensions.userErrorSubtitle
 import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.configuration.StarshipWeapons
@@ -12,10 +11,8 @@ import net.horizonsend.ion.server.features.machine.AreaShields
 import net.horizonsend.ion.server.features.machine.PowerMachines
 import net.horizonsend.ion.server.features.multiblock.type.drills.DrillMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.mininglasers.MiningLaserMultiblock
-import net.horizonsend.ion.server.features.player.CombatTimer
 import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
 import net.horizonsend.ion.server.features.starship.active.ActiveStarships
-import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
 import net.horizonsend.ion.server.features.starship.damager.Damager
 import net.horizonsend.ion.server.features.starship.event.build.StarshipBreakBlockEvent
 import net.horizonsend.ion.server.features.starship.subsystem.DirectionalSubsystem
@@ -228,13 +225,6 @@ class MiningLaserSubsystem(
 
 		if (power == 0) {
 			starship.alertSubtitle("Mining Laser at ${sign.block.x}, ${sign.block.y}, ${sign.block.z} ran out of power and was disabled!")
-
-			setFiring(false)
-			return
-		}
-
-		if (controller is PlayerController && CombatTimer.isPvpCombatTagged(controller.player)) {
-			starship.userError("Cannot enable Mining Lasers while in combat")
 
 			setFiring(false)
 			return

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
@@ -79,6 +79,7 @@ import net.horizonsend.ion.server.features.starship.factory.StarshipFactories
 import net.horizonsend.ion.server.features.starship.fleet.Fleets
 import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
 import net.horizonsend.ion.server.features.starship.hyperspace.HyperspaceBeacons
+import net.horizonsend.ion.server.features.starship.movement.PlanetTeleportCooldown
 import net.horizonsend.ion.server.features.starship.subsystem.shield.StarshipShields
 import net.horizonsend.ion.server.features.transport.Extractors
 import net.horizonsend.ion.server.features.transport.TransportConfig
@@ -211,4 +212,5 @@ val components: List<IonComponent> = listOf(
 	ContactsJammingSidebar,
 	CombatTimer,
 	Halloweeeeeen,
+	PlanetTeleportCooldown,
 )


### PR DESCRIPTION
### Balancing
- Starships cannot enter or exit planet if the player is combat tagged and the player has previously entered or exited the planet in the past 2 minutes
- Cannot build in the path of a planet's orbit within 500 blocks, unless within a space station
- Cannot claim space stations within `130 -> 500` blocks of a planet's orbit
- Cannot claim space stations within 200 blocks of another space station
- Ship drills, decomposers, and ship factories cannot be used while in combat
- Interdiction range is now based on an equation
- Improved the consistency of planet entry and exit positions

### Bug fixes
- Fixed a bug where resizing stations did not work as intended