### PR TITLE
Typo fix for when jump coordinates are outside of the world border

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -335,7 +335,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		}
 
 		failIf(!destinationWorld.worldBorder.isInside(Location(destinationWorld, x.toDouble(), 128.0, z.toDouble()))) {
-			"Destination coordinates are outside the world order"
+			"Destination coordinates are outside the world border!"
 		}
 
 		val massShadowInfo = MassShadows.find(


### PR DESCRIPTION
this is such a little thing, but it is something i am able to help with :)

i changed the message "Destination coordinates are outside the world order"
to "Destination coordinates are outside the world border!"