### PR TITLE
Added a tertiary control in the form of the space bar. Optional!

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/PlayerSettings.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/PlayerSettings.kt
@@ -67,6 +67,7 @@ data class PlayerSettings(
 	var flareTime: Int = 5,
 	var useAlternateShieldHitParticle : Boolean = false,
 	var playerRotateWithShip: Boolean = true,
+	var tertiaryButtonControl: Int = 0,
 
 	var shortenChatChannels: Boolean = false,
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -13,6 +13,7 @@ import net.horizonsend.ion.server.features.gui.custom.settings.commands.SoundSet
 import net.horizonsend.ion.server.features.sidebar.MainSidebar
 import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar.ContactsColoring
 import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar.ContactsSorting
+import net.horizonsend.ion.server.features.starship.control.input.PlayerDirectControlInput
 import net.horizonsend.ion.server.miscellaneous.AudioRange
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
@@ -37,6 +38,7 @@ class SettingsMainMenuGui(player: Player) : SettingsPageGui(player, "Settings") 
 			DBCachedBooleanToggle(text("Toggle DC Speed Boost Key"), "Enabling this setting changes the DC boost key to a toggle.", GuiItem.LIST, false, PlayerSettings::toggleDcBoost),
 			DBCachedBooleanToggle(text("Switch Light/Heavy Weapon Keys"), "Switches the firing controls for light and heavy weapons.", GuiItem.LIST, false, PlayerSettings::alternateFireButtons),
 			DBCachedBooleanToggle(text("Rotate Player with the ship"), "Disables camera rotation, useful for aiming player guided missiles.", GuiItem.COMPASS_NEEDLE, true, PlayerSettings::playerRotateWithShip),
+			DBCachedEnumCycle(PlayerDirectControlInput.TertiaryButtonControl::class.java, text("Change Tertiary Control Function"), "Changes the functionality of the Tertiary Control (jumping in dc)", GuiItem.LIST, 0, PlayerSettings::tertiaryButtonControl),
 		),
 		createSettingsPage(player, "Sidebar Settings",
 			createSettingsPage(player, "Combat Timer Settings",

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
@@ -16,6 +16,7 @@ import net.horizonsend.ion.server.features.gui.custom.settings.SettingsMainMenuG
 import net.horizonsend.ion.server.features.gui.custom.settings.SoundSettings
 import net.horizonsend.ion.server.features.sidebar.MainSidebar
 import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar
+import net.horizonsend.ion.server.features.starship.control.input.PlayerDirectControlInput
 import net.horizonsend.ion.server.miscellaneous.AudioRange
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import org.bukkit.entity.Player
@@ -88,6 +89,12 @@ object SettingsCommand : SLCommand() {
     fun onSettingsControlAltLightHeavyWeaponKeys(sender: Player, @Optional enabled: Boolean?) = asyncCommand(sender) {
         handleBooleanToggleSetting(sender, PlayerSettings::alternateFireButtons, enabled)
     }
+
+	@CommandAlias("control tertiarycontrollers")
+	@CommandCompletion("@controlTertiaryControl")
+	fun onSettingsControlChangeTertiaryControl(sender: Player, value: PlayerDirectControlInput.TertiaryButtonControl) = asyncCommand(sender) {
+		handleEnumCycleSetting(sender, PlayerSettings::tertiaryButtonControl, value, PlayerDirectControlInput.TertiaryButtonControl::class.java)
+	}
 
     @CommandAlias("sidebar combattimer enablecombattimerinfo")
     @CommandCompletion("true|false")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
@@ -205,7 +205,8 @@ class PlayerDirectControlInput(override val controller: PlayerController) : Dire
 				//Disrupts the ship the player is looking at
 				player.debugBanner("INTERACT EVENT DISRUPT TARGETING START")
 				val targetShip = ActiveStarships.getInWorld(player.world).filter {
-					it.centerOfMass.toCenterVector().distanceSquared(player.location.toVector()) <= 600 * 600 &&
+					it.centerOfMass.toCenterVector().distanceSquared(player.location.toVector()) <=
+						starship.balancing.interdictionRange * starship.balancing.interdictionRange &&
 						it != ActiveStarships.findByPassenger(player)
 				}.sortedBy { it.centerOfMass.toCenterVector().subtract(player.location.toVector()).angle(player.eyeLocation.direction) }.firstOrNull()
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
@@ -1,14 +1,17 @@
 package net.horizonsend.ion.server.features.starship.control.input
 
+//import net.horizonsend.ion.server.features.nations.NationBuffTypes
 import com.destroystokyo.paper.event.player.PlayerJumpEvent
 import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
+import net.horizonsend.ion.common.extensions.success
 import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.server.command.admin.debug
+import net.horizonsend.ion.server.command.admin.debugBanner
 import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSetting
 import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSettingOrThrow
-//import net.horizonsend.ion.server.features.nations.NationBuffTypes
 import net.horizonsend.ion.server.features.nations.utils.getPing
 import net.horizonsend.ion.server.features.starship.StarshipType
+import net.horizonsend.ion.server.features.starship.active.ActiveStarships
 import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
 import net.horizonsend.ion.server.features.starship.control.movement.DirectControlHandler
 import net.horizonsend.ion.server.features.starship.status_effects.StarshipStatusEffectTypes
@@ -195,6 +198,37 @@ class PlayerDirectControlInput(override val controller: PlayerController) : Dire
 
 	override fun handleJump(event: PlayerJumpEvent) {
 		event.isCancelled = true
+
+		when(TertiaryButtonControl.entries[player.getSettingOrThrow(PlayerSettings::tertiaryButtonControl)]) {
+			TertiaryButtonControl.NOTHING->{}
+			TertiaryButtonControl.DISRUPT-> {
+				//Disrupts the ship the player is looking at
+				player.debugBanner("INTERACT EVENT DISRUPT TARGETING START")
+				val targetShip = ActiveStarships.getInWorld(player.world).filter {
+					it.centerOfMass.toCenterVector().distanceSquared(player.location.toVector()) <= 600 * 600 &&
+						it != ActiveStarships.findByPassenger(player)
+				}.sortedBy { it.centerOfMass.toCenterVector().subtract(player.location.toVector()).angle(player.eyeLocation.direction) }.firstOrNull()
+
+				targetShip.let {
+						if (it == starship) return //should prevent setting to yourself
+						starship.disruptorTarget = it
+						starship.onlinePassengers.forEach { player -> player.success("Disruptor enabled on ${it?.identifier ?: "unknown starship; their hyperdrive is disabled as long as your starship is in range"}") }
+					}
+				player.debugBanner("INTERACT EVENT DISRUPT TARGETING END")
+			}
+			TertiaryButtonControl.CHANGE_WEAPON_SET ->{
+				val currentWeaponSet = 	starship.weaponSetSelections[player.uniqueId] ?: ""
+				val indexOf = starship.weaponSets.keys().indexOf(currentWeaponSet)+1
+				//if the player hasn't selected a weapon set, or has reached the last weapon set, give them the first one in the index.
+				if(indexOf == -1 || indexOf == starship.weaponSets.size()) {
+					starship.weaponSetSelections[player.uniqueId] = starship.weaponSets.keys().first()
+				}
+				else{
+					starship.weaponSetSelections[player.uniqueId] = starship.weaponSets.keys().elementAt(indexOf)
+				}
+				player.success("Took control of weaponset ${starship.weaponSetSelections[player.uniqueId]}")
+			}
+		}
 	}
 
 	override fun handleSneak(event: PlayerToggleSneakEvent) {
@@ -203,5 +237,11 @@ class PlayerDirectControlInput(override val controller: PlayerController) : Dire
 		if (player.getSetting(PlayerSettings::toggleDcBoost) == true) {
 			boostToggleOverride = !boostToggleOverride
 		}
+	}
+
+	enum class TertiaryButtonControl{
+		NOTHING,
+		DISRUPT,
+		CHANGE_WEAPON_SET,
 	}
 }


### PR DESCRIPTION
### Tertiary Control
Currently HE has 2 controls for ships, primary weapons, and secondary weapons. With some movement control. However as it stands, the space bar does nothing.
As such, for ships in DC, the option has been added to allow players to set their space bar to have functionality.
The following options are available

1. **Nothing:** (default option), Space bar does nothing.
2. **Change Weapon Set:**, cycles through all the weaponsets on the ship. Allowing quick changing of weaponsets.
3. **Disrupt**, runs /disrupt, on the ship currently targetted.

/settings can be used to modify which option you'd like!

These changes should hopefully in part reduce the need for commands in combat, which has been the aim of past combat updates.