### PR TITLE
Fix citizens URL and pin ProtocolLib ver instead of using dev build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val serverPlugins = listOf(
 		name = "ProtocolLib",
 		mode = PluginMode.REQUIRED,
 		downloadType = DownloadType.GITHUB_RELEASE_TAG,
-		tag = "dev-build",
+		tag = "5.4.0",
 		jarName = "ProtocolLib.jar",
 		source = "dmulloy2/ProtocolLib",
 		assetName = "ProtocolLib.jar"
@@ -44,7 +44,7 @@ val serverPlugins = listOf(
 		mode = PluginMode.EXTENDED,
 		downloadType = DownloadType.DIRECT,
 		jarName = "Citizens.jar",
-		source = "https://ci.citizensnpcs.co/job/Citizens2/lastSuccessfulBuild/artifact/dist/target/Citizens-2.0.41-b4134.jar"
+		source = "https://ci.citizensnpcs.co/view/Citizens/job/Citizens2/4134/artifact/dist/target/Citizens-2.0.41-b4134.jar"
 	),
 	ServerPlugin(
 		name = "LuckPerms",


### PR DESCRIPTION
When i synced my fork with HorizonsEndMC/Ion main after the 1.21.11 update and attempted to use the setup script it seemed fine at first but in the paper shell Ion wasn't loading because of a ProtocolLib mismatch so i pinned it to a non dev build version which works for 1.21.11 and ProtocolLib was no longer being an issue for Ion loading. Citizens was another issue it hadn't downloaded at all to run/paper/plugins using the link in build gradle so i went to jenkins and grabbed a fresh URL for the same jar and after that the setup script and Ion loading had no issues for my test server.