### PR TITLE
Added the Hyper-Hyperdrive

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -490,7 +490,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 			}
 
 		failIf(!hyperdrive.hasFuel()) {
-			"Insufficient chetherite, need ${Hyperspace.getHyperMatterAmount(starship)} in each hopper"
+			"Insufficient chetherite, need ${Hyperspace.getHyperMatterAmount(starship)} in each hopper/inventory"
 		}
 
 		val currentWorld = starship.world

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
@@ -121,6 +121,7 @@ import net.horizonsend.ion.server.features.multiblock.type.starship.gravitywell.
 import net.horizonsend.ion.server.features.multiblock.type.starship.gravitywell.DisruptorMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.starship.gravitywell.InterdictionWellMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.starship.gravitywell.StandardGravityWellMultiblock
+import net.horizonsend.ion.server.features.multiblock.type.starship.hyperdrive.HyperHyperDrive
 import net.horizonsend.ion.server.features.multiblock.type.starship.hyperdrive.HyperdriveMultiblockClass1
 import net.horizonsend.ion.server.features.multiblock.type.starship.hyperdrive.HyperdriveMultiblockClass2
 import net.horizonsend.ion.server.features.multiblock.type.starship.hyperdrive.HyperdriveMultiblockClass3
@@ -469,6 +470,7 @@ object MultiblockRegistration : IonServerComponent() {
 		registerMultiblock(HyperdriveMultiblockClass2)
 		registerMultiblock(HyperdriveMultiblockClass3)
 		registerMultiblock(HyperdriveMultiblockClass4)
+		registerMultiblock(HyperHyperDrive)
 
 		// Starship shields
 		registerMultiblock(ShieldMultiblockClass08Right)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperHyperDrive.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperHyperDrive.kt
@@ -1,0 +1,104 @@
+package net.horizonsend.ion.server.features.multiblock.type.starship.hyperdrive
+
+import net.horizonsend.ion.server.features.multiblock.shape.MultiblockShape
+import net.horizonsend.ion.server.miscellaneous.utils.coordinates.Vec3i
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+
+object HyperHyperDrive : HyperdriveMultiblock() {
+	override val name="hyperdrive"
+	override val maxPower: Int = 100_000
+	override val hyperdriveClass: Int = 4
+	override val displayName: Component get() = text("Hyper Hyperdrive")
+	override val signText: Array<Component?> = createSignText(
+		line1 = "&7Class",
+		line2 = "&dHyper",
+		line3 = "&bHyperdrive",
+		line4 = null,
+	)
+	override val chetheritePerInventory: Int = 12
+
+	override fun buildFuelInventoryOffsets() = listOf(
+		Vec3i(x = 0, y = 1, z = 0),
+		Vec3i(x = 0, y = 1, z = 0),
+		Vec3i(x = 0, y = 1, z = 0),
+		Vec3i(x = 0, y = 1, z = 0),
+		Vec3i(x = 0, y = 1, z = 0),
+		Vec3i(x = 0, y = 1, z = 0)
+	)
+
+	override fun addFuelInventories(multiblockShape: MultiblockShape) {
+		buildFuelInventoryOffsets().forEach { (x, y, z) ->multiblockShape.at(x, y, z).anyPipedInventory() }
+	}
+
+	override fun MultiblockShape.buildStructure() {
+		z(2) {
+			y(0) {
+				x(2).anyStairs()
+				x(1).ironBlock()
+				x(0).sponge()
+				x(-1).ironBlock()
+				x(-2).anyStairs()
+			}
+			y(1) {
+				x(2).ironBlock()
+				x(1).ironBlock()
+				x(0).sponge()
+				x(-1).ironBlock()
+				x(-2).ironBlock()
+			}
+			y(2) {
+				x(2).anyStairs()
+				x(1).ironBlock()
+				x(0).sponge()
+				x(-1).ironBlock()
+				x(-2).anyStairs()
+			}
+		}
+		z(1) {
+			y(0) {
+				x(2).anyGlass()
+				x(1).emeraldBlock()
+				x(0).anyGlass()
+				x(-1).emeraldBlock()
+				x(-2).anyGlass()
+			}
+			y(1) {
+				x(2).anyGlass()
+				x(1).emeraldBlock()
+				x(0).anyGlass()
+				x(-1).emeraldBlock()
+				x(-2).anyGlass()
+			}
+			y(2) {
+				x(2).anyGlass()
+				x(1).emeraldBlock()
+				x(0).anyGlass()
+				x(-1).emeraldBlock()
+				x(-2).anyGlass()
+			}
+		}
+		z(0) {
+			y(0) {
+				x(2).anyStairs()
+				x(1).ironBlock()
+				x(0).powerInput()
+				x(-1).ironBlock()
+				x(-2).anyStairs()
+			}
+			y(1) {
+				x(2).ironBlock()
+				x(1).ironBlock()
+				x(0).anyPipedInventory()
+				x(-1).ironBlock()
+				x(-2).ironBlock()
+			}
+			y(2) {
+				x(2).anyStairs()
+				x(1).ironBlock()
+				x(0).anyGlass()
+				x(-1).ironBlock()
+				x(-2).anyStairs()
+			}
+		}
+	}}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblock.kt
@@ -15,11 +15,11 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.block.BlockFace
-import org.bukkit.block.Hopper
 import org.bukkit.block.Sign
 import org.bukkit.block.sign.Side
 import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.BlockInventoryHolder
 
 abstract class HyperdriveMultiblock : Multiblock(), InteractableMultiblock, DisplayNameMultilblock {
 	override val name = "hyperdrive"
@@ -29,28 +29,30 @@ abstract class HyperdriveMultiblock : Multiblock(), InteractableMultiblock, Disp
 
 	override val description: Component get() = text("Allows a starship to enter and exit hyperspace. Consumes chetherite.")
 
-	protected abstract fun buildHopperOffsets(): List<Vec3i>
+	open val chetheritePerInventory = 2;
 
-	private val hopperOffsets: Map<BlockFace, List<Vec3i>> =
+	protected abstract fun buildFuelInventoryOffsets(): List<Vec3i>
+
+	private val fuelInventoryOffsets: Map<BlockFace, List<Vec3i>> =
 		CARDINAL_BLOCK_FACES.associate { inward ->
 			val right = inward.rightFace
-			val offsets: List<Vec3i> = buildHopperOffsets().map { (x, y, z) ->
+			val offsets: List<Vec3i> = buildFuelInventoryOffsets().map { (x, y, z) ->
 				Vec3i(x = right.modX * x + inward.modX * z, y = y, z = right.modZ * x + inward.modZ * z)
 			}
 			return@associate inward to offsets
 		}
 
-	protected fun addHoppers(multiblockShape: MultiblockShape) = buildHopperOffsets().forEach { (x, y, z) ->
+	open fun addFuelInventories(multiblockShape: MultiblockShape) = buildFuelInventoryOffsets().forEach { (x, y, z) ->
 		multiblockShape.at(x, y, z).hopper()
 	}
 
-	fun getHoppers(sign: Sign): Set<Hopper> {
+	fun getFuelInventories(sign: Sign): Set<BlockInventoryHolder> {
 		val inwards = sign.getFacing().oppositeFace
-		val offsets = hopperOffsets[inwards] ?: error("Unhandled sign direction $inwards")
+		val offsets = fuelInventoryOffsets[inwards] ?: error("Unhandled sign direction $inwards")
 
 		val origin = sign.location.add(inwards)
 
-		return offsets.map { origin.clone().add(it).block.getState(false) as Hopper }.toSet()
+		return offsets.map { origin.clone().add(it).block.state as BlockInventoryHolder }.toSet()
 	}
 
 	override fun onTransformSign(player: Player, sign: Sign) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass1.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass1.kt
@@ -20,7 +20,7 @@ object HyperdriveMultiblockClass1 : HyperdriveMultiblock() {
 	override val hyperdriveClass = 1
 
 	override fun MultiblockShape.buildStructure() {
-		addHoppers(this)
+		addFuelInventories(this)
 
 		z(+0) {
 			y(-1) {
@@ -35,7 +35,7 @@ object HyperdriveMultiblockClass1 : HyperdriveMultiblock() {
 		}
 	}
 
-	override fun buildHopperOffsets() = listOf(
+	override fun buildFuelInventoryOffsets() = listOf(
 		Vec3i(x = -1, y = -1, z = +0), // left hopper
 		Vec3i(x = +1, y = -1, z = +0) // right hopper
 	)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass2.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass2.kt
@@ -20,7 +20,7 @@ object HyperdriveMultiblockClass2 : HyperdriveMultiblock() {
 	override val hyperdriveClass = 2
 
 	override fun MultiblockShape.buildStructure() {
-		addHoppers(this)
+		addFuelInventories(this)
 
 		z(+0) {
 			y(-1) {
@@ -47,7 +47,7 @@ object HyperdriveMultiblockClass2 : HyperdriveMultiblock() {
 		}
 	}
 
-	override fun buildHopperOffsets() = listOf(
+	override fun buildFuelInventoryOffsets() = listOf(
 		Vec3i(x = -1, y = -1, z = +1), // left hopper
 		Vec3i(x = +1, y = -1, z = +1) // right hopper
 	)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass3.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass3.kt
@@ -20,7 +20,7 @@ object HyperdriveMultiblockClass3 : HyperdriveMultiblock() {
 	override val hyperdriveClass = 3
 
 	override fun MultiblockShape.buildStructure() {
-		addHoppers(this)
+		addFuelInventories(this)
 
 		z(+0) {
 			y(-1) {
@@ -55,7 +55,7 @@ object HyperdriveMultiblockClass3 : HyperdriveMultiblock() {
 		}
 	}
 
-	override fun buildHopperOffsets() = listOf(
+	override fun buildFuelInventoryOffsets() = listOf(
 		Vec3i(x = -1, y = -1, z = +1), // left hopper
 		Vec3i(x = +1, y = -1, z = +1), // right hopper
 		Vec3i(x = +0, y = -1, z = +2) // rear hopper

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass4.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblockClass4.kt
@@ -20,7 +20,7 @@ object HyperdriveMultiblockClass4 : HyperdriveMultiblock() {
 	override val hyperdriveClass = 4
 
 	override fun MultiblockShape.buildStructure() {
-		addHoppers(this)
+		addFuelInventories(this)
 
 		z(+0) {
 			y(-1) {
@@ -67,7 +67,7 @@ object HyperdriveMultiblockClass4 : HyperdriveMultiblock() {
 		}
 	}
 
-	override fun buildHopperOffsets() = listOf(
+	override fun buildFuelInventoryOffsets() = listOf(
 		Vec3i(x = -1, y = -1, z = +0), // front left hopper
 		Vec3i(x = +1, y = -1, z = +0), // front right hopper
 		Vec3i(x = -2, y = -1, z = +1), // middle left hopper

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/sequences/phases/SequencePhaseRegistry.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/sequences/phases/SequencePhaseRegistry.kt
@@ -25,7 +25,6 @@ import net.horizonsend.ion.server.features.sequences.SequenceUtils.NEXT_PHASE_SO
 import net.horizonsend.ion.server.features.sequences.SequenceUtils.RANDOM_EXPLOSION_SOUND
 import net.horizonsend.ion.server.features.sequences.SequenceUtils.RANDOM_HEAVY_TURRET_SOUND
 import net.horizonsend.ion.server.features.sequences.SequenceUtils.RANDOM_PHASER_SOUND
-import net.horizonsend.ion.server.features.sequences.SequenceUtils.SPAWN_PIRATES
 import net.horizonsend.ion.server.features.sequences.SequenceUtils.disallowDroppingItem
 import net.horizonsend.ion.server.features.sequences.SequenceUtils.disallowJumpWarmup
 import net.horizonsend.ion.server.features.sequences.SequenceUtils.disallowOpeningDoor
@@ -1547,16 +1546,16 @@ class SequencePhaseRegistry : Registry<SequencePhase>(RegistryKeys.SEQUENCE_PHAS
                         Tasks.sync {
                             val starship = PilotedStarships[player] ?: return@sync
                             val hyperdrive: HyperdriveSubsystem = starship.hyperdrives.firstOrNull() ?: return@sync
-                            hyperdrive.getHoppers().forEach { //
+                            hyperdrive.getFuelInventories().forEach { //
                                 player.sendText(
-                                    location = it.location.toCenterLocation(),
+                                    location = it.inventory.location!!.toCenterLocation(),
                                     text = text(QUEST_OBJECTIVE_ICON).font(SPECIAL_FONT_KEY),
                                     durationTicks = 2L + 1L,
                                     scale = 1.0f,
                                     seeThrough = true,
                                 )
                                 player.sendText(
-                                    location = it.location.toCenterLocation(),
+                                    location = it.inventory.location!!.toCenterLocation(),
                                     text = text(QUEST_OBJECTIVE_ICON).font(SPECIAL_FONT_KEY),
                                     durationTicks = 2L + 1L,
                                     scale = 1.0f,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/hyperspace/Hyperspace.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/hyperspace/Hyperspace.kt
@@ -53,6 +53,7 @@ object Hyperspace : IonServerComponent() {
 
 	fun getHyperMatterAmount(starship: Starship): Int {
 		val playerPilot = starship.playerPilot ?: return DEFAULT_HYPERMATTER_AMOUNT
+		if (starship.hyperdrives.find {it.multiblock.chetheritePerInventory == 12} != null) return 12
 
 		return /*if (SolarSieges.checkZoneBenefits(playerPilot)) 1 else */DEFAULT_HYPERMATTER_AMOUNT
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/HyperdriveSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/misc/HyperdriveSubsystem.kt
@@ -8,30 +8,30 @@ import net.horizonsend.ion.server.features.multiblock.type.starship.hyperdrive.H
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
 import net.horizonsend.ion.server.features.starship.subsystem.AbstractMultiblockSubsystem
-import org.bukkit.block.Hopper
 import org.bukkit.block.Sign
+import org.bukkit.inventory.InventoryHolder
 import org.bukkit.inventory.ItemStack
 import kotlin.math.min
 
 open class HyperdriveSubsystem(starship: ActiveStarship, sign: Sign, multiblock: HyperdriveMultiblock) :
 	AbstractMultiblockSubsystem<HyperdriveMultiblock>(starship, sign, multiblock) {
-	fun getHoppers(): Set<Hopper> {
+	fun getFuelInventories(): Set<InventoryHolder> {
 		val sign = starship.world.getBlockAtKey(pos.toBlockKey()).getState(false) as? Sign ?: return emptySet()
-		return multiblock.getHoppers(sign)
+		return multiblock.getFuelInventories(sign)
 	}
 
-	open fun hasFuel(): Boolean = getHoppers().all { hopper ->
-		hopper.inventory.asSequence()
+	open fun hasFuel(): Boolean = getFuelInventories().all { inventory ->
+		inventory.inventory.asSequence()
 			.filterNotNull()
 			.filter(::isHypermatter)
 			.sumOf { it.amount } >= Hyperspace.getHyperMatterAmount(starship)
 	}
 
-	open fun useFuel(): Unit = getHoppers().forEach { hopper ->
+	open fun useFuel(): Unit = getFuelInventories().forEach { inventory ->
 		var remaining = Hyperspace.getHyperMatterAmount(starship)
-		migrateInventory(hopper.inventory, DataMigrators.getVersions(0))
+		migrateInventory(inventory.inventory, DataMigrators.getVersions(0))
 
-		for (item: ItemStack? in hopper.inventory) {
+		for (item: ItemStack? in inventory.inventory) {
 			if (item == null) {
 				continue
 			}
@@ -46,7 +46,7 @@ open class HyperdriveSubsystem(starship: ActiveStarship, sign: Sign, multiblock:
 				break
 			}
 		}
-		check(remaining == 0) { "Hopper at ${hopper.location} did not have ${Hyperspace.getHyperMatterAmount(starship)} chetherite!" }
+		check(remaining == 0) { "Inventory at ${inventory.inventory.location} did not have ${Hyperspace.getHyperMatterAmount(starship)} chetherite!" }
 	}
 
 	private fun isHypermatter(item: ItemStack) = item.customItem?.key == CHETHERITE


### PR DESCRIPTION
### Hyper Hyperdrive
Analogous to the tier 4 hyperdrive. With 1 key difference.
Instead of 6 hoppers consuming 2 Chetherite each. We have 1 inventory (any inventory that can be piped into will work) consuming 12 Chetherite.
This change is to reduce the number of hoppers needed on ships, hopefully decreasing lag. As well as making piping hyperdrives easier.

This was a change requested by WitherV