### PR TITLE
Environment fixes + new end look

### DIFF
--- a/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/overworld.json
+++ b/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/overworld.json
@@ -1,19 +1,31 @@
 {
-	"name": "overworld",
 	"min_y": 0,
 	"height": 384,
-	"ultrawarm": false,
-	"respawn_anchor_works": false,
-	"piglin_safe": false,
-	"natural": true,
 	"logical_height": 384,
+
+	"skybox": "overworld",
+	"cardinal_light": "default",
+	"timelines": "#minecraft:in_overworld",
+	"attributes": {
+		"minecraft:gameplay/bed_rule": {
+			"can_set_spawn": "always",
+			"can_sleep": "when_dark",
+			"error_message": {
+				"translate": "block.minecraft.bed.no_sleep"
+			}
+		},
+		"minecraft:gameplay/respawn_anchor_works": false,
+		"minecraft:gameplay/nether_portal_spawns_piglin": false,
+		"minecraft:visual/cloud_color": "#ccffffff",
+		"minecraft:visual/cloud_height": 256.33,
+		"minecraft:visual/fog_color": "#c0d8ff",
+		"minecraft:visual/sky_color": "#78a7ff"
+	},
 	"infiniburn": "#infiniburn_overworld",
+
 	"has_skylight": true,
-	"has_raids": true,
 	"has_ceiling": false,
-	"effects": "minecraft:overworld",
 	"coordinate_scale": 1.0,
-	"bed_works": true,
 	"ambient_light": 0.0,
 	"monster_spawn_block_light_limit": 0,
 	"monster_spawn_light_level": {

--- a/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/overworld.json
+++ b/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/overworld.json
@@ -6,6 +6,7 @@
 	"skybox": "overworld",
 	"cardinal_light": "default",
 	"timelines": "#minecraft:in_overworld",
+	"has_fixed_time": false,
 	"attributes": {
 		"minecraft:gameplay/bed_rule": {
 			"can_set_spawn": "always",

--- a/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_end.json
+++ b/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_end.json
@@ -6,11 +6,11 @@
 	"has_skylight": true,
 	"has_ceiling": false,
 	"has_fixed_time": true,
-	"ambient_light": 0.25,
+	"ambient_light": 0.0,
 
 	"skybox": "end",
 	"cardinal_light": "default",
-	"timelines": "#minecraft:in_overworld",
+	"timelines": "#minecraft:in_end",
 
 	"attributes": {
 		"minecraft:gameplay/bed_rule": {
@@ -21,8 +21,8 @@
 		"minecraft:gameplay/respawn_anchor_works": false,
 		"minecraft:visual/fog_color": "#0c0c14",
 		"minecraft:visual/sky_color": "#000000",
-		"minecraft:visual/sky_light_color": "#434c4c",
-		"minecraft:visual/sky_light_factor": 0.0
+		"minecraft:visual/sky_light_color": "#ffffff",
+		"minecraft:visual/sky_light_factor": 1.0
 	},
 
 

--- a/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_end.json
+++ b/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_end.json
@@ -1,20 +1,33 @@
 {
-	"name": "the_end",
 	"min_y": 0,
 	"height": 384,
-	"ultrawarm": false,
-	"respawn_anchor_works": false,
-	"piglin_safe": false,
-	"natural": false,
 	"logical_height": 384,
-	"infiniburn": "#infiniburn_end",
-	"has_skylight": false,
-	"has_raids": false,
+
+	"has_skylight": true,
 	"has_ceiling": false,
-	"effects": "minecraft:the_end",
+	"has_fixed_time": true,
+	"ambient_light": 0.25,
+
+	"skybox": "end",
+	"cardinal_light": "default",
+	"timelines": "#minecraft:in_overworld",
+
+	"attributes": {
+		"minecraft:gameplay/bed_rule": {
+			"can_set_spawn": "never",
+			"can_sleep": "never",
+			"explodes": false
+		},
+		"minecraft:gameplay/respawn_anchor_works": false,
+		"minecraft:visual/fog_color": "#0c0c14",
+		"minecraft:visual/sky_color": "#000000",
+		"minecraft:visual/sky_light_color": "#434c4c",
+		"minecraft:visual/sky_light_factor": 0.0
+	},
+
+
 	"coordinate_scale": 1.0,
-	"bed_works": false,
-	"ambient_light": 0.0,
+	"infiniburn": "#minecraft:infiniburn_end",
 	"monster_spawn_block_light_limit": 0,
 	"monster_spawn_light_level": {
 		"type": "minecraft:uniform",

--- a/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_end.json
+++ b/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_end.json
@@ -6,7 +6,7 @@
 	"has_skylight": true,
 	"has_ceiling": false,
 	"has_fixed_time": true,
-	"ambient_light": 0.0,
+	"ambient_light": 0.1,
 
 	"skybox": "end",
 	"cardinal_light": "default",
@@ -22,7 +22,7 @@
 		"minecraft:visual/fog_color": "#0c0c14",
 		"minecraft:visual/sky_color": "#000000",
 		"minecraft:visual/sky_light_color": "#ffffff",
-		"minecraft:visual/sky_light_factor": 1.0
+		"minecraft:visual/sky_light_factor": 0.95
 	},
 
 

--- a/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_nether.json
+++ b/run/config/paper/world/datapacks/horizonsend/data/minecraft/dimension_type/the_nether.json
@@ -1,20 +1,45 @@
 {
-	"name": "the_nether",
 	"min_y": 0,
 	"height": 384,
-	"ultrawarm": true,
-	"respawn_anchor_works": true,
-	"piglin_safe": true,
-	"natural": false,
 	"logical_height": 384,
-	"infiniburn": "#infiniburn_nether",
+
 	"has_skylight": false,
-	"has_raids": false,
 	"has_ceiling": false,
+	"has_fixed_time": true,
+	"ambient_light": 0.25,
+
+	"skybox": "none",
+	"cardinal_light": "nether",
+	"timelines": "#minecraft:in_nether",
+
+	"attributes": {
+		"minecraft:gameplay/bed_rule": {
+			"can_set_spawn": "never",
+			"can_sleep": "never",
+			"explodes": false
+		},
+		"minecraft:gameplay/can_start_raid": false,
+		"minecraft:gameplay/fast_lava": true,
+		"minecraft:gameplay/piglins_zombify": false,
+		"minecraft:gameplay/respawn_anchor_works": false,
+		"minecraft:gameplay/sky_light_level": 4.0,
+		"minecraft:gameplay/snow_golem_melts": false,
+		"minecraft:gameplay/water_evaporates": false,
+		"minecraft:visual/default_dripstone_particle": {
+			"type": "minecraft:dripping_dripstone_lava"
+		},
+		"minecraft:visual/fog_end_distance": 96.0,
+		"minecraft:visual/fog_start_distance": 10.0,
+		"minecraft:visual/sky_light_color": "#7a7aff",
+		"minecraft:visual/sky_light_factor": 0.0
+	},
+
+
+	"infiniburn": "#infiniburn_nether",
+	"has_raids": false,
 	"effects": "minecraft:the_nether",
 	"coordinate_scale": 1.0,
-	"bed_works": false,
-	"ambient_light": 0.1,
+
 	"monster_spawn_block_light_limit": 15,
 	"monster_spawn_light_level": 11
 }


### PR DESCRIPTION
<img width="2560" height="1494" alt="2026-05-06_13 39 14" src="https://github.com/user-attachments/assets/1aee326d-083a-47dc-bb0e-e069616cbebb" />
fixes for 1.21.11, the end is now overworld bright with softer shadows.