### PR TITLE
Vertical Cruise

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -576,7 +576,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		val controller = ActiveStarships.findByPilot(sender)?.controller ?: return
 
 		if (!StarshipCruising.isCruisingAndAccelerating(ship)) {
-			val dir = sender.location.direction.setY(0).normalize()
+			val dir = sender.location.direction.normalize()
 
 			StarshipCruising.startCruising(controller, ship, dir)
 		} else {


### PR DESCRIPTION
Intentionally Command-only

A really minor commit but I might add more later if:
- we want it on signs too (would be kinda hard to use in this case)
- it should require enabling a setting to use
- we want straight up/down cruise (needs vertical thruster multiblock detection)
- or the 1-line change just doesn't work