### PR TITLE
Added more stealth in creative

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/modules/AISinkMessageFactory.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/modules/AISinkMessageFactory.kt
@@ -13,6 +13,7 @@ import net.horizonsend.ion.server.configuration.ConfigurationFiles
 import net.horizonsend.ion.server.features.ai.module.misc.CaravanModule
 import net.horizonsend.ion.server.features.chat.Discord
 import net.horizonsend.ion.server.features.chat.Discord.asDiscord
+import net.horizonsend.ion.server.features.nations.utils.toPlayersInRadius
 import net.horizonsend.ion.server.features.progression.ShipKillXP
 import net.horizonsend.ion.server.features.starship.active.ActiveStarship
 import net.horizonsend.ion.server.features.starship.control.controllers.NoOpController
@@ -73,13 +74,18 @@ class AISinkMessageFactory(private val sunkShip: ActiveStarship) : MessageFactor
 
 		val assists = getAssists(sortedByTime.map { it.key })
 
+		if(inArena){
+			sunkShip.centerOfMass.toLocation(sunkShip.world).getNearbyPlayers(1000.0).forEach {
+				it.sendMessage(ofChildren(sinkMessage,assists.orEmpty()))
+			}
+			return
+		}
 		if ((sunkShip.controller as? AIController)?.getUtilModule(CaravanModule::class.java) != null && !inArena) {
 			Notify.chatAndGlobal(ofChildren(sinkMessage, assists.orEmpty()))
 		} else {
 			IonServer.server.sendMessage(ofChildren(sinkMessage, assists.orEmpty()))
 		}
 		if (sunkShip.initialBlockCount < 12000) return // super capitals after this point
-		if (inArena) return
 
 		//todo: replace with another url.
 		val headURL = (sunkShip.controller as? PlayerController)?.player?.name?.let { "https://minotar.net/avatar/$it" }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/modules/PlayerShipSinkMessageFactory.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/modules/PlayerShipSinkMessageFactory.kt
@@ -64,7 +64,12 @@ class PlayerShipSinkMessageFactory(private val sunkShip: ActiveStarship) : Messa
 
 		val assistsMessage = formatAssists(assistsData)
 
-		if (arena) return IonServer.server.sendMessage(ofChildren(ARENA_PREFIX, message, assistsMessage))
+		if (arena){
+			sunkShip.centerOfMass.toLocation(sunkShip.world).getNearbyPlayers(1000.0).forEach {
+				it.sendMessage(ofChildren(ofChildren(ARENA_PREFIX, message, assistsMessage)))
+			}
+			return
+		}
 		// The rest is necessary
 
 		Notify.chatAndGlobal(ofChildren(message, assistsMessage))


### PR DESCRIPTION
Made ship sink messages only appear if you are within 1000 blocks of the sunk ships center of mass.
This is in accord with Kora Bronzes suggestion https://discord.com/channels/916891217596395631/1535371248287354920

This change has not been tested, as I do not have a multiplayer server to test with.
However they seem simple enough that I doubt testing is nessecary. (Im lazy)
Let me know if you still need me to test them.