### PR TITLE
Hopefully fix bug with gas canister auto refilling

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/data/migrator/types/item/modern/migrator/ReplacementMigrator.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/data/migrator/types/item/modern/migrator/ReplacementMigrator.kt
@@ -5,6 +5,7 @@ import net.horizonsend.ion.server.core.registration.registries.CustomItemRegistr
 import net.horizonsend.ion.server.data.migrator.types.item.MigratorResult
 import net.horizonsend.ion.server.data.migrator.types.item.predicate.CustomItemsPredicate
 import net.horizonsend.ion.server.features.custom.items.CustomItem
+import net.horizonsend.ion.server.features.custom.items.type.GasCanister
 import org.bukkit.inventory.ItemStack
 
 class ReplacementMigrator(vararg items: IonRegistryKey<CustomItem, out CustomItem>) : CustomItemStackMigrator(CustomItemsPredicate(*Array(items.size) { items[it].key })) {
@@ -13,9 +14,15 @@ class ReplacementMigrator(vararg items: IonRegistryKey<CustomItem, out CustomIte
 	override fun performMigration(subject: ItemStack): MigratorResult<ItemStack> {
 		val customItem = subject.customItem ?: return MigratorResult.Mutation()
 		val ideal = customItem.constructItemStack(subject.amount)
+
+	    // Keep the same fill amount when migrating a gas canister
+	    if (customItem is GasCanister) {
+	        customItem.setFill(ideal, customItem.getFill(subject))
+	    }
+		
 		if (ideal.isSimilar(subject)) return MigratorResult.Mutation()
 
-		return MigratorResult.Replacement(customItem.constructItemStack(subject.amount))
+		return MigratorResult.Replacement(ideal)
 	}
 
 	override fun registerTo(map: MutableMap<String, CustomItemStackMigrator>) {


### PR DESCRIPTION
Hopefully fixed bug where ReplacementMigrator would refill certain gas canisters to 1000 upon opening an inventory they were in.

Issue existed because a new gas canister's fill is 1000 (ideal), and so any gas canister with < 1000 gas that's migrating wouldn't match ideal get refilled.

Fix was to check if the migrating item is a gas canister, and if so keep the same fill amount.