### PR TITLE
T1 supercapital core transmutation

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
@@ -790,6 +790,9 @@ object Crafting : IonServerComponent() {
 			setIngredient('i', IRON_BLOCK)
 			setIngredient('c', CRAFTING_TABLE)
 		}
+		shapeless("battlecruiserReactorCore", result = BATTLECRUISER_REACTOR_CORE.getValue().constructItemStack(), CraftingBookCategory.MISC, CRUISER_REACTOR_CORE)
+		shapeless("cruiserReactorCore", result = CRUISER_REACTOR_CORE.getValue().constructItemStack(), CraftingBookCategory.MISC, BARGE_REACTOR_CORE)
+		shapeless("bargeReactorCore", result = BARGE_REACTOR_CORE.getValue().constructItemStack(), CraftingBookCategory.MISC, BATTLECRUISER_REACTOR_CORE)
 
 		// Tool Mods start
 		shaped("silk_touch_modifier", TOOL_MODIFICATION_SILK_TOUCH_MOD.getValue().constructItemStack(), CraftingBookCategory.EQUIPMENT) {


### PR DESCRIPTION
Adds crafting recipes to convert tech 1 supercapital cores to other tech 1 supercapital cores since they all cost the same now, for feature parity with tech 2 cores being swapped freely between ship classes.

cruiser core -> battlecruiser  core -> barge core -> cruiser core

Another recipe could be added for conversion of tech 1 cores into medium cores since they cost the same, although this would allow creation of supercapital cores in core systems, bypassing the requirement to craft supercapital cores in deep space with the core forge.