### PR TITLE
gravity well cooldown and duration

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -41,6 +41,7 @@ import net.horizonsend.ion.server.features.space.Space
 import net.horizonsend.ion.server.features.starship.AutoTurretTargeting
 import net.horizonsend.ion.server.features.starship.DeactivatedPlayerStarships
 import net.horizonsend.ion.server.features.starship.Interdiction
+import net.horizonsend.ion.server.features.starship.Interdiction.handleGravityWell
 import net.horizonsend.ion.server.features.starship.Interdiction.toggleGravityWell
 import net.horizonsend.ion.server.features.starship.PilotedStarships
 import net.horizonsend.ion.server.features.starship.StarshipSchematic
@@ -707,7 +708,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		val starship = getStarshipPiloting(sender)
 		Interdiction.findGravityWell(starship) ?: fail { "Intact gravity well not found!" }
 
-		toggleGravityWell(starship)
+		handleGravityWell(starship)
 	}
 
 	@Suppress("unused")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/GravityWellSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/GravityWellSubsystem.kt
@@ -4,6 +4,15 @@ import net.horizonsend.ion.server.features.multiblock.type.gravitywell.GravityWe
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.subsystem.AbstractMultiblockSubsystem
 import org.bukkit.block.Sign
+import java.time.Duration
+import kotlin.math.cbrt
+import kotlin.math.pow
 
-class GravityWellSubsystem(starship: ActiveStarship, sign: Sign, multiblock: GravityWellMultiblock) :
-	AbstractMultiblockSubsystem<GravityWellMultiblock>(starship, sign, multiblock)
+class GravityWellSubsystem(starship: ActiveStarship, sign: Sign, multiblock: GravityWellMultiblock
+) : AbstractMultiblockSubsystem<GravityWellMultiblock>(starship, sign, multiblock){
+		val baseCooldown = Duration.ofMinutes(10).toMillis()
+		val baseDuration = Duration.ofMinutes(5).toMillis()
+		val shipSizeModifier = cbrt(500.0)
+		var activatedTimer = 0L
+		var cooldownTimer = 0L
+}


### PR DESCRIPTION
Gravity Wells are now subject to a duration and a cooldown.
When a well as activated two timers are started, one for the max duration of the well and one for the cooldown. 
A well will turn off after the duration timer runs out, and will not be able to be turned on until the cooldown timer runs out. 

Both timers scale with the cube root of the ships block size. With a 500 block ship having a well of 5 min and a cooldown of 10 min.
A 4k will then have a well of 10min and a cooldown of 5 min. 
Values are adjustable- possible to drop the cooldown to 0 past a certain threshold. 

The main purpose of this pr is to allow ships to leave engagements against small ships when neither ship can reach a decisive victory (as it happens alot with piracy).