### PR TITLE
flawed-fix-to-700-dc-decrease

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -461,7 +461,7 @@ class Starship(
 	var directControlCenter: Location? = null
 
 	// Stored on starship so it can't be reset by switching to dc and back
-	val initialDirectControlCooldown get() = 300L + ((initialBlockCount / 700)/*.coerceAtLeast(1)*/) * 30
+	val initialDirectControlCooldown get() = 300L + ((initialBlockCount / 700)/*.coerceAtLeast(1)*/) * 50
 	var directControlCooldown = initialDirectControlCooldown
 
 	fun setDirectControlEnabled(enabled: Boolean) {


### PR DESCRIPTION
It changes the increasing 30ms interval to be 50ms which matches the 50ms bracket created by 20TPS conditions, every 700 blocks will now not merge into each others brackets at 20TPs conditions due to rounding up. DC would need a rewrite to be foolproof but this will enforce the per +700 decrease for every size at 20tps, TPS will still degrade the integrity of the bps lowering for some sizes the lower TPS goes regardless. 