### PR TITLE
Adjust weapon balancing for Pulse and Plasma Cannons

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipWeapons.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipWeapons.kt
@@ -1109,10 +1109,10 @@ data class PulseCannonBalancing(
 
 	@Serializable
 	data class PulseCannonProjectileBalancing(
-        override var range: Double = 160.0,
-        override var speed: Double = 230.0,
+        override var range: Double = 180.0,
+        override var speed: Double = 300.0,
         override var explosionPower: Float = 2.0f,
-        override var starshipShieldDamageMultiplier: Double = 1.8,
+        override var starshipShieldDamageMultiplier: Double = 1.2,
         override var areaShieldDamageMultiplier: Double = 2.0,
         override val entityDamage: EntityDamage = RegularDamage(10.0),
 		override val fireSoundNear: SoundInfo = SoundInfo("horizonsend:starship.weapon.pulse_cannon.shoot.near", volume = 1f, source = Sound.Source.PLAYER),
@@ -1185,9 +1185,9 @@ data class PlasmaCannonBalancing(
 	data class PlasmaCannonProjectileBalancing(
         override var range: Double = 160.0,
         override var speed: Double = 400.0,
-        override var explosionPower: Float = 3f,
+        override var explosionPower: Float = 4f,
         override var starshipShieldDamageMultiplier: Double = 2.0,
-        override var areaShieldDamageMultiplier: Double = 3.0,
+        override var areaShieldDamageMultiplier: Double = 2.0,
         override val entityDamage: EntityDamage = RegularDamage(10.0),
 		override val fireSoundNear: SoundInfo = SoundInfo("horizonsend:starship.weapon.plasma_cannon.shoot.near", volume = 1f, source = Sound.Source.PLAYER),
 		override val fireSoundFar: SoundInfo = SoundInfo("horizonsend:starship.weapon.plasma_cannon.shoot.far", volume = 1f, source = Sound.Source.PLAYER),


### PR DESCRIPTION
Updated projectile balancing parameters for Pulse and Plasma Cannons to enhance weapon performance.

This round of patches is intended to balance out t1 weapons a little bit more.

Plasma cannons have been found to have poor performance against both shields and hull; paired with their limited firing angles and range, as well as the inability of Starfighters to drift and take advantage of their agility while dealing damage, plasmas needed a buff to raw damage output.

Plasma cannon Explosion Multiplier: 3 > 4
Plasma cannon Area Multiplier: 3 > 2

Pulse cannons after the bug fix end up dealing quite a bit more shield damage than they should, making them a bit too competitive against Tech 2 ships. Pulses are intended to take down smaller ships; as such, the shield damage has been nerfed significantly in exchange for a velocity and range buff that allows them to pursue small craft as intended.

Pulse cannon range: 160 > 180
Pulse cannon speed: 230 > 300
Pulse cannon Shield Multiplier: 1.8 > 1.2