### PR TITLE
ai balancing

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AICreditRewardProvider.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AICreditRewardProvider.kt
@@ -5,7 +5,10 @@ import net.horizonsend.ion.common.utils.text.template
 import net.horizonsend.ion.common.utils.text.toCreditComponent
 import net.horizonsend.ion.server.command.admin.debug
 import net.horizonsend.ion.server.features.ai.configuration.AITemplate
+import net.horizonsend.ion.server.features.ai.faction.AIFaction.Companion.MINING_GUILD
+import net.horizonsend.ion.server.features.ai.faction.AIFaction.Companion.PERSEUS_EXPLORERS
 import net.horizonsend.ion.server.features.ai.module.misc.DifficultyModule
+import net.horizonsend.ion.server.features.ai.module.misc.FactionManagerModule
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.control.controllers.ai.AIController
 import net.horizonsend.ion.server.features.starship.damager.PlayerDamager
@@ -33,7 +36,27 @@ open class AICreditRewardProvider(override val starship: ActiveStarship, val con
 		debugAudience.debug("killStreakBonus: $killStreakBonus")
 		val percent = points.get().toDouble() / pointsSum.toDouble()
 		debugAudience.debug("percent: $percent")
-		val money = configuration.creditReward * percent / topPercent * difficultyMultiplier * killStreakBonus * penalty * 0.65
+
+		//Entire faction based final reward overrider
+		val faction = (starship.controller as? AIController)
+			?.getUtilModule(FactionManagerModule::class.java)
+			?.faction
+
+	    //Needs import per AIFaction
+		val factionCreditMultiplier = when (faction) {
+			PERSEUS_EXPLORERS -> 1.3
+			MINING_GUILD -> 1.0
+			//Every other undefined faction by %
+			else -> 1.0
+		}
+
+		val money = configuration.creditReward *
+			factionCreditMultiplier *
+			percent / topPercent *
+			difficultyMultiplier *
+			killStreakBonus *
+			penalty *
+			0.65
 
 		if (money <= 0.0) return
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIKillStreak.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/reward/AIKillStreak.kt
@@ -17,8 +17,9 @@ object AIKillStreak : IonServerComponent() {
 	private val playerHeatList: MutableMap<UUID, PlayerHeat> = mutableMapOf()
 	private const val BASE_DECAY = 5
 	private const val ADDITIONAL_DECAY_PER_LEVEL = 0.2
-	const val MAX_LEVELS = 60
-	const val MAX_MULTIPLIER = 6.0
+	const val MAX_LEVELS = 30
+	const val MAX_MULTIPLIER = 4.0
+	private const val MAX_SCORE = MAX_LEVELS * 1000 + 499
 
 	override fun onEnable() {
 		Tasks.syncRepeat(200, 20, ::tick)
@@ -54,10 +55,10 @@ object AIKillStreak : IonServerComponent() {
 		var entry = playerHeatList[player.uniqueId]
 
 		if (entry == null) {
-			entry = PlayerHeat(score, 0)
+			entry = PlayerHeat(score.coerceAtMost(MAX_SCORE), 0)
 			playerHeatList[player.uniqueId] = entry
 		} else {
-			entry.score += score
+			entry.score = (entry.score + score).coerceAtMost(MAX_SCORE)
 		}
 
 		if (calculateHeat(entry.score) > entry.currentHeat) {
@@ -72,7 +73,7 @@ object AIKillStreak : IonServerComponent() {
 	}
 
 	fun setHeatLevel(player: Player, level: Int) {
-	    val clampedLevel = level.coerceIn(0, 20)
+	    val clampedLevel = level.coerceIn(0, MAX_LEVELS)
 
 	    if (clampedLevel == 0) {
 		      playerHeatList.remove(player.uniqueId)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/spawning/spawner/AISpawners.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/spawning/spawner/AISpawners.kt
@@ -731,7 +731,7 @@ object AISpawners : IonServerComponent(true) {
 				"EXPLORER_BASIC",
 				AISpawnerTicker(
 					pointChance = 0.75,
-					pointThreshold = 20 * 60 * 10
+					pointThreshold = 20 * 60 * 5
 				),
 				spawnMessage = "<$EXPLORER_LIGHT_CYAN>Horizon Transit Lines<${HE_MEDIUM_GRAY}> {0} spawned in the {5} region".miniMessage(),
 				worlds = listOf(
@@ -752,7 +752,7 @@ object AISpawners : IonServerComponent(true) {
 			"<$EXPLORER_LIGHT_CYAN>Horizon Transit Lines<${HE_MEDIUM_GRAY}> Congregation".miniMessage(),
 			EXPLORER_LIGHT_CYAN,
 			duration = { Duration.ofMinutes(15) },
-			separation = { getRandomDuration(Duration.ofHours(1), Duration.ofHours(2)) },
+			separation = { getRandomDuration(Duration.ofMinutes(30), Duration.ofHours(1)) },
 			difficultySupplier = DifficultyModule::regularSpawnDifficultySupplier,
 			"<$EXPLORER_LIGHT_CYAN>Horizon Transit Lines<${HE_MEDIUM_GRAY}> are meeting in {0} at {1} {3}. <$EXPLORER_LIGHT_CYAN>Do not disturb.".miniMessage(),
 			"<$EXPLORER_LIGHT_CYAN>Horizon Transit Lines<${HE_MEDIUM_GRAY}> meeting has ended".miniMessage(),

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/spawning/spawner/scheduler/AISpawnerTicker.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/ai/spawning/spawner/scheduler/AISpawnerTicker.kt
@@ -5,6 +5,9 @@ import net.horizonsend.ion.server.features.ai.spawning.spawner.AISpawner
 import org.slf4j.Logger
 import kotlin.random.Random
 
+//Set natural spawning rate as a percentage compared to the base
+private const val NATURAL_SPAWN_RATE_MULTIPLIER = 0.8
+
 class AISpawnerTicker(
 	private val pointChance: Double = 1.0,
 	private val pointThreshold: Int
@@ -27,7 +30,7 @@ class AISpawnerTicker(
 	override fun tick(logger: Logger) {
 		handleSuccess(logger)
 
-		if (Random.nextDouble() >= pointChance) return
+		if (Random.nextDouble() >= pointChance * NATURAL_SPAWN_RATE_MULTIPLIER) return
 
 		points++
 	}


### PR DESCRIPTION
-1.3x transit line faction rewards
- 2x transit line encounter spawns
- overall natural spawning reduced 0.8x 
- max heat cap of 30 (previously uncapped just hard to get past, dominion made this easier)
adds some balancing config to make ai easier to tune. 


