### PR TITLE
Cost of each material/Remaining cost for printing ships

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/ShipFactoryCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/ShipFactoryCommand.kt
@@ -9,9 +9,11 @@ import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.common.utils.text.toComponent
 import net.horizonsend.ion.server.command.SLCommand
 import net.horizonsend.ion.server.features.starship.factory.StarshipFactories
+import net.horizonsend.ion.server.miscellaneous.registrations.ShipFactoryMaterialCosts
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.entity.Player
+import org.bukkit.Material
 
 @CommandAlias("shipfactory")
 object ShipFactoryCommand : SLCommand() {
@@ -52,4 +54,35 @@ object ShipFactoryCommand : SLCommand() {
 
 		sender.sendMessage(StarshipFactories.getPrintItemCountString(missing))
 	}
+
+@Subcommand("remainingcost")
+fun listMaterialsCostPaginated(sender: Player, @Optional page: Int?) {
+	val missing = StarshipFactories.missingMaterialsCache[sender.uniqueId]
+	if (missing == null) {
+		sender.userError("You have no missing materials on record. Try running the ship factory again. (5 minute expiration)")
+		return
+	}
+
+	val items = missing.entries.mapNotNull { (item, count) ->
+		val material = Material.matchMaterial(item.itemString)!!
+		val blockData = material.createBlockData()
+		val price = ShipFactoryMaterialCosts.getPrice(blockData) * count
+		item to price
+	}.sortedByDescending { it.second }
+
+	sender.sendMessage(formatPaginatedMenu(
+		entries = items.size,
+		command = "/shipfactory remaining cost",
+		currentPage = page ?: 1,
+	) { index ->
+		val (item, price) = items[index]
+
+		return@formatPaginatedMenu ofChildren(
+			item.toComponent(color = NamedTextColor.RED),
+			text(": ", NamedTextColor.DARK_GRAY),
+			text(price, NamedTextColor.YELLOW)
+		)
+	})
 }
+	}
+

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/ShipFactoryCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/ShipFactoryCommand.kt
@@ -72,7 +72,7 @@ fun listMaterialsCostPaginated(sender: Player, @Optional page: Int?) {
 
 	sender.sendMessage(formatPaginatedMenu(
 		entries = items.size,
-		command = "/shipfactory remaining cost",
+		command = "/shipfactory remainingcost",
 		currentPage = page ?: 1,
 	) { index ->
 		val (item, price) = items[index]

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/BlueprintCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/BlueprintCommand.kt
@@ -169,7 +169,8 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 					Blueprint::trustedNations contains SLPlayer[sender]?.nation
 				),
 				Blueprint::name eq name
-			)).toSet()
+			)
+		).toSet()
 	}
 
 	private fun saveBlueprint(blueprint: Blueprint) {
@@ -265,7 +266,8 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 	@CommandPermission("starships.blueprint.list.other")
 	@CommandCompletion("@players")
 	fun onListOther(sender: Player, player: String) = asyncCommand(sender) {
-		val target = SLPlayer[player] ?: fail { "Player $player not found or not online." } // Database lookup so it works when the player is offline
+		val target = SLPlayer[player]
+			?: fail { "Player $player not found or not online." } // Database lookup so it works when the player is offline
 
 		failIf(!Blueprint.any(Blueprint::owner eq target._id)) { "${target.lastKnownName} has no blueprints!" }
 
@@ -280,7 +282,8 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 	@CommandPermission("starships.blueprint.list.other")
 	@CommandCompletion("@players")
 	fun onListSharedOther(sender: Player, player: String) = asyncCommand(sender) {
-		val target = SLPlayer[player] ?: fail { "Player $player not found or not online." } // Database lookup so it works when the player is offline
+		val target = SLPlayer[player]
+			?: fail { "Player $player not found or not online." } // Database lookup so it works when the player is offline
 
 		val accessibleBlueprints = or(
 			Blueprint::trustedPlayers contains target._id,
@@ -315,6 +318,27 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 
 		handleMultipleFoundBlueprints(sender, blueprints, name) { player, foundBlueprint ->
 			player.sendRichMessage(blueprintInfo(foundBlueprint).joinToString("\n"))
+		}
+	}
+
+	@Suppress("Unused")
+	@Subcommand("cost personal")
+	@CommandCompletion("@blueprints")
+	fun onCostPersonal(sender: Player, name: String) = asyncCommand(sender) {
+		val target = sender.slPlayerId
+		val blueprint = getBlueprint(target, name)
+		showMaterialCost(sender, blueprint)
+	}
+
+	@Suppress("Unused")
+	@Subcommand("cost shared")
+	@CommandCompletion("@sharedblueprints")
+	fun onCostShared(sender: Player, name: String) = asyncCommand(sender) {
+		val target = sender.slPlayerId
+		val blueprints = getSharedBlueprints(target, name)
+
+		handleMultipleFoundBlueprints(sender, blueprints, name) { player, foundBlueprint ->
+			showMaterialCost(player, foundBlueprint)
 		}
 	}
 
@@ -474,7 +498,8 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 	}
 
 	fun getPasteVector(origin: Location, pilotLoc: Vec3i): BlockVector3 {
-		return BukkitAdapter.asVector(origin).toBlockPoint().subtract(BlockVector3.at(pilotLoc.x, pilotLoc.y, pilotLoc.z))
+		return BukkitAdapter.asVector(origin).toBlockPoint()
+			.subtract(BlockVector3.at(pilotLoc.x, pilotLoc.y, pilotLoc.z))
 	}
 
 	fun tryPilot(
@@ -491,7 +516,14 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 			return
 		}
 
-		DeactivatedPlayerStarships.createPlayerShipAsync(block.world, block.x, block.y, block.z, sender.uniqueId, name) { data ->
+		DeactivatedPlayerStarships.createPlayerShipAsync(
+			block.world,
+			block.x,
+			block.y,
+			block.z,
+			sender.uniqueId,
+			name
+		) { data ->
 			Tasks.async {
 				try {
 					DeactivatedPlayerStarships.updateType(data, type)
@@ -533,6 +565,32 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 		sender.sendMessage(StarshipFactories.getPrintItemCountString(map))
 	}
 
+	fun showMaterialCost(sender: Player, blueprint: Blueprint) {
+		val clipboard = blueprint.loadClipboard()
+
+		val map = mutableMapOf<PrintItem, Int>()
+
+		for (vec in clipboard.region) {
+			val state = clipboard.getBlock(vec) ?: continue
+			val blockData = state.toBukkitBlockData()
+
+			if (blockData.material.isAir) {
+				continue
+			}
+
+			val printItem = PrintItem[blockData] ?: continue
+			val amount = StarshipFactories.getRequiredAmount(blockData)
+			val price = ShipFactoryMaterialCosts.getPrice(blockData)
+
+			val totalprice = (price * amount).toInt()
+
+			map[printItem] = map.getOrDefault(printItem, 0) + totalprice
+		}
+
+		sender.sendMessage(StarshipFactories.getPrintItemCostString(map))
+	}
+
+
 	@Suppress("Unused")
 	@Subcommand("trust player")
 	@CommandCompletion("@blueprints @players")
@@ -546,7 +604,11 @@ object BlueprintCommand : net.horizonsend.ion.server.command.SLCommand() {
 		}
 		blueprint.trustedPlayers.add(slPlayerId)
 		saveBlueprint(blueprint)
-		Notify.playerCrossServer(playerId, MiniMessage.miniMessage().deserialize("<aqua>${sender.name} <gray>trusted you to their blueprint <aqua>$name"))
+		Notify.playerCrossServer(
+			playerId,
+			MiniMessage.miniMessage()
+				.deserialize("<aqua>${sender.name} <gray>trusted you to their blueprint <aqua>$name")
+		)
 		sender.success("Trusted $player to blueprint $name")
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/shipfactory/ShipFactoryGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/shipfactory/ShipFactoryGui.kt
@@ -12,6 +12,7 @@ import net.horizonsend.ion.common.utils.text.template
 import net.horizonsend.ion.common.utils.text.toCreditComponent
 import net.horizonsend.ion.server.command.GlobalCompletions.fromItemString
 import net.horizonsend.ion.server.command.starship.BlueprintCommand.blueprintInfo
+import net.horizonsend.ion.server.command.starship.BlueprintCommand.showMaterialCost
 import net.horizonsend.ion.server.command.starship.BlueprintCommand.showMaterials
 import net.horizonsend.ion.server.features.economy.bazaar.Bazaars
 import net.horizonsend.ion.server.features.gui.GuiItem
@@ -71,10 +72,11 @@ class ShipFactoryGui(viewer: Player, val entity: ShipFactoryEntity) : InvUIWindo
 				"x y z . . . . d .",
 				". . . . C c . . .",
 				"X Y Z . . . . . .",
-				"B A M R . P . e .",
+				"B A M R G P . e .",
 				"m 1 3 6 b I . . ."
 			)
 			.addIngredient('s', searchMenuBotton)
+			.addIngredient('r', showMaterialCost)
 			.addIngredient('i', blueprintMenuBotton)
 			.addIngredient('x', tracked { id ->
 				ValueScrollButton({ GuiItem.UP.makeItem(text("Increase X offset")) }, false, { entity.settings.offsetX },+1, -100..100) {
@@ -135,6 +137,7 @@ class ShipFactoryGui(viewer: Player, val entity: ShipFactoryEntity) : InvUIWindo
 			.addIngredient('B', boundingBoxPreview)
 			.addIngredient('A', GuiItems.CustomControlItem(text("Align [Coming Soon]"), GuiItem.ALIGN))
 			.addIngredient('M', materialsButton)
+			.addIngredient('G', showMaterialCost)
 			.addIngredient('R', resetButton)
 			.addIngredient('1', getPreviewButton(GuiItem.ONE_QUARTER, 10))
 			.addIngredient('3', getPreviewButton(GuiItem.TWO_QUARTER, 30))
@@ -372,6 +375,19 @@ class ShipFactoryGui(viewer: Player, val entity: ShipFactoryEntity) : InvUIWindo
 	private val placementMenu = GuiItems.createButton(GuiItem.GEAR.makeItem(text("Placement Settings"))) { _, _, _ ->
 		placementSettings.openGui()
 	}
+
+	private val showMaterialCost = FeedbackItem.builder(GuiItem.MATERIALS.makeItem(text("Get Cost of each Material"))) { _, player ->
+		if (!entity.ensureBlueprintLoaded(player)) {
+			return@builder InputResult.FailureReason(listOf(text("You must load a blueprint first!", RED)))
+		}
+		InputResult.InputSuccess
+	}
+		.withSuccessHandler { _, _ ->
+			Tasks.async {
+				showMaterialCost(viewer, entity.cachedBlueprintData ?: return@async)
+			}
+		}
+		.build()
 
 	private val placementSettings = createSettingsPage(
 		viewer,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/StarshipFactories.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/StarshipFactories.kt
@@ -186,6 +186,30 @@ object StarshipFactories : IonServerComponent() {
 		return list.join(separator = text(", ", YELLOW))
 	}
 
+	fun getPrintItemCostString(map: Map<PrintItem, Int>): Component {
+		val list = LinkedList<Component>()
+		var color = false // used to make it alternate colors
+
+		val entriesByValue = map.entries.toList().sortedBy { it.value }
+
+		for ((item, totalprice) in entriesByValue) {
+			if (totalprice == 0) {
+				continue
+			}
+
+			color = !color
+
+			if (color) {
+				list.add(ofChildren(item.toComponent(color = DARK_AQUA), text(": ", DARK_GRAY), text(totalprice, YELLOW)))
+				continue
+			}
+
+			list.add(ofChildren(item.toComponent(color = RED), text(": ", DARK_GRAY), text(totalprice, YELLOW)))
+		}
+
+		return list.join(separator = text(", ", YELLOW))
+	}
+
 	fun getRequiredAmount(data: BlockData): Int {
 		if (data is Slab) {
 			return if (data.type == Slab.Type.DOUBLE) 2 else 1


### PR DESCRIPTION
Adds a new gui option in shipfactory "list cost of each material" shows all the costs in a simple list

adds new blueprint command: /bp cost personal, /bp cost shared (doing same thing as gui option)

adds new shipfactory command: /shipfactory remainingcost, calculates the credit printing value of the missing materials

