### PR TITLE
Major Combat Meta Shift/Jump Beacon/JFG/Render/Bug Fixes

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -245,7 +245,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		else -> string.toIntOrNull() ?: fail { "&cInvalid X or Z coordinate! Must be a number." }
 	}
 
-	private val jumpFieldGeneratorCooldown = object : PerPlayerCooldown(5L, TimeUnit.MINUTES) {
+	private val jumpFieldGeneratorCooldown = object : PerPlayerCooldown(2L, TimeUnit.MINUTES) {
 		override fun cooldownRejected(player: UUID) {
 			Bukkit.getPlayer(player)?.userError("Your jump field generator cannot activate that frequently!")
 		}
@@ -363,9 +363,6 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 					sender.userError("Cannot jump to a player in a different space region!")
 					sender.sendRichMessage(addToRouteMessage)
 					return
-				} else if (starship.world.ion.hasFlag(WorldFlag.CORE_REGION_WORLD)) {
-					sender.userError("You cannot jump to a beacon from a core world!")
-					return
 				}
 			} else {
 				// Sender was not jumping to a player, always fail and ask to add to route
@@ -391,7 +388,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		}
 	}
 
-	private val jumpBeaconCooldown = object : PerPlayerCooldown(5L, TimeUnit.MINUTES) {
+	private val jumpBeaconCooldown = object : PerPlayerCooldown(2L, TimeUnit.MINUTES) {
 		override fun cooldownRejected(player: UUID) {
 			Bukkit.getPlayer(player)?.userError("Your jump beacon cannot switch on/off that frequently!")
 		}
@@ -415,8 +412,6 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		failIf(starship.isDirectControlEnabled || starship.isMoving || StarshipCruising.isCruising(starship)) { "You cannot use a jump beacon while moving!" }
 
 		failIf(!starship.world.hasFlag(WorldFlag.SPACE_WORLD)) { "You can only activate jump beacons in space!" }
-
-		failIf(starship.world.hasFlag(WorldFlag.CORE_REGION_WORLD)) { "You cannot activate a jump beacon in a core world!" }
 
 		jumpBeaconCooldown.tryExec(sender) {
 			starship.enableJumpBeacon()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipTypeBalancing.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipTypeBalancing.kt
@@ -428,7 +428,7 @@ data class NewStarshipBalancing(
 			wellStrength = 1.0,
 			hyperspaceRangeMultiplier = 3.0,
 			cruiseSpeedMultiplier = 0.45,
-			shieldPowerMultiplier = 0.10,
+			shieldPowerMultiplier = 0.90,
 			weaponOverrides = listOf(
 				TriTurretBalancing(
 					fireRestrictions = FireRestrictions(minBlockCount = 3400),
@@ -489,9 +489,9 @@ data class NewStarshipBalancing(
 					projectile = TriTurretProjectileBalancing(speed = 110.0)
 				),
 				HeavyTurretBalancing(
-					fireRestrictions = FireRestrictions(minBlockCount = 16500, maxBlockCount = 20000),
-					firePowerConsumption = 3333,
-					projectile = HeavyTurretBalancing.HeavyTurretProjectileBalancing(speed = 200.0)
+					fireRestrictions = FireRestrictions(minBlockCount = 24000, maxBlockCount = 32000),
+					firePowerConsumption = 3333, maxPerShot = 4,
+					projectile = HeavyTurretBalancing.HeavyTurretProjectileBalancing(speed = 95.0)
 				),
 				AdvancedProbeBalancing(fireRestrictions = FireRestrictions(canFire = true))
 				),
@@ -608,7 +608,7 @@ data class NewStarshipBalancing(
 				AdvancedProbeBalancing(fireRestrictions = FireRestrictions(canFire = true)),
 				EMPMissileBalancing(fireRestrictions = FireRestrictions(canFire = true), maxPerShot = 1)
 			),
-			shieldPowerMultiplier = 0.4,
+			shieldPowerMultiplier = 0.55,
 			shieldRegenMultiplier = 0.7,
 			shipSounds = StarshipSounds(
 				explodeNear = SoundInfo("horizonsend:starship.explosion.fighter.near"),
@@ -1001,8 +1001,8 @@ data class NewStarshipBalancing(
 			wellStrength = 0.0,
 			cruiseSpeedMultiplier = 0.75,
 			hyperspaceRangeMultiplier = 1.7,
-			shieldPowerMultiplier = 0.65,
-			shieldRegenMultiplier = 1.25,
+			shieldPowerMultiplier = 0.75,
+			shieldRegenMultiplier = 1.50,
 			requiredMultiblocks = listOf(
 				RequiredSubsystemInfo(
 					SmallReactorSubsystem::class.java,
@@ -1029,12 +1029,12 @@ data class NewStarshipBalancing(
 				)))
 			),
 			weaponOverrides = listOf(
-				TriTurretBalancing(
-					fireRestrictions = FireRestrictions(canFire = false, minBlockCount = 3400),
-					boostChargeNanos = TimeUnit.SECONDS.toNanos(7)
-				),
 				PulseCannonBalancing(fireRestrictions = FireRestrictions(canFire = false, minBlockCount = 1000, maxBlockCount = 4000)),
 				TorpedoBalancing(fireRestrictions = FireRestrictions(canFire = false)),
+				PhaserBalancing(fireRestrictions = FireRestrictions(canFire = false)),
+				TriTurretBalancing(fireRestrictions = FireRestrictions(canFire = false)),
+				HeavyTurretBalancing(fireRestrictions = FireRestrictions(canFire = false)),
+				LaserCannonBalancing(fireRestrictions = FireRestrictions(canFire = false), firePowerConsumption = 420),
 				LightLogisticsCannonBalancing(fireRestrictions = FireRestrictions(canFire = true), maxPerShot = 2)
 			),
 			forbiddenMultiblocks = listOf(
@@ -1110,7 +1110,7 @@ data class NewStarshipBalancing(
 			sneakFlyAccelDistance = 6,
 			maxSneakFlyAccel = 2,
 			interdictionRange = 850,
-			jumpStrength = 1.0,
+			jumpStrength = 2.0,
 			warmupTime = 15,
 			wellStrength = 1.0,
 			hyperspaceRangeMultiplier = 1.8,
@@ -1129,10 +1129,8 @@ data class NewStarshipBalancing(
 				)),
 			weaponOverrides = listOf(
 				HeavyTurretBalancing(fireRestrictions = FireRestrictions(canFire = false)),
-				NeutralizerBalancing(fireRestrictions = FireRestrictions(canFire = true), maxPerShot = 2),
-				HeavyNeutralizerBalancing(fireRestrictions = FireRestrictions(canFire = true)),
-				AssaultTurretBalancing(fireRestrictions = FireRestrictions(canFire = true, minBlockCount = 6500, ), maxPerShot = 3,),
-				LaserCannonBalancing(fireRestrictions = FireRestrictions(canFire = false), firePowerConsumption = 420),
+				NeutralizerBalancing(fireRestrictions = FireRestrictions(canFire = true), maxPerShot = 3, firePowerConsumption = 17500),
+				GaussCannonBalancing(fireRestrictions = FireRestrictions(canFire = true), maxPerShot = 4, firePowerConsumption = 1850),
 				SwarmMissileBalancing(fireRestrictions = FireRestrictions(canFire = false, minBlockCount = 4500, maxBlockCount = 8000), maxPerShot = 1, boostChargeNanos = TimeUnit.SECONDS.toNanos(6))
 			),
 			forbiddenMultiblocks = listOf(
@@ -1143,10 +1141,6 @@ data class NewStarshipBalancing(
 				IncompatibleSubsystemInfo(
 					GravityWellSubsystem::class.java,
 					"Only interdictors can use gravity wells!"
-				),
-				IncompatibleSubsystemInfo(
-					JumpBeaconSubsystem::class.java,
-					"This ship cannot use jump beacons!"
 				)
 			),
 			shipSounds = StarshipSounds(
@@ -1411,10 +1405,6 @@ data class NewStarshipBalancing(
 					"Only interdictors can use gravity wells!"
 				),
 				IncompatibleSubsystemInfo(
-					JumpBeaconSubsystem::class.java,
-					"This ship cannot use jump beacons!"
-				),
-				IncompatibleSubsystemInfo(
 					LargeReactorSubsystem::class.java,
 					"Tech 1 super-capitals cannot house tech 2 reactors!"
 				)
@@ -1448,8 +1438,8 @@ data class NewStarshipBalancing(
 			wellStrength = 0.0,
 			hyperspaceRangeMultiplier = 1.9,
 			cruiseSpeedMultiplier = 0.85,
-			shieldPowerMultiplier = 0.8,
-			shieldRegenMultiplier = 4.5,
+			shieldPowerMultiplier = 0.95,
+			shieldRegenMultiplier = 5.8,
 			commandBurstOverrides = listOf(
 				CapitalSkirmishCommandBurstBalancing(activateRestrictions = StarshipCommandBurstBalancing.ActivateRestrictions(canActivate = true, incompatibleMultiblocks = listOf(
 					IncompatibleSubsystemInfo(
@@ -1595,10 +1585,6 @@ data class NewStarshipBalancing(
 				IncompatibleSubsystemInfo(
 					GravityWellSubsystem::class.java,
 					"Only interdictors can use gravity wells!"
-				),
-				IncompatibleSubsystemInfo(
-					JumpBeaconSubsystem::class.java,
-				"This ship cannot use jump beacons!"
 				),
 				IncompatibleSubsystemInfo(
 					LargeReactorSubsystem::class.java,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipWeapons.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipWeapons.kt
@@ -687,8 +687,8 @@ data class LightMissileLauncherBalancing(
 
 	@Serializable
 	data class LightMissileLauncherProjectileBalancing(
-		override var range: Double = 290.0,
-		override var speed: Double = 80.0,
+		override var range: Double = 300.0,
+		override var speed: Double = 85.0,
 		override var explosionPower: Float = 5.50f,
 		override var starshipShieldDamageMultiplier: Double = 5.5,
 		override var areaShieldDamageMultiplier: Double = 4.0,
@@ -737,8 +737,8 @@ data class RapidHeavyMissileLauncherBalancing(
 
 	@Serializable
 	data class RapidHeavyMissileLauncherProjectileBalancing(
-		override var range: Double = 300.0,
-		override var speed: Double = 42.5,
+		override var range: Double = 315.0,
+		override var speed: Double = 55.0,
 		override var explosionPower: Float = 7.0f,
 		override var starshipShieldDamageMultiplier: Double = 10.0,
 		override var areaShieldDamageMultiplier: Double = 4.0,
@@ -746,7 +746,7 @@ data class RapidHeavyMissileLauncherBalancing(
 		override val fireSoundFar: SoundInfo = SoundInfo("horizonsend:starship.weapon.swarm_missile.shoot.far", volume = 1f, source = Sound.Source.PLAYER),
 		override val entityDamage: EntityDamage = RegularDamage(10.0),
 		override var maxDegrees: Double = 90.0,
-		override var detonationRange: Double = 7.5,
+		override var detonationRange: Double = 9.0,
 		override var turnRate: Double = 0.65,
 		override var acceleration: Double = 3.5,
 		override var particleThickness: Double = 2.0,
@@ -847,7 +847,7 @@ data class HeavyTurretBalancing(
 	@Serializable
 	data class HeavyTurretProjectileBalancing(
         override var range: Double = 400.0,
-        override var speed: Double = 80.0,
+        override var speed: Double = 95.0,
         override var explosionPower: Float = 3.5f,
         override var starshipShieldDamageMultiplier: Double = 3.25,
         override var areaShieldDamageMultiplier: Double = 1.0,
@@ -912,7 +912,7 @@ data class AssaultTurretBalancing(
 	@Serializable
 	data class AssaultTurretProjectileBalancing(
 		override var range: Double = 500.0,
-		override var speed: Double = 92.5,
+		override var speed: Double = 105.0,
 		override var explosionPower: Float = 4.5f,
 		override var starshipShieldDamageMultiplier: Double = 6.0,
 		override var areaShieldDamageMultiplier: Double = 1.0,
@@ -976,7 +976,7 @@ data class QuadTurretBalancing(
 	@Serializable
 	data class QuadTurretProjectileBalancing(
         override var range: Double = 500.0,
-        override var speed: Double = 50.0,
+        override var speed: Double = 77.5,
         override var explosionPower: Float = 5f,
         override var starshipShieldDamageMultiplier: Double = 6.9,
         override var areaShieldDamageMultiplier: Double = 10.0,
@@ -1008,7 +1008,7 @@ data class ACAPTurretBalancing(
 	@Serializable
 	data class ACAPTurretProjectileBalancing(
 		override var range: Double = 500.0,
-		override var speed: Double = 50.0,
+		override var speed: Double = 77.5,
 		override var explosionPower: Float = 10f,
 		override var starshipShieldDamageMultiplier: Double = 9.5,
 		override var areaShieldDamageMultiplier: Double = 6.0,
@@ -1040,7 +1040,7 @@ data class IonTurretBalancing(
 	@Serializable
 	data class IonTurretProjectileBalancing(
 		override var range: Double = 400.0,
-		override var speed: Double = 65.0,
+		override var speed: Double = 77.5,
 		override var explosionPower: Float = 3f,
 		override var starshipShieldDamageMultiplier: Double = 3.7,
 		override var areaShieldDamageMultiplier: Double = 100.0,
@@ -1111,7 +1111,7 @@ data class PulseCannonBalancing(
 	data class PulseCannonProjectileBalancing(
         override var range: Double = 160.0,
         override var speed: Double = 230.0,
-        override var explosionPower: Float = 1.5f,
+        override var explosionPower: Float = 2.0f,
         override var starshipShieldDamageMultiplier: Double = 1.8,
         override var areaShieldDamageMultiplier: Double = 2.0,
         override val entityDamage: EntityDamage = RegularDamage(10.0),
@@ -1257,7 +1257,7 @@ data class LaserCannonBalancing(
 	data class LaserCannonProjectileBalancing(
         override var range: Double = 200.0,
         override var speed: Double = 250.0,
-        override var explosionPower: Float = 1f,
+        override var explosionPower: Float = 2f,
         override var starshipShieldDamageMultiplier: Double = 0.2,
         override var areaShieldDamageMultiplier: Double = 1.0,
         override val entityDamage: EntityDamage = RegularDamage(10.0),
@@ -1435,7 +1435,7 @@ data class LightLogisticsCannonBalancing(
 	@Serializable
 	data class LightLogisticsCannonProjectileBalancing(
 		override var range: Double = 140.0,
-		override var speed: Double = 8000.0,
+		override var speed: Double = 800.0,
 		override var explosionPower: Float = 0f,
 		override var starshipShieldDamageMultiplier: Double = 0.0,
 		override var areaShieldDamageMultiplier: Double = 0.0,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/power/powerfurnace/PowerFurnaceMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/power/powerfurnace/PowerFurnaceMultiblock.kt
@@ -102,7 +102,7 @@ abstract class PowerFurnaceMultiblock(tierText: String) : Multiblock(), EntityMu
 		structureDirection: BlockFace,
 	) : SimplePoweredEntity(data, multiblock, manager, x, y, z, world, structureDirection, multiblock.maxPower), SyncTickingMultiblockEntity, StatusTickedMultiblockEntity, PoweredMultiblockEntity, LegacyMultiblockEntity, FurnaceBasedMultiblockEntity,
 		DisplayMultiblockEntity {
-		override val tickingManager: TickedMultiblockEntityParent.TickingManager = TickedMultiblockEntityParent.TickingManager(interval = 20)
+		override val tickingManager: TickedMultiblockEntityParent.TickingManager = TickedMultiblockEntityParent.TickingManager(interval = 10)
 		override val statusManager: StatusMultiblockEntity.StatusManager = StatusMultiblockEntity.StatusManager()
 
 		override val displayHandler = DisplayHandlers.newMultiblockSignOverlay(

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/weapon/event/RapidHeavilyMissileLauncherMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/weapon/event/RapidHeavilyMissileLauncherMultiblock.kt
@@ -52,11 +52,11 @@ sealed class RapidHeavyMissileLauncherMultiblock : TurretMultiblock<RapidHeavyMi
 		z(1) {
 			y(getSign() * 3) {
 				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
-				x(2).anyTerracotta()
-				x(1).anyTerracotta()
-				x(0).anyTerracotta()
-				x(-1).anyTerracotta()
-				x(-2).anyTerracotta()
+				x(2).terracottaOrDoubleSlab()
+				x(1).terracottaOrDoubleSlab()
+				x(0).terracottaOrDoubleSlab()
+				x(-1).terracottaOrDoubleSlab()
+				x(-2).terracottaOrDoubleSlab()
 				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
 			}
 			y(getSign() * 4) {
@@ -78,11 +78,11 @@ sealed class RapidHeavyMissileLauncherMultiblock : TurretMultiblock<RapidHeavyMi
 		z(0) {
 			y(getSign() * 3) {
 				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
-				x(2).anyTerracotta()
-				x(1).anyTerracotta()
-				x(0).anyTerracotta()
-				x(-1).anyTerracotta()
-				x(-2).anyTerracotta()
+				x(2).terracottaOrDoubleSlab()
+				x(1).terracottaOrDoubleSlab()
+				x(0).terracottaOrDoubleSlab()
+				x(-1).terracottaOrDoubleSlab()
+				x(-2).terracottaOrDoubleSlab()
 				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
 			}
 			y(getSign() * 4) {
@@ -105,11 +105,11 @@ sealed class RapidHeavyMissileLauncherMultiblock : TurretMultiblock<RapidHeavyMi
 		z(-1) {
 			y(getSign() * 3) {
 				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
-				x(2).anyTerracotta()
-				x(1).anyTerracotta()
-				x(0).anyTerracotta()
-				x(-1).anyTerracotta()
-				x(-2).anyTerracotta()
+				x(2).terracottaOrDoubleSlab()
+				x(1).terracottaOrDoubleSlab()
+				x(0).terracottaOrDoubleSlab()
+				x(-1).terracottaOrDoubleSlab()
+				x(-2).terracottaOrDoubleSlab()
 				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
 			}
 			y(getSign() * 4) {
@@ -131,9 +131,9 @@ sealed class RapidHeavyMissileLauncherMultiblock : TurretMultiblock<RapidHeavyMi
 		z(2) {
 			y(getSign() * 3) {
 				x(2).ironBlock()
-				x(1).anyTerracotta()
-				x(0).anyTerracotta()
-				x(-1).anyTerracotta()
+				x(1).terracottaOrDoubleSlab()
+				x(0).terracottaOrDoubleSlab()
+				x(-1).terracottaOrDoubleSlab()
 				x(-2).ironBlock()
 			}
 			y(getSign() * 4) {
@@ -145,9 +145,9 @@ sealed class RapidHeavyMissileLauncherMultiblock : TurretMultiblock<RapidHeavyMi
 		z(-2) {
 			y(getSign() * 3) {
 				x(2).ironBlock()
-				x(1).anyTerracotta()
-				x(0).anyTerracotta()
-				x(-1).anyTerracotta()
+				x(1).terracottaOrDoubleSlab()
+				x(0).terracottaOrDoubleSlab()
+				x(-1).terracottaOrDoubleSlab()
 				x(-2).ironBlock()
 			}
 			y(getSign() * 4) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipType.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipType.kt
@@ -1232,7 +1232,7 @@ enum class StarshipType(
 		minLevel = 90,
 		concretePercent = 0.1,
 		containerPercent = 0.02,
-		crateLimitMultiplier = 3.0,
+		crateLimitMultiplier = 7.0,
 		menuItemRaw = { ItemStack(Material.PEARLESCENT_FROGLIGHT) },
 		displayInMainMenu = false,
 		typeCategory = TypeCategory.TRADE_SHIP,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/ActiveStarshipMechanics.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/ActiveStarshipMechanics.kt
@@ -153,7 +153,7 @@ object ActiveStarshipMechanics : IonServerComponent() {
 		}
 	}
 
-	const val SUPERCAPITAL_FUEL_CONSUMPTION = 9
+	const val SUPERCAPITAL_FUEL_CONSUMPTION = 4
 
 	private fun handleSupercapitalMechanics() {
 		// Consume fuel

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipControl.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipControl.kt
@@ -3,6 +3,7 @@ package net.horizonsend.ion.server.features.starship.control.movement
 import net.horizonsend.ion.common.utils.miscellaneous.d
 import net.horizonsend.ion.server.core.IonServerComponent
 import net.horizonsend.ion.server.features.space.Space
+import net.horizonsend.ion.server.features.starship.StarshipType
 import net.horizonsend.ion.server.features.starship.StarshipType.BATTLECRUISER
 import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
 import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
@@ -34,6 +35,9 @@ object StarshipControl : IonServerComponent() {
 
 		// Don't allow battlecruisers to enter planets
 		if (starship.type == BATTLECRUISER && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
+		if (starship.type == StarshipType.BARGE && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
+		if (starship.type == StarshipType.LANCER_BATTLECRUISER && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
+		if (starship.type == StarshipType.INDUSTRIAL_COMMAND_SHIP && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
 
 		// Don't allow players that have recently entered planets to re-enter again
 		val controller = starship.controller

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/checklist/LargeReactorSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/checklist/LargeReactorSubsystem.kt
@@ -10,5 +10,5 @@ import org.bukkit.block.Sign
 
 class LargeReactorSubsystem(starship: ActiveStarship, sign: Sign, multiblock: LargeReactorMultiblock) :
 	SupercapitalReactorSubsystem<LargeReactorMultiblock>(starship, sign, multiblock) {
-	override val fuelKey: IonRegistryKey<CustomItem, GasCanister> = CustomItemKeys.GAS_CANISTER_HYDROGEN
+	override val fuelKey: IonRegistryKey<CustomItem, GasCanister> = CustomItemKeys.GAS_CANISTER_XENON
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Crafting.kt
@@ -378,7 +378,7 @@ object Crafting : IonServerComponent() {
 		shapeless("prismarine_crystals", ItemStack(PRISMARINE_CRYSTALS, 4), CraftingBookCategory.MISC, SEA_LANTERN)
 		shapeless("pink_petals", ItemStack(PINK_PETALS, 4), CraftingBookCategory.BUILDING, CHERRY_LEAVES)
 		shapeless("nether_warts", ItemStack(NETHER_WART, 9), CraftingBookCategory.BUILDING, NETHER_WART_BLOCK)
-		shapeless("honeycomb", ItemStack(HONEYCOMB, 9), CraftingBookCategory.MISC, HONEYCOMB_BLOCK)
+		shapeless("honeycomb", ItemStack(HONEYCOMB, 4), CraftingBookCategory.MISC, HONEYCOMB_BLOCK)
 		shapedMaterial("cobweb", COBWEB, "s s", " s ", "s s", CraftingBookCategory.BUILDING, 's' to STRING)
 		shapedMaterial("small_dripleaf" , Material.SMALL_DRIPLEAF, shape1 = "xx ", shape2 = " y ", shape3 = "   ", CraftingBookCategory.BUILDING,'x' to Material.OAK_LEAVES, 'y' to Material.BAMBOO)
 		shapedMaterial("big_dripleaf" , Material.BIG_DRIPLEAF, shape1 = "xxx", shape2 = "  y", shape3 = "  y", CraftingBookCategory.BUILDING, 'x' to Material.OAK_LEAVES, 'y' to Material.BAMBOO)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/VariableRenderDistance.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/VariableRenderDistance.kt
@@ -24,17 +24,17 @@ object VariableRenderDistance: IonServerComponent() {
 				// When oped or in dutymode
 				(player.isOp || player.hasPermission("group.dutymode")) -> 20
 				// When on planet
-				player.world.hasFlag(WorldFlag.PLANET_WORLD) -> 6
+				player.world.hasFlag(WorldFlag.PLANET_WORLD) -> 8
 				// When in a creative server arena
-				player.world.hasFlag(WorldFlag.ARENA) -> 20
+				player.world.hasFlag(WorldFlag.ARENA) -> 22
 				// When in combat but not piloting
-				isPvpCombatTagged(player) && !isPiloting(player) -> 7
+				isPvpCombatTagged(player) && !isPiloting(player) -> 8
 				//When in combat and piloting
-				(isPvpCombatTagged(player)) && isPiloting(player) -> 20
+				(isPvpCombatTagged(player)) && isPiloting(player) -> 22
 				//NPC combat tag set to old render, should help with lag pretty massively
 				(isNpcCombatTagged(player)) && isPiloting(player) -> 12
 				//Other cases, like when piloting but not in combat
-				else -> 7
+				else -> 10
 			}
 			val simulationDistance = when {
 				player.isDead -> 2


### PR DESCRIPTION
MAJOR COMBAT META SHIFTS - VANDRAYK:
Another month has passed since the last major changes to the combat meta, and we have kept a close eye on how combat is unfolding across the sector. We are looking to shift the meta towards capitals rather than seeing corvettes continue to dominate the meta. Below are the coming shakeups and rebalances: (TL:DR - Corvettes less strong, Caps/Supercaps/JFG/JB/Logi largely buffed)

LOGI
-Logi Cruiser SPM -> 0.95
-Logi Cruiser SRM -> 5.8

Logistics Cruiser was a little too underpowered to justify a large core/could easily get run down. Improving Regen/Shield Power to bring it up to parity

Logi Corv SPM -> 0.75
Logi Corv SRM -> 1.50

Similarly, Logi corv utilization rate is too low, and even though it's already strong, these changes should cement its role in the meta.

TURRET VELOS
Massively bringing up Capital/Supercapital Turret velos up again to incentivize capital ship utilization, lower skill floor and make them closer to par with their missile counterparts for application.

Assault Turret Speed -> 105.0
Heavy Turret Speed -> 95.0
ACAP Turret Speed -> 77.5
Ion Turret Speed -> 77.5
Quad Turret Speed -> 77.5

MISSILE APPLICATION
Minor increases to detonation/speed/range for RHML and LML to make these more justified in their roles.

Rapid Heavy Missile Launcher Speed -> 55.0
Rapid Heavy Missile Launcher Range -> 315.0
Rapid Heavy Missile Launcher Detonation Range -> 9.0

Light Missile Launcher Speed -> 85.0
Light Missile Launcher Range -> 300.0

ASSAULT FRIGATE
Assault Frigate has existed in no man's land since release. Changing its role to be more flexible than current. Making it into an ideal priority frontline option for punching down against corvettes (6.5k -> 7.5k recommended) or an alternative less than ideal secondary option for punching up against ADS (8k -> 8.5k). Trading its weapon capabilities as following:

Loses: Access to Heavy Neutralizer and Assault Turret

Gains: 4 Gauss Cannon, 3 Neutralizer
Assault Frigate Jump Strength -> 2.0

JUMP BEACON/JUMP FIELD GENERATOR RELATED CHANGES:
- Can now Use JB/JFG between core worlds and their relevant deep space regions. i.e - (Regulus and Fracture)
- Added Jump Beacon to the following classes: Assault Frigate, T1 Cruiser, T1 Battlecruiser
- Jump Beacon Cooldown 5m -> 2m
- Jump Field Generator Cooldown 5m -> 2m

These changes should bring Jump Beacons/Jump Field generators to the forefront of fights, open up content opportunities, and further incentivize supercapital usage.

JUMP FREIGHTER
No longer going to be as much of a meme! Well deserved buffs alongside Jump Beacons/Jump Field gens to make this actually worth using.

Crate Limit Multiplier 3.0 -> 7.0 
Shield Power Multi -> 0.90

SCRAMBLER
Underperforming a bit after its last changes, giving it a little more Shield Power to increase survivability against counters. 

Scrambler Shield Power Multiplier -> 0.55

XENON/Fuel Changes
Given that Xenon has come into the game with such abundance, going to give this some more usage, restricting T2 Supers to Xenon Only alongside reduced spawn rates for Xenon. To further grow Fuel's role in the economy, reverting fuel rates back to pre-dominion as a baseline, but expect potential future adjustment.

Large Reactor Fuelkey : Xenon
Fuel Consumption Rate 9 -> 4

RENDER
RENDER CHANGES:
With server population stabilizing after Dominion, making the following changes:
On planet -> 8 Render
In combat and piloted -> 22 Render
Out of Combat and Piloted -> 10 Render

BUG FIXES
- Light Logistics Cannon speed fix
- Made Power Furnace 2x faster as originally intended with dominion, fixed Burntime issues.
- Fixed Honeycomb Dupe
- Industrial Command Ship HT min/max size bug fix (should be able to fire 4 HT as intended)
- Fixed Rapid Heavy Missile Launcher not being able to use doubleslabs
- Fixed Bug where Supercaps could enter planets
- Fixed Bug where Logi Corvs could fire a bunch of weapons
- Fixed Pulse/Laser Cannons not being able to deal hull:
- Laser Cannon Explosion Power -> 2.0
- Pulse Cannon Explosion Power -> 2.0


