### PR TITLE
ai reward capping

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AICreditRewardProvider.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AICreditRewardProvider.kt
@@ -20,11 +20,12 @@ open class AICreditRewardProvider(override val starship: ActiveStarship, val con
 	override val log: Logger = LoggerFactory.getLogger(javaClass)
 
 	override fun processDamagerRewards(
-		damager: PlayerDamager,
-		topDamagerPoints: AtomicInteger,
-		points: AtomicInteger,
-		pointsSum: Int
-	) {
+        damager: PlayerDamager,
+        topDamagerPoints: AtomicInteger,
+        points: AtomicInteger,
+        pointsSum: Int,
+        penalty: Double
+    ) {
 		val difficultyMultiplier = (starship.controller as? AIController)?.getCoreModuleByType<DifficultyModule>()?.rewardMultiplier ?: 1.0
 		val topPercent = topDamagerPoints.get().toDouble() / pointsSum.toDouble()
 		debugAudience.debug("topPercent: $topPercent")
@@ -32,7 +33,7 @@ open class AICreditRewardProvider(override val starship: ActiveStarship, val con
 		debugAudience.debug("killStreakBonus: $killStreakBonus")
 		val percent = points.get().toDouble() / pointsSum.toDouble()
 		debugAudience.debug("percent: $percent")
-		val money = configuration.creditReward * percent / topPercent * difficultyMultiplier * killStreakBonus
+		val money = configuration.creditReward * percent / topPercent * difficultyMultiplier * killStreakBonus * penalty
 
 		if (money <= 0.0) return
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIItemBagRewardProvider.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIItemBagRewardProvider.kt
@@ -1,16 +1,12 @@
 package net.horizonsend.ion.server.features.ai.reward
 
-import io.papermc.paper.util.ItemComponentSanitizer.override
 import net.horizonsend.ion.common.utils.miscellaneous.randomDouble
-import net.horizonsend.ion.common.utils.miscellaneous.randomFloat
-import net.horizonsend.ion.common.utils.miscellaneous.testRandom
 import net.horizonsend.ion.common.utils.text.template
 import net.horizonsend.ion.server.command.GlobalCompletions.fromItemString
+import net.horizonsend.ion.server.command.GlobalCompletions.toItemString
 import net.horizonsend.ion.server.features.ai.configuration.AITemplate
 import net.horizonsend.ion.server.features.ai.module.misc.DifficultyModule
-import net.horizonsend.ion.server.features.ai.spawning.ships.SpawnedShip
 import net.horizonsend.ion.server.features.economy.bazaar.Bazaars
-import net.horizonsend.ion.server.features.progression.ShipKillXP
 import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
 import net.horizonsend.ion.server.features.starship.control.controllers.ai.AIController
 import net.horizonsend.ion.server.features.starship.damager.PlayerDamager
@@ -22,7 +18,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Supplier
-import kotlin.math.cbrt
 
 class AIItemBagRewardProvider(
 	override val starship: ActiveControlledStarship,
@@ -31,15 +26,17 @@ class AIItemBagRewardProvider(
 	override val log: Logger = LoggerFactory.getLogger(javaClass)
 
 	override fun processDamagerRewards(
-		damager: PlayerDamager,
-		topDamagerPoints: AtomicInteger,
-		points: AtomicInteger,
-		pointsSum: Int) {
+        damager: PlayerDamager,
+        topDamagerPoints: AtomicInteger,
+        points: AtomicInteger,
+        pointsSum: Int,
+        penalty: Double
+    ) {
 		val difficultyMultiplier = (starship.controller as? AIController)?.getCoreModuleByType<DifficultyModule>()?.rewardMultiplier ?: 1.0
 		val topPercent = topDamagerPoints.get().toDouble() / pointsSum.toDouble()
 		val killStreakBonus = AIKillStreak.getHeatMultiplier(damager.player)
 		val percent = points.get().toDouble() / pointsSum.toDouble()
-		val score = ((percent / topPercent) * difficultyMultiplier * killStreakBonus)
+		val score = ((percent / topPercent) * difficultyMultiplier * killStreakBonus) * penalty
 		if (score <= 0) return
 
 		val maxBagSize = configuration.maxBagSize * score
@@ -66,7 +63,7 @@ class AIItemBagRewardProvider(
 
 	private fun getItems(budget : Double): Set<ItemStack> {
 		var points = budget
-		val bag = mutableSetOf<ItemStack>()//TODO: Combine items into one itemstack
+		val bag = mutableSetOf<ItemStack>()
 
 		val items = getItems()
 
@@ -80,7 +77,13 @@ class AIItemBagRewardProvider(
 
 			val stack = stackSupplier.get()
 			if (stack.isEmpty) continue
-			bag += stack
+			val existing = bag.firstOrNull {toItemString(it) == toItemString(stack)}
+			if (existing != null) {
+				existing.amount += 1
+				continue
+			} else {
+				bag += stack
+			}
 		}
 
 		return bag

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIKillStreakRewardProvider.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIKillStreakRewardProvider.kt
@@ -9,7 +9,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.cbrt
-import kotlin.math.sqrt
 
 class AIKillStreakRewardProvider(override val starship: ActiveStarship, val configuration: AITemplate.KillStreakRewardProviderConfiguration) : AIRewardsProvider {
 	override val log: Logger = LoggerFactory.getLogger(javaClass)
@@ -18,7 +17,8 @@ class AIKillStreakRewardProvider(override val starship: ActiveStarship, val conf
 		damager: PlayerDamager,
 		topDamagerPoints: AtomicInteger,
 		points: AtomicInteger,
-		pointsSum: Int
+		pointsSum: Int,
+		penalty: Double
 	) {
 		val killedSize = starship.initialBlockCount.toDouble()
 		val damagerSize = (damager.starship?.initialBlockCount ?: 2000).toDouble()
@@ -26,7 +26,7 @@ class AIKillStreakRewardProvider(override val starship: ActiveStarship, val conf
 		val difficultyMultiplier = (starship.controller as? AIController)?.getCoreModuleByType<DifficultyModule>()?.rewardMultiplier ?: 1.0
 		val topPercent = topDamagerPoints.get().toDouble() / pointsSum.toDouble()
 		val percent = points.get().toDouble() / pointsSum.toDouble()
-		val score = (ratio * (percent / topPercent) * configuration.streakMultiplier * difficultyMultiplier).toInt()
+		val score = (ratio * (percent / topPercent) * configuration.streakMultiplier * difficultyMultiplier * penalty).toInt()
 
 		if (score <= 0) return
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIRewardCap.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIRewardCap.kt
@@ -1,0 +1,70 @@
+package net.horizonsend.ion.server.features.ai.reward
+
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_BLUE
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.common.utils.text.template
+import net.horizonsend.ion.server.core.IonServerComponent
+import net.horizonsend.ion.server.features.starship.Starship
+import net.horizonsend.ion.server.features.starship.damager.PlayerDamager
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.entity.Player
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.set
+import kotlin.math.cbrt
+
+object AIRewardCap : IonServerComponent() {
+	private val playerScores: MutableMap<UUID, Int> = mutableMapOf()
+	private const val MAX_SCORE = 1000
+	private const val PENALTY = 0.5
+	const val MAX_CAP_MULTIPLIER = 2
+	const val SHIP_SIZE_MULTIPLIER = 4.0
+
+
+	fun getPenalty(player: Player): Double {
+		val score = playerScores[player.uniqueId] ?: 0
+		if (score <= MAX_SCORE) {
+			return 1.0
+		}
+		if (score > MAX_SCORE * MAX_CAP_MULTIPLIER) {
+			return 0.0
+		}
+		return PENALTY
+	}
+
+	fun addToCap(player: Player, score: Int) {
+		val entry = playerScores[player.uniqueId]
+
+		if (entry == null) {
+			playerScores[player.uniqueId] = 0
+		} else {
+			playerScores[player.uniqueId] = score + entry
+		}
+
+		val penalty = getPenalty(player)
+		if (penalty < 1.0) {
+			player.sendMessage(template(
+				message = Component.text("Due to overzealous sinking rewards are reduced by {0}% {1}.", NamedTextColor.DARK_RED),
+				paramColor = NamedTextColor.RED,
+				"%.0f".format((1 - penalty) * 100),
+				text("[Details]", HE_LIGHT_BLUE).hoverEvent(text("The cap resets every server restart"))
+			))
+		}
+	}
+
+	fun processDamager(
+		starship: Starship,
+		damager: PlayerDamager,
+		points: AtomicInteger,
+		pointsSum: Int
+	) {
+		val killedSize = starship.initialBlockCount.toDouble()
+		val percent = points.get().toDouble() / pointsSum.toDouble()
+		val score = (cbrt(killedSize) * SHIP_SIZE_MULTIPLIER * percent).toInt()
+
+		if (score <= 0) return
+		addToCap(damager.player, score)
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIRewardsProvider.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIRewardsProvider.kt
@@ -49,7 +49,10 @@ interface AIRewardsProvider : RewardsProvider {
 			debugAudience.debug("points: ${points.get()}, player : ${player.name}")
 
 			try {
-				processDamagerRewards(damager, topDamager!!.value.points, points, sum)
+				AIRewardCap.processDamager(starship,damager,points,sum)
+				val penalty = AIRewardCap.getPenalty(damager.player)
+				if (penalty == 0.0) continue
+				processDamagerRewards(damager, topDamager!!.value.points, points, sum, penalty)
 			} catch (e: Throwable) {
 				log.error("Exception processing damager rewards: ${e.message}!")
 				e.printStackTrace()
@@ -63,7 +66,8 @@ interface AIRewardsProvider : RewardsProvider {
 		damager: PlayerDamager,
 		topDamagerPoints: AtomicInteger,
 		points: AtomicInteger,
-		pointsSum: Int
+		pointsSum: Int,
+		penalty: Double
 	) {
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIXPRewardProvider.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIXPRewardProvider.kt
@@ -18,18 +18,19 @@ class AIXPRewardProvider(override val starship: ActiveStarship, val configuratio
 	override val log: Logger = LoggerFactory.getLogger(javaClass)
 
 	override fun processDamagerRewards(
-		damager: PlayerDamager,
-		topDamagerPoints: AtomicInteger,
-		points: AtomicInteger,
-		pointsSum: Int
-	) {
+        damager: PlayerDamager,
+        topDamagerPoints: AtomicInteger,
+        points: AtomicInteger,
+        pointsSum: Int,
+        penalty: Double
+    ) {
 		val killedSize = starship.initialBlockCount.toDouble()
 		val difficultyMultiplier = (starship.controller as? AIController)?.getCoreModuleByType<DifficultyModule>()?.rewardMultiplier ?: 1.0
 		val killStreakBonus = AIKillStreak.getHeatMultiplier(damager.player)
 		val topPercent = topDamagerPoints.get().toDouble() / pointsSum.toDouble()
 		val percent = points.get().toDouble() / pointsSum.toDouble()
 		val xp = ((sqrt(killedSize.pow(2.0) / sqrt(killedSize * 0.00005)))
-			* (percent / topPercent) * configuration.xpMultiplier * difficultyMultiplier * killStreakBonus).toInt()
+			* (percent / topPercent) * configuration.xpMultiplier * difficultyMultiplier * killStreakBonus * penalty).toInt()
 
 		if (xp <= 0) return
 


### PR DESCRIPTION
reduced ai rewards by 50% when a score of 1000 is reached and to 100% when a score of 2000 is reached.
