### PR TITLE
2 command "fixes":

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/DisposalCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/misc/DisposalCommand.kt
@@ -1,0 +1,80 @@
+package net.horizonsend.ion.server.command.misc
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.Default
+import net.horizonsend.ion.common.extensions.userError
+import net.horizonsend.ion.server.command.SLCommand
+import net.horizonsend.ion.server.features.player.CombatTimer
+import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.InventoryCloseEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryHolder
+
+@CommandAlias("disposal|dispose|trash|etrash")
+object DisposalCommand : SLCommand(), Listener {
+
+	private const val INVENTORY_SIZE = 36
+	private val TITLE = Component.text("Disposal")
+	private fun isCombatTagged(player: Player): Boolean {
+		return CombatTimer.isNpcCombatTagged(player) ||
+			CombatTimer.isPvpCombatTagged(player)
+	}
+	@EventHandler
+	fun onInventoryClose(event: InventoryCloseEvent) {
+
+		val player = event.player as? Player ?: return
+		if (event.inventory.holder !is DisposalHolder) {
+			return
+		}
+		// If the player became combat tagged while the disposal inventory was open, return their items (main reason why we needed to recreate the /disposal command)
+		if (isCombatTagged(player)) {
+			returnItems(player, event.inventory)
+			player.userError("You became combat tagged. Your items were returned.")
+			return
+		}
+
+		event.inventory.clear()
+	}
+
+	@Default
+	fun onDisposal(sender: Player) {
+		if (isCombatTagged(sender)) {
+			sender.userError("You cannot dispose of items while combat tagged.")
+			return
+		}
+		val inventory = Bukkit.createInventory(
+			DisposalHolder(),
+			INVENTORY_SIZE,
+			TITLE
+		)
+		sender.openInventory(inventory)
+	}
+
+	private fun returnItems(player: Player, inventory: Inventory) {
+		for (item in inventory.contents) {
+			if (item == null || item.isEmpty) {
+				continue
+			}
+			val remainderItems = player.inventory.addItem(item)
+			//If the players inventory became full while the gui was open, drops remaining items  on the ground
+			for (remainderItems in remainderItems.values) {
+				player.world.dropItemNaturally(player.location, remainderItems)
+			}
+		}
+		inventory.clear()
+	}
+
+	private class DisposalHolder : InventoryHolder {
+		override fun getInventory(): Inventory {
+			throw UnsupportedOperationException(
+				"DisposalHolder does not own an inventory directly."
+			)
+		}
+	}
+}
+
+

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/CustomBlockCopyPasteFixCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/CustomBlockCopyPasteFixCommand.kt
@@ -1,0 +1,36 @@
+package net.horizonsend.ion.server.command.qol
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandCompletion
+import co.aikar.commands.annotation.Optional
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Default
+import net.horizonsend.ion.server.miscellaneous.utils.pasteClipboardCustomBlocks
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_MEDIUM_GRAY
+import net.horizonsend.ion.server.command.SLCommand
+import net.kyori.adventure.text.Component.text
+import org.bukkit.entity.Player
+
+@CommandAlias("p|paste|ionpaste|ionPaste")
+@CommandPermission("worldedit.clipboard.paste")
+object CustomBlockCopyPasteFixCommand : SLCommand() {
+	@Default
+	@CommandCompletion("-a")
+	fun command(
+		player: Player,
+		@Optional flag: String?
+	) = asyncCommand(player) {
+		val ignoreAir = when (flag?.lowercase()) {
+			null -> false
+			"-a" -> true
+			else -> fail { "Unknown option: $flag" }
+		}
+		player.pasteClipboardCustomBlocks(ignoreAir)
+		player.sendMessage(
+			text(
+				if (ignoreAir) "Pasted without air" else "Pasted",
+				HE_MEDIUM_GRAY
+			)
+		)
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Commands.kt
@@ -44,6 +44,7 @@ import net.horizonsend.ion.server.command.misc.RegenerateCommand
 import net.horizonsend.ion.server.command.misc.ShipFactoryCommand
 import net.horizonsend.ion.server.command.misc.ShuttleCommand
 import net.horizonsend.ion.server.command.misc.SuicideCommand
+import net.horizonsend.ion.server.command.misc.DisposalCommand
 import net.horizonsend.ion.server.command.misc.TransponderCommand
 import net.horizonsend.ion.server.command.misc.TransportDebugCommand
 import net.horizonsend.ion.server.command.nations.NationCommand
@@ -71,6 +72,7 @@ import net.horizonsend.ion.server.command.qol.CalcExpCommand
 import net.horizonsend.ion.server.command.qol.CheckCryoCommand
 import net.horizonsend.ion.server.command.qol.CheckProtectionCommand
 import net.horizonsend.ion.server.command.qol.ContainerCommand
+import net.horizonsend.ion.server.command.qol.CustomBlockCopyPasteFixCommand
 import net.horizonsend.ion.server.command.qol.DisplayShieldsCommand
 import net.horizonsend.ion.server.command.qol.EnableOrbitBreakingCommand
 import net.horizonsend.ion.server.command.qol.EnableStationBreakingCommand
@@ -178,6 +180,7 @@ val commands: List<SLCommand> = listOf(
 	CalcExpCommand,
 	CheckProtectionCommand,
 	FixExtractorsCommand,
+	CustomBlockCopyPasteFixCommand,
 	SetPowerCommand,
 	RegenerateCommand,
 	RemoveGhostShipCommand,
@@ -207,6 +210,7 @@ val commands: List<SLCommand> = listOf(
     ForbiddenBlocksCommand,
 	IonSitCommand,
 	SuicideCommand,
+	DisposalCommand,
 	StructureCreator,
 	ModelCreator,
 	NavigationCommand,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/WorldEditCustomBlockFix.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/WorldEditCustomBlockFix.kt
@@ -1,0 +1,126 @@
+package net.horizonsend.ion.server.miscellaneous.utils
+
+import com.sk89q.worldedit.WorldEdit
+import com.sk89q.worldedit.bukkit.BukkitAdapter
+import com.sk89q.worldedit.extent.Extent
+import com.sk89q.worldedit.extent.clipboard.Clipboard
+import com.sk89q.worldedit.EmptyClipboardException
+import com.sk89q.worldedit.extent.transform.BlockTransformExtent
+import com.sk89q.worldedit.math.BlockVector3
+import com.sk89q.worldedit.math.Vector3
+import com.sk89q.worldedit.math.transform.Transform
+import com.sk89q.worldedit.world.block.BaseBlock
+import net.horizonsend.ion.server.core.registration.registries.CustomBlockRegistry.Companion.customBlock
+import net.horizonsend.ion.server.features.custom.blocks.misc.DirectionalCustomBlock
+import org.bukkit.block.BlockFace
+import org.bukkit.entity.Player
+import kotlin.math.roundToInt
+
+// Fixes the issue where users in creative rotate or flip selections with custom blocks (or any other edit that changes the faces/direction of custom blocks)
+// There's probably a smarter fix, but for now this only looks for directional custom blocks
+// If anyone changes this to include other clipboard flags they should read the world edit docs (currently cmd can either paste w/ or w/o air)
+
+private val CARDINAL_FACES = arrayOf(
+	BlockFace.NORTH,
+	BlockFace.SOUTH,
+	BlockFace.EAST,
+	BlockFace.WEST,
+	BlockFace.UP,
+	BlockFace.DOWN
+)
+
+fun Transform.toCardinalFaceMap(): Map<BlockFace, BlockFace> {
+	val origin = apply(Vector3.ZERO)
+
+	return buildMap {
+		for (face in CARDINAL_FACES) {
+			val direction = Vector3.at(
+				face.modX.toDouble(),
+				face.modY.toDouble(),
+				face.modZ.toDouble()
+			)
+			val transformed = apply(direction)
+				.subtract(origin)
+			val transformedX = transformed.x().roundToInt()
+			val transformedY = transformed.y().roundToInt()
+			val transformedZ = transformed.z().roundToInt()
+			val newFace = CARDINAL_FACES.firstOrNull {
+				it.modX == transformedX &&
+						it.modY == transformedY &&
+						it.modZ == transformedZ
+			} ?: face
+
+			put(face, newFace)
+		}
+	}
+}
+
+private fun resolveTransformedBlock(
+	sourceBlock: BaseBlock,
+	sourcePos: BlockVector3,
+	faceMap: Map<BlockFace, BlockFace>,
+	vanillaFallback: Extent
+): BaseBlock {
+	val blockData = sourceBlock.toImmutableState().toBukkitBlockData()
+	val customBlock = blockData.customBlock ?: return vanillaFallback.getFullBlock(sourcePos)
+
+	return when (customBlock) {
+		is DirectionalCustomBlock -> {
+			val currentFace = customBlock.getFace(blockData.nms)
+			val newFace = faceMap[currentFace] ?: currentFace
+			val newData = customBlock.faceData[newFace] ?: blockData
+			BukkitAdapter.adapt(newData).toBaseBlock(sourceBlock.nbt)
+		}
+		else -> sourceBlock
+	}
+}
+
+fun pasteClipboardCustomBlocks(
+	clipboard: Clipboard,
+	transform: Transform,
+	destination: Extent,
+	to: BlockVector3,
+	ignoreAirBlocks: Boolean = false
+) {
+	val faceMap = transform.toCardinalFaceMap()
+	val vanillaFallback = BlockTransformExtent(clipboard, transform)
+
+	for (sourcePos in clipboard.region) {
+		val sourceBlock = clipboard.getFullBlock(sourcePos)
+		if (ignoreAirBlocks && sourceBlock.blockType.material.isAir) continue
+
+		val destBlock = resolveTransformedBlock(sourceBlock, sourcePos, faceMap, vanillaFallback)
+		val relative = sourcePos.subtract(clipboard.origin).toVector3()
+		val destPos = transform.apply(relative).toBlockPoint().add(to)
+
+		destination.setBlock(
+			destPos.x(),
+			destPos.y(),
+			destPos.z(),
+			destBlock
+		)
+	}
+}
+
+//Gets and edits the world edit session b/c custom block world edits gotta work with //redo & //undo
+fun Player.pasteClipboardCustomBlocks(ignoreAirBlocks: Boolean = false) {
+	val user = BukkitAdapter.adapt(this)
+	val session = WorldEdit.getInstance().sessionManager.get(user)
+	val holder = try {
+		session.clipboard
+	}
+	catch (_:EmptyClipboardException) {
+		sendMessage("Your clipboard is empty.")
+		return
+	}
+
+	world.worldEditSession { editSession ->
+		val to = BukkitAdapter.adapt(location).toVector().toBlockPoint()
+		val clipboard = holder.clipboards.firstOrNull() ?: run {
+			sendMessage("Your clipboard is empty.")
+			return@worldEditSession
+		}
+		pasteClipboardCustomBlocks(clipboard, holder.transform, editSession, to, ignoreAirBlocks)
+		session.remember(editSession)
+	}
+}


### PR DESCRIPTION
- WorldEdit/Customblock copypaste cmd: - Added ion command "/paste" that edits the players world edit session so world edit transformations (rotate / flip etc) don't convert custom blocks into different custom blocks.

- Disposal/Trash cmd: Recreated EssentialsX command "/disposal" so we can have a combat tag check for players who might try to deny attackers the loot.