### PR TITLE
fix for custom turret rendering

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/client/display/modular/BlockDisplayWrapper.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/client/display/modular/BlockDisplayWrapper.kt
@@ -69,6 +69,7 @@ class BlockDisplayWrapper(
 		teleportDuration = 1
 		interpolationDuration = 1
 		viewRange = 1000f
+		brightness = org.bukkit.entity.Display.Brightness(15, 15)
 
 		transformation = Transformation(
 			offset.toVector3f(),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
@@ -41,7 +41,6 @@ import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERG
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_PURPLE
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_RED
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_YELLOW
-import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_BLACK
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENRICHED_URANIUM
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENRICHED_URANIUM_BLOCK
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.EXTENDED_BAR
@@ -206,7 +205,6 @@ import org.bukkit.Material.STRING
 import org.bukkit.Material.TRIPWIRE_HOOK
 import org.bukkit.Material.TURTLE_EGG
 import org.bukkit.Material.VERDANT_FROGLIGHT
-import org.bukkit.Material.WITHER_ROSE
 import org.bukkit.NamespacedKey
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.inventory.FurnaceRecipe
@@ -790,7 +788,6 @@ object Crafting : IonServerComponent() {
 		registerSwordRecipes(ENERGY_SWORD_PURPLE, ExactChoice(CHETHERITE.constructItemStack()))
 		registerSwordRecipes(ENERGY_SWORD_ORANGE, RecipeChoice.MaterialChoice(COPPER_INGOT))
 		registerSwordRecipes(ENERGY_SWORD_PINK, RecipeChoice.MaterialChoice(PINK_TULIP))
-		registerSwordRecipes(ENERGY_SWORD_BLACK, RecipeChoice.MaterialChoice(WITHER_ROSE))
 	}
 
 	// Different names due to signature problems from type erasure

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
@@ -41,6 +41,7 @@ import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERG
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_PURPLE
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_RED
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_YELLOW
+import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENERGY_SWORD_BLACK
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENRICHED_URANIUM
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.ENRICHED_URANIUM_BLOCK
 import net.horizonsend.ion.server.features.custom.items.CustomItemRegistry.EXTENDED_BAR
@@ -205,6 +206,7 @@ import org.bukkit.Material.STRING
 import org.bukkit.Material.TRIPWIRE_HOOK
 import org.bukkit.Material.TURTLE_EGG
 import org.bukkit.Material.VERDANT_FROGLIGHT
+import org.bukkit.Material.WITHER_ROSE
 import org.bukkit.NamespacedKey
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.inventory.FurnaceRecipe
@@ -788,6 +790,7 @@ object Crafting : IonServerComponent() {
 		registerSwordRecipes(ENERGY_SWORD_PURPLE, ExactChoice(CHETHERITE.constructItemStack()))
 		registerSwordRecipes(ENERGY_SWORD_ORANGE, RecipeChoice.MaterialChoice(COPPER_INGOT))
 		registerSwordRecipes(ENERGY_SWORD_PINK, RecipeChoice.MaterialChoice(PINK_TULIP))
+		registerSwordRecipes(ENERGY_SWORD_BLACK, RecipeChoice.MaterialChoice(WITHER_ROSE))
 	}
 
 	// Different names due to signature problems from type erasure


### PR DESCRIPTION
added a "brightness" value under the .apply for the block entities that make up the turret model, set it to 15 for both sky and block brightness. this will prevent the custom turrets appearing black when the ship is active, i plan on testing custom light levels for the turret based on the light surrounding it upon ship redection, unsure if it will look good, need to test it.