### PR TITLE
Make ship factories print itemFilter's data aswell

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/blocks/filter/ItemFilterBlock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/blocks/filter/ItemFilterBlock.kt
@@ -96,7 +96,7 @@ object ItemFilterBlock : DirectionalCustomBlock(
 
 		state.nextStateUpdateTime = Long.MAX_VALUE
 
-		val storedFilterData = placedItem?.persistentDataContainer?.get(NamespacedKeys.FILTER_DATA, FilterData)
+		val storedFilterData = placedItem?.persistentDataContainer?.get(NamespacedKeys.FILTER_DATA, FilterData) ?: state.persistentDataContainer.get(NamespacedKeys.FILTER_DATA, FilterData)
 		if (storedFilterData != null) state.persistentDataContainer.set(NamespacedKeys.FILTER_DATA, FilterData, storedFilterData)
 
 		state.update()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/ShipFactoryBlockProcessor.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/ShipFactoryBlockProcessor.kt
@@ -4,8 +4,17 @@ import com.sk89q.worldedit.extent.clipboard.Clipboard
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap
 import it.unimi.dsi.fastutil.longs.Long2ObjectSortedMaps
 import net.horizonsend.ion.common.database.schema.starships.Blueprint
+import net.horizonsend.ion.common.utils.text.plainText
+import net.horizonsend.ion.common.utils.text.toComponent
+import net.horizonsend.ion.server.core.registration.registries.CustomBlockRegistry.Companion.customBlock
+import net.horizonsend.ion.server.features.custom.blocks.CustomBlock
+import net.horizonsend.ion.server.features.custom.blocks.filter.ItemFilterBlock
 import net.horizonsend.ion.server.features.multiblock.type.shipfactory.ShipFactoryEntity
 import net.horizonsend.ion.server.features.multiblock.type.shipfactory.ShipFactorySettings
+import net.horizonsend.ion.server.features.transport.filters.FilterData
+import net.horizonsend.ion.server.features.transport.filters.FilterMeta
+import net.horizonsend.ion.server.features.transport.filters.FilterType
+import net.horizonsend.ion.server.miscellaneous.registrations.persistence.NamespacedKeys
 import net.horizonsend.ion.server.miscellaneous.utils.LegacyBlockUtils.getRotatedBlockData
 import net.horizonsend.ion.server.miscellaneous.utils.coordinates.BlockKey
 import net.horizonsend.ion.server.miscellaneous.utils.coordinates.Vec3i
@@ -14,13 +23,23 @@ import net.horizonsend.ion.server.miscellaneous.utils.isSign
 import net.starlegacy.javautil.BannerUtils
 import net.starlegacy.javautil.BannerUtils.BannerData
 import net.horizonsend.ion.server.miscellaneous.utils.loadClipboard
+import net.horizonsend.ion.server.miscellaneous.utils.nms
 import net.horizonsend.ion.server.miscellaneous.utils.rightFace
 import net.horizonsend.ion.server.miscellaneous.utils.toBukkitBlockData
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.NbtUtils
 import net.minecraft.world.level.block.Rotation
+import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.state.BlockState
 import net.starlegacy.javautil.SignUtils
 import net.starlegacy.javautil.SignUtils.SignData
+import org.bukkit.Material
+import org.bukkit.block.TileState
 import org.bukkit.block.data.BlockData
+import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import org.enginehub.linbus.tree.LinTagType
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.math.cos
 import kotlin.math.roundToInt
@@ -37,6 +56,7 @@ abstract class ShipFactoryBlockProcessor(
 	val blockMap: MutableMap<BlockKey, BlockData> = Long2ObjectSortedMaps.synchronize(Long2ObjectRBTreeMap())
 	protected val signMap: MutableMap<BlockKey, SignData> = Long2ObjectSortedMaps.synchronize(Long2ObjectRBTreeMap())
 	protected val bannerMap: MutableMap<BlockKey, BannerData> = Long2ObjectSortedMaps.synchronize(Long2ObjectRBTreeMap())
+	protected val filters: MutableMap<BlockKey, FilterData<*, *>?> = Long2ObjectSortedMaps.synchronize(Long2ObjectRBTreeMap())
 
 	var blockQueue = ConcurrentLinkedQueue<Long>()
 
@@ -65,6 +85,25 @@ abstract class ShipFactoryBlockProcessor(
 
 			if (data.material.name.endsWith("_BANNER")) {
 				bannerMap[worldKey] = BannerUtils.readBannerData(baseBlock.nbt)
+			}
+
+			if(data.material == Material.VAULT && data.customBlock == ItemFilterBlock) {
+				val nbt = baseBlock.nbt
+				val publicValues = nbt
+					?.findTag("PublicBukkitValues", LinTagType.compoundTag())
+					?: nbt?.findTag("components", LinTagType.compoundTag())
+						?.findTag("minecraft:custom_data", LinTagType.compoundTag())
+						?.findTag("PublicBukkitValues", LinTagType.compoundTag())
+				if(publicValues != null) {
+					val pdc = (data.createBlockState() as TileState).persistentDataContainer
+					val nmsTag = publicValues.nms() as CompoundTag
+					(pdc as CraftPersistentDataContainer).putAll(nmsTag)
+
+					val filterData: FilterData<*, *>? = pdc.get(NamespacedKeys.FILTER_DATA, FilterData)
+					if (filterData != null) {
+						filters[worldKey] = filterData
+					}
+				}
 			}
 
 			blockQueue.add(worldKey)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/ShipFactoryPrintTask.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/factory/ShipFactoryPrintTask.kt
@@ -18,6 +18,7 @@ import net.horizonsend.ion.common.utils.text.toCreditComponent
 import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.configuration.ConfigurationFiles
 import net.horizonsend.ion.server.core.registration.registries.CustomBlockRegistry.Companion.customBlock
+import net.horizonsend.ion.server.features.custom.blocks.filter.ItemFilterBlock
 import net.horizonsend.ion.server.features.multiblock.MultiblockEntities
 import net.horizonsend.ion.server.features.multiblock.entity.task.MultiblockEntityTask
 import net.horizonsend.ion.server.features.multiblock.entity.type.LegacyMultiblockEntity
@@ -28,13 +29,20 @@ import net.horizonsend.ion.server.features.multiblock.type.shipfactory.AdvancedS
 import net.horizonsend.ion.server.features.multiblock.type.shipfactory.ShipFactoryEntity
 import net.horizonsend.ion.server.features.multiblock.type.shipfactory.ShipFactoryGui
 import net.horizonsend.ion.server.features.multiblock.type.shipfactory.ShipFactorySettings
+import net.horizonsend.ion.server.features.nations.gui.item
 import net.horizonsend.ion.server.features.starship.factory.StarshipFactories.missingMaterialsCache
 import net.horizonsend.ion.server.features.starship.factory.integration.ShipFactoryIntegration
 import net.horizonsend.ion.server.features.transport.NewTransport
+import net.horizonsend.ion.server.features.transport.filters.FilterData
 import net.horizonsend.ion.server.features.transport.items.util.ItemReference
+import net.horizonsend.ion.server.features.transport.manager.ChunkTransportManager
 import net.horizonsend.ion.server.features.transport.manager.extractors.ExtractorManager
+import net.horizonsend.ion.server.features.transport.manager.holders.ChunkCacheHolder
+import net.horizonsend.ion.server.features.transport.nodes.cache.ItemTransportCache
+import net.horizonsend.ion.server.features.world.chunk.IonChunk
 import net.horizonsend.ion.server.miscellaneous.registrations.CreditPrintBlackList
 import net.horizonsend.ion.server.miscellaneous.registrations.ShipFactoryMaterialCosts
+import net.horizonsend.ion.server.miscellaneous.registrations.persistence.NamespacedKeys
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import net.horizonsend.ion.server.miscellaneous.utils.coordinates.BlockKey
 import net.horizonsend.ion.server.miscellaneous.utils.coordinates.getX
@@ -55,14 +63,16 @@ import net.starlegacy.javautil.BannerUtils.BannerData
 import net.starlegacy.javautil.SignUtils.SignData
 import org.bukkit.Material
 import org.bukkit.block.Banner
-import org.bukkit.block.Furnace
 import org.bukkit.block.Sign
+import org.bukkit.block.TileState
+import org.bukkit.block.Vault
 import org.bukkit.block.data.BlockData
 import org.bukkit.block.data.Waterlogged
 import org.bukkit.entity.Player
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataContainer
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -329,6 +339,7 @@ class ShipFactoryPrintTask(
 			val blockData = blockMap.remove(entry) ?: continue
 			val signData = signMap.remove(entry)
 			val bannerData = bannerMap.remove(entry)
+			val itemFilterData = filters.remove(entry)
 
 			val block = entity.world.getBlockAt(getX(entry), getY(entry), getZ(entry))
 
@@ -345,7 +356,7 @@ class ShipFactoryPrintTask(
 			if (!event.callEvent()) continue
 
 			placements++
-			placeBlock(entry, blockData, signData, bannerData)
+			placeBlock(entry, blockData, signData, bannerData, itemFilterData)
 		}
 
 		if (entity is AdvancedShipFactoryParent.AdvancedShipFactoryEntity) {
@@ -355,7 +366,13 @@ class ShipFactoryPrintTask(
 		if (ConfigurationFiles.featureFlags().economy) player.withdrawMoney(tickCredits)
 	}
 
-	private fun placeBlock(printPosition: BlockKey, data: BlockData, signData: SignData?, bannerData: BannerData?) {
+	private fun placeBlock(
+		printPosition: BlockKey,
+		data: BlockData,
+		signData: SignData?,
+		bannerData: BannerData?,
+		itemFilterData:  FilterData<*, *>?
+	) {
 		var placedData = data
 
 		val (x, y, z) = toVec3i(printPosition)
@@ -371,6 +388,12 @@ class ShipFactoryPrintTask(
 
 		if (ExtractorManager.isExtractorData(data)) {
 			NewTransport.addExtractor(world, x, y, z)
+		}
+
+		if(itemFilterData != null) {
+			val state = block.state as TileState
+			state.persistentDataContainer.set(NamespacedKeys.FILTER_DATA, FilterData, itemFilterData)
+			state.update()
 		}
 
 		data.customBlock?.placeCallback(null, block)


### PR DESCRIPTION
Made the custom block the "ItemFilter" print with its data. This means you can print ships with their filters already setup. Which is another step towards removing entirely hoppers from our transport network.
