### PR TITLE
Remove 'p' alias

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/CustomBlockCopyPasteFixCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/qol/CustomBlockCopyPasteFixCommand.kt
@@ -11,7 +11,7 @@ import net.horizonsend.ion.server.command.SLCommand
 import net.kyori.adventure.text.Component.text
 import org.bukkit.entity.Player
 
-@CommandAlias("p|paste|ionpaste|ionPaste")
+@CommandAlias("paste|ionpaste|ionPaste")
 @CommandPermission("worldedit.clipboard.paste")
 object CustomBlockCopyPasteFixCommand : SLCommand() {
 	@Default


### PR DESCRIPTION
Remove 'p' alias from CustomBlockCopyPasteFixCommand (it was messing with /plot)