### PR TITLE
LC power consumption 240 -> 600

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/StarshipTypeBalancing.kt
@@ -1014,7 +1014,7 @@ class StarshipWeapons(
 				volume = 10,
 				pitch = 2.0f,
 				soundName = "entity.firework_rocket.blast_far",
-				powerUsage = 240,
+				powerUsage = 600,
 				length = 2,
 				angleRadiansHorizontal = 17.0,
 				angleRadiansVertical = 17.0,


### PR DESCRIPTION
Temporary nerf to LCs, puts them on par with other ships at 1k only. 
They will be worse than normal weapons on every other ship.