### PR TITLE
Add energy generation from unfinished fluid update (with changes)

### DIFF
--- a/run/config/paper/config/paper-global.yml
+++ b/run/config/paper/config/paper-global.yml
@@ -7,5 +7,5 @@ proxies:
     online-mode: true
     secret: test
 block-updates:
-  disable-chorus-plant-updates: false
+  disable-chorus-plant-updates: true
   disable-mushroom-block-updates: true

--- a/server/src/main/kotlin/net/horizonsend/ion/server/core/registration/keys/FluidTypeKeys.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/core/registration/keys/FluidTypeKeys.kt
@@ -18,4 +18,6 @@ object FluidTypeKeys : KeyRegistry<FluidType>(RegistryKeys.FLUID_TYPE, FluidType
 
 	val WATER = registerKey("WATER")
 	val LAVA = registerKey("LAVA")
+	val DENSE_STEAM = registerKey("DENSE_STEAM")
+	val POLLUTION = registerKey("POLLUTION")
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/core/registration/registries/FluidRegistry.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/core/registration/registries/FluidRegistry.kt
@@ -9,11 +9,14 @@ import net.horizonsend.ion.server.features.transport.fluids.properties.FluidCate
 import net.horizonsend.ion.server.features.transport.fluids.types.GasFluid
 import net.horizonsend.ion.server.features.transport.fluids.types.Lava
 import net.horizonsend.ion.server.features.transport.fluids.types.Water
+import net.horizonsend.ion.server.features.transport.fluids.types.SimpleGasFluid
 import net.horizonsend.ion.server.features.transport.manager.graph.fluid.FluidNode
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor.WHITE
 import org.bukkit.Color
+import net.kyori.adventure.text.format.NamedTextColor.AQUA
+import net.kyori.adventure.text.format.NamedTextColor.GRAY
 import org.bukkit.World
 import org.bukkit.block.BlockFace
 import org.bukkit.util.Vector
@@ -42,5 +45,17 @@ class FluidTypeRegistry : Registry<FluidType>(RegistryKeys.FLUID_TYPE) {
 
 		register(FluidTypeKeys.WATER, Water)
 		register(FluidTypeKeys.LAVA, Lava)
+		register(FluidTypeKeys.DENSE_STEAM, SimpleGasFluid(
+			FluidTypeKeys.DENSE_STEAM,
+			text("Dense Steam", AQUA),
+			Color.WHITE
+		))
+
+		register(FluidTypeKeys.POLLUTION, SimpleGasFluid(
+			FluidTypeKeys.POLLUTION,
+			text("Pollution", GRAY),
+			Color.GRAY,
+			leakDistance = 17.5
+		))
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/industry/FluidFuelProperties.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/industry/FluidFuelProperties.kt
@@ -1,0 +1,25 @@
+package net.horizonsend.ion.server.features.industry
+
+import net.horizonsend.ion.server.core.registration.IonRegistryKey
+import net.horizonsend.ion.server.core.registration.keys.FluidTypeKeys
+import net.horizonsend.ion.server.features.transport.fluids.FluidType
+
+enum class FluidFuelProperties(
+	val fluidType: IonRegistryKey<FluidType, out FluidType>,
+	val joulesPerLiter: Double
+) {
+	HYDROGEN(FluidTypeKeys.HYDROGEN, 200_000.0),
+	NITROGEN(FluidTypeKeys.NITROGEN, 1_000_000.0),
+	METHANE(FluidTypeKeys.METHANE, 3_000_000.0),
+	LAVA(FluidTypeKeys.LAVA, 6_000_000.0);
+
+	companion object {
+		private val byFluidType: Map<IonRegistryKey<FluidType, out FluidType>, FluidFuelProperties> =
+			entries.associateBy(FluidFuelProperties::fluidType)
+
+		val acceptedFluidTypes: Set<IonRegistryKey<FluidType, out FluidType>> = byFluidType.keys
+
+		operator fun get(fluidType: IonRegistryKey<FluidType, out FluidType>): FluidFuelProperties? =
+			byFluidType[fluidType]
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/industry/ItemFuelProperties.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/industry/ItemFuelProperties.kt
@@ -1,42 +1,77 @@
 package net.horizonsend.ion.server.features.industry
 
+import net.horizonsend.ion.server.core.registration.IonRegistryKey
+import net.horizonsend.ion.server.core.registration.keys.CustomItemKeys
 import net.horizonsend.ion.server.core.registration.keys.FluidTypeKeys
+import net.horizonsend.ion.server.core.registration.registries.CustomItemRegistry.Companion.customItem
+import net.horizonsend.ion.server.features.custom.items.CustomItem
 import net.horizonsend.ion.server.features.transport.fluids.FluidStack
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 
+private fun customItem(key: IonRegistryKey<CustomItem, out CustomItem>): ItemStack = key.getValue().constructItemStack()
+private fun vanillaItem(material: Material): ItemStack = ItemStack(material, 1)
+
 enum class ItemFuelProperties(
-	val material: Material,
+	private val item: ItemStack,
 	val burnDurationMillis: Long,
 	val heatOutputJoulesPerSecond: Double,
 	val pollutionResult: FluidStack
 ) {
 	COAL(
-		material = Material.COAL,
+		item = vanillaItem(Material.COAL),
 		burnDurationMillis = 2_000,
-		heatOutputJoulesPerSecond = 4_000_000.0,
+		heatOutputJoulesPerSecond = 2_500_000.0,
 		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
 	),
 	COAL_BLOCK(
-		material = Material.COAL_BLOCK,
+		item = vanillaItem(Material.COAL_BLOCK),
 		burnDurationMillis = 18_000,
-		heatOutputJoulesPerSecond = 3_500_000.0,
+		heatOutputJoulesPerSecond = 2_800_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	URANIUM(
+		item = customItem(CustomItemKeys.URANIUM),
+		burnDurationMillis = 100_000,
+		heatOutputJoulesPerSecond = 2_300_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	URANIUM_BLOCK(
+		item = customItem(CustomItemKeys.URANIUM_BLOCK),
+		burnDurationMillis = 900_000,
+		heatOutputJoulesPerSecond = 2_400_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	REDSTONE(
+		item = vanillaItem(Material.REDSTONE),
+		burnDurationMillis = 3_750,
+		heatOutputJoulesPerSecond = 100_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	REDSTONE_BLOCK(
+		item = vanillaItem(Material.REDSTONE_BLOCK),
+		burnDurationMillis = 33_750,
+		heatOutputJoulesPerSecond = 120_000.0,
 		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
 	),
 	DRIED_KELP_BLOCK(
-		material = Material.DRIED_KELP_BLOCK,
+		item = vanillaItem(Material.DRIED_KELP_BLOCK),
 		burnDurationMillis = 250 * 9,
 		heatOutputJoulesPerSecond = 40_000.0,
 		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
 	),
 	DRIED_KELP(
-		material = Material.DRIED_KELP,
+		item = vanillaItem(Material.DRIED_KELP),
 		burnDurationMillis = 250,
 		heatOutputJoulesPerSecond = 40_000.0,
 		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
 	);
 
 	companion object {
-		operator fun get(item: ItemStack): ItemFuelProperties? = entries.firstOrNull { fuel -> fuel.material == item.type }
+		private val itemMap: Map<String, ItemFuelProperties> = entries.associateBy { fuel -> createKey(fuel.item) }
+
+		operator fun get(item: ItemStack): ItemFuelProperties? = itemMap[createKey(item)]
+
+		private fun createKey(item: ItemStack): String = item.customItem?.identifier ?: item.type.name
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/industry/ItemFuelProperties.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/industry/ItemFuelProperties.kt
@@ -1,0 +1,42 @@
+package net.horizonsend.ion.server.features.industry
+
+import net.horizonsend.ion.server.core.registration.keys.FluidTypeKeys
+import net.horizonsend.ion.server.features.transport.fluids.FluidStack
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
+
+enum class ItemFuelProperties(
+	val material: Material,
+	val burnDurationMillis: Long,
+	val heatOutputJoulesPerSecond: Double,
+	val pollutionResult: FluidStack
+) {
+	COAL(
+		material = Material.COAL,
+		burnDurationMillis = 2_000,
+		heatOutputJoulesPerSecond = 4_000_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	COAL_BLOCK(
+		material = Material.COAL_BLOCK,
+		burnDurationMillis = 18_000,
+		heatOutputJoulesPerSecond = 3_500_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	DRIED_KELP_BLOCK(
+		material = Material.DRIED_KELP_BLOCK,
+		burnDurationMillis = 250 * 9,
+		heatOutputJoulesPerSecond = 40_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	),
+	DRIED_KELP(
+		material = Material.DRIED_KELP,
+		burnDurationMillis = 250,
+		heatOutputJoulesPerSecond = 40_000.0,
+		pollutionResult = FluidStack(FluidTypeKeys.POLLUTION, 20.0)
+	);
+
+	companion object {
+		operator fun get(item: ItemStack): ItemFuelProperties? = entries.firstOrNull { fuel -> fuel.material == item.type }
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
@@ -525,11 +525,11 @@ object MultiblockRegistration : IonServerComponent() {
 		/*
 		if (ConfigurationFiles.featureFlags().graphTransfer) {
 			registerMultiblock(ChemicalProcessorMultiblock)
-			registerMultiblock(PumpMultiblock)
 		}
 		 */
 
 		// Fluids
+		registerMultiblock(PumpMultiblock)
 		registerMultiblock(BasicFluidStorageTankMultiblock)
 		registerMultiblock(CanisterUnloaderMultiblock)
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
@@ -36,6 +36,7 @@ import net.horizonsend.ion.server.features.multiblock.type.fluid.GasPowerPlantMu
 import net.horizonsend.ion.server.features.multiblock.type.fluid.PumpMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.collector.CanisterGasCollectorMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.storage.BasicFluidStorageTankMultiblock
+import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockFluidFuel
 import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockItemFuel
 import net.horizonsend.ion.server.features.multiblock.type.fluid.turbine.SteamTurbineMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CentrifugeMultiblock
@@ -535,6 +536,7 @@ object MultiblockRegistration : IonServerComponent() {
 		registerMultiblock(BasicFluidStorageTankMultiblock)
 		registerMultiblock(CanisterUnloaderMultiblock)
 		registerMultiblock(BoilerMultiblockItemFuel)
+		registerMultiblock(BoilerMultiblockFluidFuel)
 		registerMultiblock(SteamTurbineMultiblock)
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
@@ -37,6 +37,7 @@ import net.horizonsend.ion.server.features.multiblock.type.fluid.PumpMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.collector.CanisterGasCollectorMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.storage.BasicFluidStorageTankMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockItemFuel
+import net.horizonsend.ion.server.features.multiblock.type.fluid.turbine.SteamTurbineMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CentrifugeMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CircuitfabMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CompressorMultiblock
@@ -534,6 +535,7 @@ object MultiblockRegistration : IonServerComponent() {
 		registerMultiblock(BasicFluidStorageTankMultiblock)
 		registerMultiblock(CanisterUnloaderMultiblock)
 		registerMultiblock(BoilerMultiblockItemFuel)
+		registerMultiblock(SteamTurbineMultiblock)
 	}
 
 	private fun sortMultiblocks() {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
@@ -36,6 +36,7 @@ import net.horizonsend.ion.server.features.multiblock.type.fluid.GasPowerPlantMu
 import net.horizonsend.ion.server.features.multiblock.type.fluid.PumpMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.collector.CanisterGasCollectorMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.storage.BasicFluidStorageTankMultiblock
+import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockItemFuel
 import net.horizonsend.ion.server.features.multiblock.type.industry.CentrifugeMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CircuitfabMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CompressorMultiblock
@@ -532,6 +533,7 @@ object MultiblockRegistration : IonServerComponent() {
 		registerMultiblock(PumpMultiblock)
 		registerMultiblock(BasicFluidStorageTankMultiblock)
 		registerMultiblock(CanisterUnloaderMultiblock)
+		registerMultiblock(BoilerMultiblockItemFuel)
 	}
 
 	private fun sortMultiblocks() {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/MultiblockRegistration.kt
@@ -34,10 +34,10 @@ import net.horizonsend.ion.server.features.multiblock.type.fluid.CanisterVentMul
 import net.horizonsend.ion.server.features.multiblock.type.fluid.ChemicalProcessorMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.GasPowerPlantMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.PumpMultiblock
+import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockItemFuel
+import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockLiquidFuel
 import net.horizonsend.ion.server.features.multiblock.type.fluid.collector.CanisterGasCollectorMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.fluid.storage.BasicFluidStorageTankMultiblock
-import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockFluidFuel
-import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockItemFuel
 import net.horizonsend.ion.server.features.multiblock.type.fluid.turbine.SteamTurbineMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CentrifugeMultiblock
 import net.horizonsend.ion.server.features.multiblock.type.industry.CircuitfabMultiblock
@@ -536,7 +536,8 @@ object MultiblockRegistration : IonServerComponent() {
 		registerMultiblock(BasicFluidStorageTankMultiblock)
 		registerMultiblock(CanisterUnloaderMultiblock)
 		registerMultiblock(BoilerMultiblockItemFuel)
-		registerMultiblock(BoilerMultiblockFluidFuel)
+		registerMultiblock(BoilerMultiblockLiquidFuel)
+		registerMultiblock(BoilerMultiblockLiquidFuel, "BoilerMultiblockFluidFuel")
 		registerMultiblock(SteamTurbineMultiblock)
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/entity/type/fluids/FluidInputMetadata.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/entity/type/fluids/FluidInputMetadata.kt
@@ -7,6 +7,11 @@ class FluidInputMetadata(
 	val connectedStore: FluidStorageContainer,
 
 	val inputAllowed: Boolean,
-	val outputAllowed: Boolean
+	outputAllowed: Boolean,
+	private val outputCondition: () -> Boolean = { true }
 ) : InputMetaData {
+	private val outputConfigured = outputAllowed
+
+	val outputAllowed: Boolean
+		get() = outputConfigured && outputCondition()
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/entity/type/fluids/storage/FluidStorageContainer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/entity/type/fluids/storage/FluidStorageContainer.kt
@@ -47,18 +47,19 @@ class FluidStorageContainer private constructor(
 	}
 
 	fun canAdd(fluidStack: FluidStack): Boolean {
+		if (!restriction.canAdd(fluidStack)) return false
 		if (contentsUnsafe.isEmpty()) return true
-
 		if (contentsUnsafe.type != fluidStack.type) return false
 
-		return restriction.canAdd(fluidStack)
+		return true
 	}
 
 	fun canAdd(type: IonRegistryKey<FluidType, out FluidType>): Boolean {
+		if (!restriction.canAdd(type)) return false
 		if (contentsUnsafe.isEmpty()) return true
 		if (contentsUnsafe.type != type) return false
 
-		return restriction.canAdd(type)
+		return true
 	}
 
 	fun hasRoomFor(fluidStack: FluidStack): Boolean {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/shape/MultiblockShape.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/shape/MultiblockShape.kt
@@ -1,6 +1,7 @@
 package net.horizonsend.ion.server.features.multiblock.shape
 
 import net.horizonsend.ion.server.core.registration.keys.CustomBlockKeys
+import net.horizonsend.ion.server.core.registration.IonRegistryKey
 import net.horizonsend.ion.server.core.registration.registries.CustomBlockRegistry.Companion.customBlock
 import net.horizonsend.ion.server.core.registration.registries.CustomItemRegistry.Companion.customItem
 import net.horizonsend.ion.server.features.custom.blocks.CustomBlock
@@ -282,6 +283,56 @@ class MultiblockShape {
 			complete(requirement)
 		}
 
+		fun anyCustomBlock(
+			vararg types: IonRegistryKey<CustomBlock, out CustomBlock>,
+			alias: String,
+			edit: BlockRequirement.() -> Unit = {}
+		) {
+			val allowedKeys = types.toSet()
+
+			val requirement = BlockRequirement(
+				alias = alias,
+				example = types.first().getValue().blockData,
+				syncCheck = { block, _, loadChunks ->
+					val customBlockKey = if (loadChunks) {
+						block.customBlock?.key
+					} else {
+						getBlockDataSafe(
+							block.world,
+							block.x,
+							block.y,
+							block.z
+						)?.customBlock?.key
+					}
+
+					customBlockKey != null && allowedKeys.contains(customBlockKey)
+				},
+				itemRequirement = BlockRequirement.ItemRequirement(
+					itemCheck = {
+						val customItem = it.customItem
+
+						customItem is CustomBlockItem &&
+							allowedKeys.contains(customItem.getCustomBlock().key)
+					},
+					amountConsumed = { 1 },
+					toBlock = { item ->
+						(item.customItem as CustomBlockItem)
+							.getCustomBlock()
+							.blockData
+					},
+					toItemStack = { blockData ->
+						blockData.customBlock
+							?.customItem
+							?.constructItemStack()
+							?: ItemStack(Material.AIR)
+					}
+				)
+			)
+
+			complete(requirement)
+			edit(requirement)
+		}
+
 		fun anyType(alias: String, types: Iterable<Material>, edit: BlockRequirement.() -> Unit = {}) = anyType(
 			*types.toList().toTypedArray(),
 			alias = alias,
@@ -490,6 +541,16 @@ class MultiblockShape {
 		fun assemblyCore() = customBlock(CustomBlockKeys.ASSEMBLY_CORE.getValue())
 
 		fun fluidInput() = customBlock(CustomBlockKeys.FLUID_INPUT.getValue())
+		fun anyFluidPipe() = anyCustomBlock(
+			CustomBlockKeys.FLUID_PIPE,
+			CustomBlockKeys.FLUID_PIPE_JUNCTION,
+			CustomBlockKeys.REINFORCED_FLUID_PIPE,
+			CustomBlockKeys.REINFORCED_FLUID_PIPE_JUNCTION,
+			CustomBlockKeys.FLUID_VALVE,
+			alias = "any fluid pipe"
+		) {
+			setExample(CustomBlockKeys.FLUID_PIPE.getValue().blockData)
+		}
 		fun powerInput() = type(Material.NOTE_BLOCK)
 		fun extractor() = type(STANDARD_EXTRACTOR_TYPE)
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
@@ -491,11 +491,13 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 
 		override fun tickAsync() {
 			bootstrapNetwork()
-			val deltaSeconds = min(deltaTMS, MAXIMUM_DELTA_MILLIS).toDouble() / 1000.0
-			val burning = continueOrStartBurning()
+			val deltaMillis = min(deltaTMS, MAXIMUM_DELTA_MILLIS).coerceAtLeast(0L)
+			val deltaSeconds = deltaMillis.toDouble() / 1000.0
+			val generatedHeat = burnFuel(deltaMillis)
+			val burning = generatedHeat > EPSILON
 
 			if (burning) {
-				boilerTemperature += (burningOutput * deltaSeconds) / BOILER_THERMAL_MASS
+				boilerTemperature += generatedHeat / BOILER_THERMAL_MASS
 				boilerTemperature = min(boilerTemperature, MAXIMUM_TEMPERATURE)
 				Tasks.sync { if (!removed) displayBurningParticles() }
 			}
@@ -510,14 +512,36 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			updateTemperatureDisplay()
 		}
 
-		private fun continueOrStartBurning(): Boolean {
-			val now = System.currentTimeMillis()
-			if (burningEnds > now) return true
+		private fun burnFuel(deltaMillis: Long): Double {
+			if (deltaMillis <= 0L) return 0.0
 
-			burningEnds = 0L
-			burningOutput = 0.0
+			val intervalEnd = System.currentTimeMillis()
+			var cursor = intervalEnd - deltaMillis
+			var generatedHeat = 0.0
 
-			return Tasks.getSyncBlocking { tryStartFuel(System.currentTimeMillis()) }
+			while (cursor < intervalEnd) {
+				if (burningEnds <= cursor) {
+					burningEnds = 0L
+					burningOutput = 0.0
+
+					val started = Tasks.getSyncBlocking { tryStartFuel(cursor) }
+					if (!started) break
+				}
+
+				val segmentEnd = minOf(intervalEnd, burningEnds)
+				val segmentDurationMillis = segmentEnd - cursor
+				if (segmentDurationMillis <= 0L) break
+
+				generatedHeat += burningOutput * (segmentDurationMillis.toDouble() / 1000.0)
+				cursor = segmentEnd
+			}
+
+			if (burningEnds <= intervalEnd) {
+				burningEnds = 0L
+				burningOutput = 0.0
+			}
+
+			return generatedHeat
 		}
 
 		@Synchronized
@@ -530,7 +554,7 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			return steamOutputUnlocked
 		}
 
-		private fun tryStartFuel(now: Long): Boolean {
+		private fun tryStartFuel(startTime: Long): Boolean {
 			if (removed) return false
 
 			val fuelInventory = getInventory(0, -1, 0) ?: return false
@@ -546,7 +570,7 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 				if (!pollutionStorage.canAdd(pollutionStack) || !pollutionStorage.hasRoomFor(pollutionStack)) continue
 				*/
 
-				burningEnds = now + fuelProperties.burnDurationMillis
+				burningEnds = startTime + fuelProperties.burnDurationMillis
 				burningOutput = fuelProperties.heatOutputJoulesPerSecond
 
 				if (itemStack.amount <= 1) fuelInventory.setItem(slot, null)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
@@ -128,12 +128,12 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			}
 			y(4) {
 				x(-1).titaniumBlock()
-				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(0).anyCopperGrate()
 				x(1).titaniumBlock()
 			}
 			y(5) {
 				x(-1).titaniumBlock()
-				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(0).anyCopperGrate()
 				x(1).titaniumBlock()
 			}
 			y(6) {
@@ -232,12 +232,12 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 				x(2).titaniumBlock()
 			}
 			y(4) {
-				x(-2).type(Material.WAXED_COPPER_GRATE)
-				x(2).type(Material.WAXED_COPPER_GRATE)
+				x(-2).anyCopperGrate()
+				x(2).anyCopperGrate()
 			}
 			y(5) {
-				x(-2).type(Material.WAXED_COPPER_GRATE)
-				x(2).type(Material.WAXED_COPPER_GRATE)
+				x(-2).anyCopperGrate()
+				x(2).anyCopperGrate()
 			}
 			y(6) {
 				x(-2).titaniumBlock()
@@ -346,12 +346,12 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			}
 			y(4) {
 				x(-1).titaniumBlock()
-				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(0).anyCopperGrate()
 				x(1).titaniumBlock()
 			}
 			y(5) {
 				x(-1).titaniumBlock()
-				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(0).anyCopperGrate()
 				x(1).titaniumBlock()
 			}
 			y(6) {
@@ -500,14 +500,14 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 				Tasks.sync { if (!removed) displayBurningParticles() }
 			}
 
-			val boiledWater = boilWater(deltaSeconds)
+			boilWater(deltaSeconds)
 
 			if (!burning) {
 				boilerTemperature = maxOf(AMBIENT_TEMPERATURE, boilerTemperature - (PASSIVE_COOLING_PER_SECOND * deltaSeconds))
 			}
 
 			// Overheat explosions are intentionally disabled. A full steam output only stops further boiling.
-			updateStatus(burning, boiledWater)
+			updateTemperatureDisplay()
 		}
 
 		private fun continueOrStartBurning(): Boolean {
@@ -592,17 +592,8 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			return waterActuallyBoiled
 		}
 
-		private fun updateStatus(burning: Boolean, boiledWater: Double) {
-			val temperatureText = "${boilerTemperature.roundToInt()}°C"
-			val inputHasWater = fluidInput.getContents().type == FluidTypeKeys.WATER
-
-			when {
-				fluidOutput.getRemainingRoom() <= EPSILON && inputHasWater -> setStatus(text("Steam output full: $temperatureText", NamedTextColor.RED))
-				boiledWater > EPSILON -> setStatus(text("Boiling: $temperatureText", NamedTextColor.GOLD))
-				burning -> setStatus(text("Heating: $temperatureText", NamedTextColor.YELLOW))
-				boilerTemperature > AMBIENT_TEMPERATURE + EPSILON -> setStatus(text("Cooling: $temperatureText", NamedTextColor.AQUA))
-				else -> setStatus(text("Idle: $temperatureText", NamedTextColor.GRAY))
-			}
+		private fun updateTemperatureDisplay() {
+			setStatus(text("${boilerTemperature.roundToInt()}°C", NamedTextColor.WHITE))
 		}
 
 		private fun displayBurningParticles() {
@@ -630,7 +621,7 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			private const val WATER_LATENT_HEAT_PER_LITER = 2_257_000.0
 			private const val PASSIVE_COOLING_PER_SECOND = 5.0
 			private const val MAXIMUM_WATER_CONVERSION_PER_SECOND = 5.0
-			private const val STEAM_EXPANSION_FACTOR = 12.0
+			private const val STEAM_EXPANSION_FACTOR = 6.0
 			private const val MINIMUM_STEAM_OUTPUT_RELEASE = 5.0
 
 			private const val MAXIMUM_DELTA_MILLIS = 1_000L

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
@@ -452,13 +452,22 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 		private var boilerTemperature = data.getAdditionalDataOrDefault(TEMPERATURE_KEY, DOUBLE, AMBIENT_TEMPERATURE)
 		private var burningEnds = data.getAdditionalDataOrDefault(BURNING_ENDS_KEY, LONG, 0L)
 		private var burningOutput = data.getAdditionalDataOrDefault(BURNING_OUTPUT_KEY, DOUBLE, 0.0)
+		@Volatile private var steamOutputUnlocked = fluidOutput.getContents().amount >= MINIMUM_STEAM_OUTPUT_RELEASE
 
 		override val ioData: IOData = IOData.builder(this)
 			.addPort(IOType.FLUID, -3, 0, 3) {
 				IOPort.RegisteredMetaDataInput(this, FluidInputMetadata(fluidInput, inputAllowed = true, outputAllowed = false))
 			}
 			.addPort(IOType.FLUID, 3, 0, 3) {
-				IOPort.RegisteredMetaDataInput(this, FluidInputMetadata(fluidOutput, inputAllowed = false, outputAllowed = true))
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(
+						fluidOutput,
+						inputAllowed = false,
+						outputAllowed = true,
+						outputCondition = ::canExtractSteam
+					)
+				)
 			}
 			.addPort(IOType.FLUID, 0, 1, 6) {
 				IOPort.RegisteredMetaDataInput(this, FluidInputMetadata(pollutionStorage, inputAllowed = false, outputAllowed = true))
@@ -509,6 +518,16 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			burningOutput = 0.0
 
 			return Tasks.getSyncBlocking { tryStartFuel(System.currentTimeMillis()) }
+		}
+
+		@Synchronized
+		private fun canExtractSteam(): Boolean {
+			val storedSteam = fluidOutput.getContents().amount
+
+			if (storedSteam <= EPSILON) steamOutputUnlocked = false
+			else if (!steamOutputUnlocked && storedSteam >= MINIMUM_STEAM_OUTPUT_RELEASE) steamOutputUnlocked = true
+
+			return steamOutputUnlocked
 		}
 
 		private fun tryStartFuel(now: Long): Boolean {
@@ -612,6 +631,7 @@ object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntit
 			private const val PASSIVE_COOLING_PER_SECOND = 5.0
 			private const val MAXIMUM_WATER_CONVERSION_PER_SECOND = 5.0
 			private const val STEAM_EXPANSION_FACTOR = 12.0
+			private const val MINIMUM_STEAM_OUTPUT_RELEASE = 5.0
 
 			private const val MAXIMUM_DELTA_MILLIS = 1_000L
 			private const val EPSILON = 0.000_001

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockItemFuel.kt
@@ -1,0 +1,620 @@
+package net.horizonsend.ion.server.features.multiblock.type.fluid.boiler
+
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.server.core.registration.keys.FluidTypeKeys
+import net.horizonsend.ion.server.features.client.display.modular.DisplayHandlers
+import net.horizonsend.ion.server.features.client.display.modular.TextDisplayHandler
+import net.horizonsend.ion.server.features.client.display.modular.display.MATCH_SIGN_FONT_SIZE
+import net.horizonsend.ion.server.features.client.display.modular.display.StatusDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.fluid.ComplexFluidDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.getLinePos
+import net.horizonsend.ion.server.features.industry.ItemFuelProperties
+import net.horizonsend.ion.server.features.multiblock.Multiblock
+import net.horizonsend.ion.server.features.multiblock.entity.MultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.PersistentMultiblockData
+import net.horizonsend.ion.server.features.multiblock.entity.type.DisplayMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.StatusMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.StatusMultiblockEntity.StatusManager
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.FluidInputMetadata
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.FluidStoringMultiblock
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.storage.FluidRestriction
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.storage.FluidStorageContainer
+import net.horizonsend.ion.server.features.multiblock.entity.type.ticked.AsyncTickingMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.ticked.TickedMultiblockEntityParent
+import net.horizonsend.ion.server.features.multiblock.manager.MultiblockManager
+import net.horizonsend.ion.server.features.multiblock.shape.MultiblockShape
+import net.horizonsend.ion.server.features.multiblock.type.EntityMultiblock
+import net.horizonsend.ion.server.features.multiblock.type.fluid.boiler.BoilerMultiblockItemFuel.ItemBoilerEntity
+import net.horizonsend.ion.server.features.multiblock.util.PrepackagedPreset
+import net.horizonsend.ion.server.features.transport.fluids.FluidStack
+import net.horizonsend.ion.server.features.transport.inputs.IOData
+import net.horizonsend.ion.server.features.transport.inputs.IOPort
+import net.horizonsend.ion.server.features.transport.inputs.IOType
+import net.horizonsend.ion.server.miscellaneous.registrations.persistence.NamespacedKeys
+import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.horizonsend.ion.server.miscellaneous.utils.coordinates.RelativeFace
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.Material
+import org.bukkit.Particle
+import org.bukkit.World
+import org.bukkit.block.BlockFace
+import org.bukkit.block.data.type.Slab
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataType.DOUBLE
+import org.bukkit.persistence.PersistentDataType.LONG
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+object BoilerMultiblockItemFuel : Multiblock(), EntityMultiblock<ItemBoilerEntity> {
+	override val name: String = "boiler"
+	override val signText: Array<Component?> = createSignText(
+		ofChildren(text("Item ", NamedTextColor.RED), text("Boiler", HEColorScheme.HE_MEDIUM_GRAY)),
+		null,
+		null,
+		null
+	)
+
+	override fun MultiblockShape.buildStructure() {
+		z(6) {
+			y(-1) {
+				x(-3).anySlab(PrepackagedPreset.slab(Slab.Type.TOP))
+				x(-2).titaniumBlock()
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+				x(2).titaniumBlock()
+				x(3).anySlab(PrepackagedPreset.slab(Slab.Type.TOP))
+			}
+			y(0) {
+				x(-3).anyWall()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyWall()
+			}
+			y(1) {
+				x(-3).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(-2).titaniumBlock()
+				x(-1).titaniumBlock()
+				x(0).fluidInput()
+				x(1).titaniumBlock()
+				x(2).titaniumBlock()
+				x(3).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+			y(2) {
+				x(0).anyFluidPipe()
+			}
+		}
+		z(5) {
+			y(-1) {
+				x(-3).titaniumBlock()
+				x(-2).titaniumBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).titaniumBlock()
+				x(3).titaniumBlock()
+			}
+			y(0) {
+				x(-3).type(Material.MUD_BRICKS)
+				x(-2).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).type(Material.MUD_BRICKS)
+			}
+			y(1) {
+				x(-3).titaniumBlock()
+				x(-2).titaniumBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).titaniumBlock()
+				x(3).titaniumBlock()
+			}
+			y(2) {
+				x(-1).steelBlock()
+				x(0).steelBlock()
+				x(1).steelBlock()
+			}
+			y(3) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(4) {
+				x(-1).titaniumBlock()
+				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(1).titaniumBlock()
+			}
+			y(5) {
+				x(-1).titaniumBlock()
+				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(1).titaniumBlock()
+			}
+			y(6) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(7) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(4) {
+			y(-1) {
+				x(-3).titaniumBlock()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).titaniumBlock()
+			}
+			y(0) {
+				x(-3).type(Material.MUD_BRICKS)
+				x(3).type(Material.MUD_BRICKS)
+			}
+			y(1) {
+				x(-3).titaniumBlock()
+				x(-2).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).titaniumBlock()
+			}
+			y(2) {
+				x(-2).steelBlock()
+				x(2).steelBlock()
+			}
+			y(3) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(4) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(5) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(6) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(7) {
+				x(-2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(-1).titaniumBlock()
+				x(1).titaniumBlock()
+				x(2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+			y(8) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(3) {
+			y(-1) {
+				x(-3).titaniumBlock()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).titaniumBlock()
+			}
+			y(0) {
+				x(-3).fluidInput()
+				x(3).fluidInput()
+			}
+			y(1) {
+				x(-3).titaniumBlock()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).titaniumBlock()
+			}
+			y(2) {
+				x(-2).steelBlock()
+				x(2).steelBlock()
+			}
+			y(3) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(4) {
+				x(-2).type(Material.WAXED_COPPER_GRATE)
+				x(2).type(Material.WAXED_COPPER_GRATE)
+			}
+			y(5) {
+				x(-2).type(Material.WAXED_COPPER_GRATE)
+				x(2).type(Material.WAXED_COPPER_GRATE)
+			}
+			y(6) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(7) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(8) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+		}
+		z(2) {
+			y(-1) {
+				x(-3).titaniumBlock()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).titaniumBlock()
+			}
+			y(0) {
+				x(-3).type(Material.MUD_BRICKS)
+				x(3).type(Material.MUD_BRICKS)
+			}
+			y(1) {
+				x(-3).titaniumBlock()
+				x(-2).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).titaniumBlock()
+			}
+			y(2) {
+				x(-2).steelBlock()
+				x(2).steelBlock()
+			}
+			y(3) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(4) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(5) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(6) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(7) {
+				x(-2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(-1).titaniumBlock()
+				x(1).titaniumBlock()
+				x(2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+			y(8) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(1) {
+			y(-1) {
+				x(-3).titaniumBlock()
+				x(-2).titaniumBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).titaniumBlock()
+				x(3).titaniumBlock()
+			}
+			y(0) {
+				x(-3).type(Material.MUD_BRICKS)
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.IRON_BARS)
+				x(0).type(Material.IRON_BARS)
+				x(1).type(Material.IRON_BARS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).type(Material.MUD_BRICKS)
+			}
+			y(1) {
+				x(-3).titaniumBlock()
+				x(-2).titaniumBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).titaniumBlock()
+				x(3).titaniumBlock()
+			}
+			y(2) {
+				x(-1).steelBlock()
+				x(0).steelBlock()
+				x(1).steelBlock()
+			}
+			y(3) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(4) {
+				x(-1).titaniumBlock()
+				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(1).titaniumBlock()
+			}
+			y(5) {
+				x(-1).titaniumBlock()
+				x(0).type(Material.WAXED_COPPER_GRATE)
+				x(1).titaniumBlock()
+			}
+			y(6) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(7) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(0) {
+			y(-1) {
+				x(-3).anySlab(PrepackagedPreset.slab(Slab.Type.TOP))
+				x(-2).titaniumBlock()
+				x(-1).titaniumBlock()
+				x(0).anyPipedInventory()
+				x(1).titaniumBlock()
+				x(2).titaniumBlock()
+				x(3).anySlab(PrepackagedPreset.slab(Slab.Type.TOP))
+			}
+			y(0) {
+				x(-3).anyWall()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.FORWARD, RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(0).anyGlass()
+				x(1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.FORWARD, RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyWall()
+			}
+			y(1) {
+				x(-3).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(-2).titaniumBlock()
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+				x(2).titaniumBlock()
+				x(3).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+	}
+
+	override fun createEntity(
+		manager: MultiblockManager,
+		data: PersistentMultiblockData,
+		world: World,
+		x: Int,
+		y: Int,
+		z: Int,
+		structureDirection: BlockFace
+	): ItemBoilerEntity {
+		return ItemBoilerEntity(manager, data, world, x, y, z, structureDirection)
+	}
+
+	class ItemBoilerEntity(
+		manager: MultiblockManager,
+		data: PersistentMultiblockData,
+		world: World,
+		x: Int,
+		y: Int,
+		z: Int,
+		structureDirection: BlockFace
+	) : MultiblockEntity(manager, BoilerMultiblockItemFuel, world, x, y, z, structureDirection),
+		DisplayMultiblockEntity,
+		FluidStoringMultiblock,
+		StatusMultiblockEntity,
+		AsyncTickingMultiblockEntity {
+		override val tickingManager: TickedMultiblockEntityParent.TickingManager = TickedMultiblockEntityParent.TickingManager(2)
+		override val statusManager: StatusManager = StatusManager()
+
+		val fluidInput = FluidStorageContainer(
+			data,
+			"primaryin",
+			text("Water Input"),
+			NamespacedKeys.key("primaryin"),
+			10_000.0,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.WATER))
+		)
+		val fluidOutput = FluidStorageContainer(
+			data,
+			"primaryout",
+			text("Dense Steam Output"),
+			NamespacedKeys.key("primaryout"),
+			100.0,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.DENSE_STEAM))
+		)
+		val pollutionStorage = FluidStorageContainer(
+			data,
+			"pollution_out",
+			text("Pollution Output"),
+			NamespacedKeys.key("pollution_out"),
+			100_000.0,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.POLLUTION))
+		)
+
+		private var boilerTemperature = data.getAdditionalDataOrDefault(TEMPERATURE_KEY, DOUBLE, AMBIENT_TEMPERATURE)
+		private var burningEnds = data.getAdditionalDataOrDefault(BURNING_ENDS_KEY, LONG, 0L)
+		private var burningOutput = data.getAdditionalDataOrDefault(BURNING_OUTPUT_KEY, DOUBLE, 0.0)
+
+		override val ioData: IOData = IOData.builder(this)
+			.addPort(IOType.FLUID, -3, 0, 3) {
+				IOPort.RegisteredMetaDataInput(this, FluidInputMetadata(fluidInput, inputAllowed = true, outputAllowed = false))
+			}
+			.addPort(IOType.FLUID, 3, 0, 3) {
+				IOPort.RegisteredMetaDataInput(this, FluidInputMetadata(fluidOutput, inputAllowed = false, outputAllowed = true))
+			}
+			.addPort(IOType.FLUID, 0, 1, 6) {
+				IOPort.RegisteredMetaDataInput(this, FluidInputMetadata(pollutionStorage, inputAllowed = false, outputAllowed = true))
+			}
+			.build()
+
+		override val displayHandler: TextDisplayHandler = DisplayHandlers.newMultiblockSignOverlay(this,
+			{ ComplexFluidDisplayModule(handler = it, container = fluidInput, title = text("Input"), offsetLeft = 3.5, offsetUp = 1.15, offsetBack = -4.0 + 0.39, scale = 0.7f, RelativeFace.RIGHT) },
+			{ ComplexFluidDisplayModule(handler = it, container = fluidOutput, title = text("Output"), offsetLeft = -3.5, offsetUp = 1.15, offsetBack = -4.0 + 0.39, scale = 0.7f, RelativeFace.LEFT) },
+			{ StatusDisplayModule(handler = it, statusSupplier = statusManager, offsetLeft = 0.0, offsetUp = getLinePos(4), offsetBack = 0.0, scale = MATCH_SIGN_FONT_SIZE) },
+		)
+
+		override fun getStores(): List<FluidStorageContainer> = listOf(fluidInput, fluidOutput, pollutionStorage)
+
+		override fun storeAdditionalData(store: PersistentMultiblockData, adapterContext: PersistentDataAdapterContext) {
+			saveStorageData(store)
+			store.addAdditionalData(TEMPERATURE_KEY, DOUBLE, boilerTemperature)
+			store.addAdditionalData(BURNING_ENDS_KEY, LONG, burningEnds)
+			store.addAdditionalData(BURNING_OUTPUT_KEY, DOUBLE, burningOutput)
+		}
+
+		override fun tickAsync() {
+			bootstrapNetwork()
+			val deltaSeconds = min(deltaTMS, MAXIMUM_DELTA_MILLIS).toDouble() / 1000.0
+			val burning = continueOrStartBurning()
+
+			if (burning) {
+				boilerTemperature += (burningOutput * deltaSeconds) / BOILER_THERMAL_MASS
+				boilerTemperature = min(boilerTemperature, MAXIMUM_TEMPERATURE)
+				Tasks.sync { if (!removed) displayBurningParticles() }
+			}
+
+			val boiledWater = boilWater(deltaSeconds)
+
+			if (!burning) {
+				boilerTemperature = maxOf(AMBIENT_TEMPERATURE, boilerTemperature - (PASSIVE_COOLING_PER_SECOND * deltaSeconds))
+			}
+
+			// Overheat explosions are intentionally disabled. A full steam output only stops further boiling.
+			updateStatus(burning, boiledWater)
+		}
+
+		private fun continueOrStartBurning(): Boolean {
+			val now = System.currentTimeMillis()
+			if (burningEnds > now) return true
+
+			burningEnds = 0L
+			burningOutput = 0.0
+
+			return Tasks.getSyncBlocking { tryStartFuel(System.currentTimeMillis()) }
+		}
+
+		private fun tryStartFuel(now: Long): Boolean {
+			if (removed) return false
+
+			val fuelInventory = getInventory(0, -1, 0) ?: return false
+
+			for (slot in 0 until fuelInventory.size) {
+				val itemStack = fuelInventory.getItem(slot) ?: continue
+				val fuelProperties = ItemFuelProperties[itemStack] ?: continue
+
+				// Pollution generation is disabled for now. Keep this block for an easy later re-enable.
+				/*
+				val pollutionStack = fuelProperties.pollutionResult.clone()
+
+				if (!pollutionStorage.canAdd(pollutionStack) || !pollutionStorage.hasRoomFor(pollutionStack)) continue
+				*/
+
+				burningEnds = now + fuelProperties.burnDurationMillis
+				burningOutput = fuelProperties.heatOutputJoulesPerSecond
+
+				if (itemStack.amount <= 1) fuelInventory.setItem(slot, null)
+				else itemStack.amount--
+
+				// pollutionStorage.addFluid(pollutionStack, location)
+				return true
+			}
+
+			return false
+		}
+
+		private fun boilWater(deltaSeconds: Double): Double {
+			if (boilerTemperature <= BOILING_TEMPERATURE) return 0.0
+
+			val inputContents = fluidInput.getContents()
+			if (inputContents.isEmpty() || inputContents.type != FluidTypeKeys.WATER) return 0.0
+
+			val outputContents = fluidOutput.getContents()
+			if (!outputContents.isEmpty() && outputContents.type != FluidTypeKeys.DENSE_STEAM) return 0.0
+
+			val availableEnergy = (boilerTemperature - BOILING_TEMPERATURE) * BOILER_THERMAL_MASS
+			val waterAllowedByHeat = availableEnergy / WATER_LATENT_HEAT_PER_LITER
+			val waterAllowedByOutput = fluidOutput.getRemainingRoom() / STEAM_EXPANSION_FACTOR
+			val waterAllowedByRate = MAXIMUM_WATER_CONVERSION_PER_SECOND * deltaSeconds
+			val waterToBoil = minOf(inputContents.amount, waterAllowedByHeat, waterAllowedByOutput, waterAllowedByRate)
+
+			if (waterToBoil <= EPSILON) return 0.0
+
+			val intendedSteam = waterToBoil * STEAM_EXPANSION_FACTOR
+			val steamNotAdded = fluidOutput.addFluid(FluidStack(FluidTypeKeys.DENSE_STEAM, intendedSteam), location)
+			val steamAdded = intendedSteam - steamNotAdded
+			val waterActuallyBoiled = steamAdded / STEAM_EXPANSION_FACTOR
+
+			if (waterActuallyBoiled <= EPSILON) return 0.0
+
+			fluidInput.removeAmount(waterActuallyBoiled)
+			boilerTemperature = maxOf(
+				BOILING_TEMPERATURE,
+				boilerTemperature - ((waterActuallyBoiled * WATER_LATENT_HEAT_PER_LITER) / BOILER_THERMAL_MASS)
+			)
+
+			return waterActuallyBoiled
+		}
+
+		private fun updateStatus(burning: Boolean, boiledWater: Double) {
+			val temperatureText = "${boilerTemperature.roundToInt()}°C"
+			val inputHasWater = fluidInput.getContents().type == FluidTypeKeys.WATER
+
+			when {
+				fluidOutput.getRemainingRoom() <= EPSILON && inputHasWater -> setStatus(text("Steam output full: $temperatureText", NamedTextColor.RED))
+				boiledWater > EPSILON -> setStatus(text("Boiling: $temperatureText", NamedTextColor.GOLD))
+				burning -> setStatus(text("Heating: $temperatureText", NamedTextColor.YELLOW))
+				boilerTemperature > AMBIENT_TEMPERATURE + EPSILON -> setStatus(text("Cooling: $temperatureText", NamedTextColor.AQUA))
+				else -> setStatus(text("Idle: $temperatureText", NamedTextColor.GRAY))
+			}
+		}
+
+		private fun displayBurningParticles() {
+			val location = getBlockRelative(0, 0, 3).location.toCenterLocation()
+
+			repeat(2) {
+				val offsetX = Random.nextDouble(-2.5, 2.5)
+				val offsetY = Random.nextDouble(-0.45, 0.45)
+				val offsetZ = Random.nextDouble(-2.5, 2.5)
+
+				world.spawnParticle(Particle.FLAME, location.x + offsetX, location.y + offsetY, location.z + offsetZ, 1, 0.0, 0.0, 0.0, 0.0, null)
+			}
+		}
+
+		companion object {
+			private val TEMPERATURE_KEY = NamespacedKeys.key("item_boiler_temperature")
+			private val BURNING_ENDS_KEY = NamespacedKeys.key("item_boiler_burning_ends")
+			private val BURNING_OUTPUT_KEY = NamespacedKeys.key("item_boiler_burning_output")
+
+			private const val AMBIENT_TEMPERATURE = 20.0
+			private const val BOILING_TEMPERATURE = 100.0
+			private const val MAXIMUM_TEMPERATURE = 650.0
+
+			private const val BOILER_THERMAL_MASS = 100_000.0 // Joules required to raise the boiler by 1°C
+			private const val WATER_LATENT_HEAT_PER_LITER = 2_257_000.0
+			private const val PASSIVE_COOLING_PER_SECOND = 5.0
+			private const val MAXIMUM_WATER_CONVERSION_PER_SECOND = 5.0
+			private const val STEAM_EXPANSION_FACTOR = 12.0
+
+			private const val MAXIMUM_DELTA_MILLIS = 1_000L
+			private const val EPSILON = 0.000_001
+		}
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockLiquidFuel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockLiquidFuel.kt
@@ -1,0 +1,718 @@
+package net.horizonsend.ion.server.features.multiblock.type.fluid.boiler
+
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.server.core.registration.keys.CustomBlockKeys
+import net.horizonsend.ion.server.core.registration.keys.FluidTypeKeys
+import net.horizonsend.ion.server.features.client.display.modular.DisplayHandlers
+import net.horizonsend.ion.server.features.client.display.modular.TextDisplayHandler
+import net.horizonsend.ion.server.features.client.display.modular.display.MATCH_SIGN_FONT_SIZE
+import net.horizonsend.ion.server.features.client.display.modular.display.StatusDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.fluid.ComplexFluidDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.fluid.SimpleFluidDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.getLinePos
+import net.horizonsend.ion.server.features.industry.FluidFuelProperties
+import net.horizonsend.ion.server.features.multiblock.Multiblock
+import net.horizonsend.ion.server.features.multiblock.entity.MultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.PersistentMultiblockData
+import net.horizonsend.ion.server.features.multiblock.entity.type.DisplayMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.StatusMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.StatusMultiblockEntity.StatusManager
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.FluidInputMetadata
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.FluidStoringMultiblock
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.storage.FluidRestriction
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.storage.FluidStorageContainer
+import net.horizonsend.ion.server.features.multiblock.entity.type.ticked.AsyncTickingMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.ticked.TickedMultiblockEntityParent
+import net.horizonsend.ion.server.features.multiblock.manager.MultiblockManager
+import net.horizonsend.ion.server.features.multiblock.shape.MultiblockShape
+import net.horizonsend.ion.server.features.multiblock.type.EntityMultiblock
+import net.horizonsend.ion.server.features.multiblock.util.PrepackagedPreset
+import net.horizonsend.ion.server.features.transport.fluids.FluidStack
+import net.horizonsend.ion.server.features.transport.inputs.IOData
+import net.horizonsend.ion.server.features.transport.inputs.IOPort
+import net.horizonsend.ion.server.features.transport.inputs.IOType
+import net.horizonsend.ion.server.miscellaneous.registrations.persistence.NamespacedKeys
+import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.horizonsend.ion.server.miscellaneous.utils.coordinates.RelativeFace
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.Material
+import org.bukkit.Particle
+import org.bukkit.World
+import org.bukkit.block.BlockFace
+import org.bukkit.block.data.Bisected
+import org.bukkit.block.data.type.Slab
+import org.bukkit.block.data.type.Stairs
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataType.DOUBLE
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+object BoilerMultiblockFluidFuel : Multiblock(), EntityMultiblock<BoilerMultiblockFluidFuel.FluidBoilerEntity> {
+	override val name: String = "fluidboiler"
+	override val signText: Array<Component?> = createSignText(
+		ofChildren(text("Fluid ", NamedTextColor.GOLD), text("Boiler", HEColorScheme.HE_MEDIUM_GRAY)),
+		null,
+		null,
+		null
+	)
+
+	override fun MultiblockShape.buildStructure() {
+		z(6) {
+			y(-1) {
+				x(-3).anyWall()
+				x(-2).ironBlock()
+				x(-1).anyStairs(PrepackagedPreset.stairs(RelativeFace.BACKWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(0).anyStairs(PrepackagedPreset.stairs(RelativeFace.BACKWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(1).anyStairs(PrepackagedPreset.stairs(RelativeFace.BACKWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(2).ironBlock()
+				x(3).anyWall()
+			}
+			y(0) {
+				x(-3).anyWall()
+				x(-2).ironBlock()
+				x(-1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(0).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(2).ironBlock()
+				x(3).anyWall()
+			}
+			y(1) {
+				x(-2).anyStairs(PrepackagedPreset.stairs(RelativeFace.BACKWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(-1).anyTerracotta()
+				x(0).fluidInput()
+				x(1).anyTerracotta()
+				x(2).anyStairs(PrepackagedPreset.stairs(RelativeFace.BACKWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+			}
+			y(2) {
+				x(0).anyFluidPipe()
+			}
+		}
+		z(5) {
+			y(-1) {
+				x(-3).ironBlock()
+				x(-2).ironBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).ironBlock()
+				x(1).type(Material.MUD_BRICKS)
+				x(2).ironBlock()
+				x(3).ironBlock()
+			}
+			y(0) {
+				x(-3).ironBlock()
+				x(-2).type(Material.WAXED_COPPER_BLOCK)
+				x(-1).anyFluidPipe()
+				x(0).customBlock(CustomBlockKeys.FLUID_VALVE.getValue())
+				x(1).anyFluidPipe()
+				x(2).type(Material.WAXED_COPPER_BLOCK)
+				x(3).ironBlock()
+			}
+			y(1) {
+				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(-2).ironBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).ironBlock()
+				x(1).type(Material.MUD_BRICKS)
+				x(2).ironBlock()
+				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+			}
+			y(2) {
+				x(-1).steelBlock()
+				x(0).steelBlock()
+				x(1).steelBlock()
+			}
+			y(3) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(4) {
+				x(-1).titaniumBlock()
+				x(0).anyCopperGrate()
+				x(1).titaniumBlock()
+			}
+			y(5) {
+				x(-1).titaniumBlock()
+				x(0).anyCopperGrate()
+				x(1).titaniumBlock()
+			}
+			y(6) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(7) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(4) {
+			y(-1) {
+				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+			}
+			y(0) {
+				x(-3).anyGlassPane(PrepackagedPreset.pane(RelativeFace.FORWARD, RelativeFace.RIGHT, RelativeFace.BACKWARD))
+				x(-2).redstoneBlock()
+				x(0).dispenser()
+				x(2).redstoneBlock()
+				x(3).anyGlassPane(PrepackagedPreset.pane(RelativeFace.FORWARD, RelativeFace.BACKWARD, RelativeFace.LEFT))
+			}
+			y(1) {
+				x(-3).anyTerracotta()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyTerracotta()
+			}
+			y(2) {
+				x(-2).steelBlock()
+				x(2).steelBlock()
+			}
+			y(3) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(4) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(5) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(6) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(7) {
+				x(-2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(-1).titaniumBlock()
+				x(1).titaniumBlock()
+				x(2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+			y(8) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(3) {
+			y(-1) {
+				x(-3).anyTerracotta()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyTerracotta()
+			}
+			y(0) {
+				x(-3).fluidInput()
+				x(-2).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).fluidInput()
+			}
+			y(1) {
+				x(-3).anyTerracotta()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyTerracotta()
+			}
+			y(2) {
+				x(-2).steelBlock()
+				x(2).steelBlock()
+			}
+			y(3) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(4) {
+				x(-2).anyCopperGrate()
+				x(2).anyCopperGrate()
+			}
+			y(5) {
+				x(-2).anyCopperGrate()
+				x(2).anyCopperGrate()
+			}
+			y(6) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(7) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(8) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+		}
+		z(2) {
+			y(-1) {
+				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+			}
+			y(0) {
+				x(-3).anyGlassPane(PrepackagedPreset.pane(RelativeFace.FORWARD, RelativeFace.RIGHT, RelativeFace.BACKWARD))
+				x(-2).redstoneBlock()
+				x(0).dispenser()
+				x(2).redstoneBlock()
+				x(3).anyGlassPane(PrepackagedPreset.pane(RelativeFace.FORWARD, RelativeFace.BACKWARD, RelativeFace.LEFT))
+			}
+			y(1) {
+				x(-3).anyTerracotta()
+				x(-2).type(Material.MUD_BRICKS)
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).type(Material.MUD_BRICKS)
+				x(1).type(Material.MUD_BRICKS)
+				x(2).type(Material.MUD_BRICKS)
+				x(3).anyTerracotta()
+			}
+			y(2) {
+				x(-2).steelBlock()
+				x(2).steelBlock()
+			}
+			y(3) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(4) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(5) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(6) {
+				x(-2).titaniumBlock()
+				x(2).titaniumBlock()
+			}
+			y(7) {
+				x(-2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(-1).titaniumBlock()
+				x(1).titaniumBlock()
+				x(2).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+			y(8) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(1) {
+			y(-1) {
+				x(-3).ironBlock()
+				x(-2).ironBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).ironBlock()
+				x(1).type(Material.MUD_BRICKS)
+				x(2).ironBlock()
+				x(3).ironBlock()
+			}
+			y(0) {
+				x(-3).ironBlock()
+				x(-2).type(Material.WAXED_COPPER_BLOCK)
+				x(-1).anyFluidPipe()
+				x(0).anyFluidPipe()
+				x(1).anyFluidPipe()
+				x(2).type(Material.WAXED_COPPER_BLOCK)
+				x(3).ironBlock()
+			}
+			y(1) {
+				x(-3).anyStairs(PrepackagedPreset.stairs(RelativeFace.RIGHT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(-2).ironBlock()
+				x(-1).type(Material.MUD_BRICKS)
+				x(0).ironBlock()
+				x(1).type(Material.MUD_BRICKS)
+				x(2).ironBlock()
+				x(3).anyStairs(PrepackagedPreset.stairs(RelativeFace.LEFT, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+			}
+			y(2) {
+				x(-1).steelBlock()
+				x(0).steelBlock()
+				x(1).steelBlock()
+			}
+			y(3) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(4) {
+				x(-1).titaniumBlock()
+				x(0).anyCopperGrate()
+				x(1).titaniumBlock()
+			}
+			y(5) {
+				x(-1).titaniumBlock()
+				x(0).anyCopperGrate()
+				x(1).titaniumBlock()
+			}
+			y(6) {
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+			y(7) {
+				x(-1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+				x(0).titaniumBlock()
+				x(1).anySlab(PrepackagedPreset.slab(Slab.Type.BOTTOM))
+			}
+		}
+		z(0) {
+			y(-1) {
+				x(-3).anyWall()
+				x(-2).ironBlock()
+				x(-1).anyStairs(PrepackagedPreset.stairs(RelativeFace.FORWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(0).fluidInput()
+				x(1).anyStairs(PrepackagedPreset.stairs(RelativeFace.FORWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(2).ironBlock()
+				x(3).anyWall()
+			}
+			y(0) {
+				x(-3).anyWall()
+				x(-2).ironBlock()
+
+				x(-1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(0).anyGlass()
+				x(1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
+				x(2).ironBlock()
+				x(3).anyWall()
+			}
+			y(1) {
+				x(-2).anyStairs(PrepackagedPreset.stairs(RelativeFace.FORWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+				x(-1).anyTerracotta()
+				x(0).anyStairs(PrepackagedPreset.stairs(RelativeFace.FORWARD, Bisected.Half.TOP, shape = Stairs.Shape.STRAIGHT))
+				x(1).anyTerracotta()
+				x(2).anyStairs(PrepackagedPreset.stairs(RelativeFace.FORWARD, Bisected.Half.BOTTOM, shape = Stairs.Shape.STRAIGHT))
+			}
+		}
+	}
+
+
+	override fun createEntity(
+		manager: MultiblockManager,
+		data: PersistentMultiblockData,
+		world: World,
+		x: Int,
+		y: Int,
+		z: Int,
+		structureDirection: BlockFace
+	): FluidBoilerEntity {
+		return FluidBoilerEntity(manager, data, world, x, y, z, structureDirection)
+	}
+
+	class FluidBoilerEntity(
+		manager: MultiblockManager,
+		data: PersistentMultiblockData,
+		world: World,
+		x: Int,
+		y: Int,
+		z: Int,
+		structureDirection: BlockFace
+	) : MultiblockEntity(manager, BoilerMultiblockFluidFuel, world, x, y, z, structureDirection),
+		DisplayMultiblockEntity,
+		FluidStoringMultiblock,
+		StatusMultiblockEntity,
+		AsyncTickingMultiblockEntity {
+		override val tickingManager: TickedMultiblockEntityParent.TickingManager =
+			TickedMultiblockEntityParent.TickingManager(2)
+		override val statusManager: StatusManager = StatusManager()
+
+		val fluidInput = FluidStorageContainer(
+			data,
+			"primaryin",
+			text("Water Input"),
+			NamespacedKeys.key("primaryin"),
+			10_000.0,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.WATER))
+		)
+		val fluidOutput = FluidStorageContainer(
+			data,
+			"primaryout",
+			text("Dense Steam Output"),
+			NamespacedKeys.key("primaryout"),
+			100.0,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.DENSE_STEAM))
+		)
+		val fuelStorage = FluidStorageContainer(
+			data,
+			"fuel_storage",
+			text("Fuel Storage"),
+			NamespacedKeys.key("fuel_storage"),
+			100_000.0,
+			FluidRestriction.FluidTypeWhitelist(FluidFuelProperties.acceptedFluidTypes)
+		)
+		val pollutionStorage = FluidStorageContainer(
+			data,
+			"pollution_out",
+			text("Pollution Output"),
+			NamespacedKeys.key("pollution_out"),
+			100_000.0,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.POLLUTION))
+		)
+
+		private var boilerTemperature =
+			data.getAdditionalDataOrDefault(TEMPERATURE_KEY, DOUBLE, AMBIENT_TEMPERATURE)
+		@Volatile private var steamOutputUnlocked =
+			fluidOutput.getContents().amount >= MINIMUM_STEAM_OUTPUT_RELEASE
+
+		override val ioData: IOData = IOData.builder(this)
+			.addPort(IOType.FLUID, -3, 0, 3) {
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(fluidInput, inputAllowed = true, outputAllowed = false)
+				)
+			}
+			.addPort(IOType.FLUID, 3, 0, 3) {
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(
+						fluidOutput,
+						inputAllowed = false,
+						outputAllowed = true,
+						outputCondition = ::canExtractSteam
+					)
+				)
+			}
+			.addPort(IOType.FLUID, 0, -1, 0) {
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(fuelStorage, inputAllowed = true, outputAllowed = false)
+				)
+			}
+			.addPort(IOType.FLUID, 0, 1, 6) {
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(pollutionStorage, inputAllowed = false, outputAllowed = true)
+				)
+			}
+			.build()
+
+		override val displayHandler: TextDisplayHandler = DisplayHandlers.newMultiblockSignOverlay(
+			this,
+			{
+				ComplexFluidDisplayModule(
+					handler = it,
+					container = fluidInput,
+					title = text("Input"),
+					offsetLeft = 3.5,
+					offsetUp = 1.15,
+					offsetBack = -4.0 + 0.39,
+					scale = 0.7f,
+					RelativeFace.RIGHT
+				)
+			},
+			{
+				ComplexFluidDisplayModule(
+					handler = it,
+					container = fluidOutput,
+					title = text("Output"),
+					offsetLeft = -3.5,
+					offsetUp = 1.15,
+					offsetBack = -4.0 + 0.39,
+					scale = 0.7f,
+					RelativeFace.LEFT
+				)
+			},
+			{
+				SimpleFluidDisplayModule(
+					handler = it,
+					storage = fuelStorage,
+					offsetLeft = 0.0,
+					offsetUp = getLinePos(2),
+					offsetBack = 0.0,
+					scale = MATCH_SIGN_FONT_SIZE
+				)
+			},
+			{
+				StatusDisplayModule(
+					handler = it,
+					statusSupplier = statusManager,
+					offsetLeft = 0.0,
+					offsetUp = getLinePos(4),
+					offsetBack = 0.0,
+					scale = MATCH_SIGN_FONT_SIZE
+				)
+			}
+		)
+
+		override fun getStores(): List<FluidStorageContainer> =
+			listOf(fluidInput, fluidOutput, fuelStorage, pollutionStorage)
+
+		override fun storeAdditionalData(
+			store: PersistentMultiblockData,
+			adapterContext: PersistentDataAdapterContext
+		) {
+			saveStorageData(store)
+			store.addAdditionalData(TEMPERATURE_KEY, DOUBLE, boilerTemperature)
+		}
+
+		override fun tickAsync() {
+			bootstrapNetwork()
+			val deltaSeconds = min(deltaTMS, MAXIMUM_DELTA_MILLIS).toDouble() / 1000.0
+			val burning = consumeFuel(deltaSeconds)
+
+			if (burning) {
+				Tasks.sync { if (!removed) displayBurningParticles() }
+			}
+
+			boilWater(deltaSeconds)
+
+			if (!burning) {
+				boilerTemperature = maxOf(
+					AMBIENT_TEMPERATURE,
+					boilerTemperature - (PASSIVE_COOLING_PER_SECOND * deltaSeconds)
+				)
+			}
+
+			updateTemperatureDisplay()
+		}
+
+		private fun consumeFuel(deltaSeconds: Double): Boolean {
+			val fuelContents = fuelStorage.getContents()
+			if (fuelContents.isEmpty()) return false
+
+			val fuelProperties = FluidFuelProperties[fuelContents.type] ?: return false
+			val requestedFuel = minOf(
+				FUEL_CONSUMPTION_PER_SECOND * deltaSeconds,
+				fuelContents.amount
+			)
+			if (requestedFuel <= EPSILON) return false
+
+			val fuelNotRemoved = fuelStorage.removeAmount(requestedFuel)
+			val fuelRemoved = requestedFuel - fuelNotRemoved
+			if (fuelRemoved <= EPSILON) return false
+
+			val energyProduced = fuelRemoved * fuelProperties.joulesPerLiter
+			boilerTemperature = min(
+				MAXIMUM_TEMPERATURE,
+				boilerTemperature + (energyProduced / BOILER_THERMAL_MASS)
+			)
+
+			return true
+		}
+
+		@Synchronized
+		private fun canExtractSteam(): Boolean {
+			val storedSteam = fluidOutput.getContents().amount
+
+			if (storedSteam <= EPSILON) steamOutputUnlocked = false
+			else if (!steamOutputUnlocked && storedSteam >= MINIMUM_STEAM_OUTPUT_RELEASE) {
+				steamOutputUnlocked = true
+			}
+
+			return steamOutputUnlocked
+		}
+
+		private fun boilWater(deltaSeconds: Double): Double {
+			if (boilerTemperature <= BOILING_TEMPERATURE) return 0.0
+
+			val inputContents = fluidInput.getContents()
+			if (inputContents.isEmpty() || inputContents.type != FluidTypeKeys.WATER) return 0.0
+
+			val outputContents = fluidOutput.getContents()
+			if (!outputContents.isEmpty() && outputContents.type != FluidTypeKeys.DENSE_STEAM) return 0.0
+
+			val availableEnergy =
+				(boilerTemperature - BOILING_TEMPERATURE) * BOILER_THERMAL_MASS
+			val waterAllowedByHeat = availableEnergy / WATER_LATENT_HEAT_PER_LITER
+			val waterAllowedByOutput = fluidOutput.getRemainingRoom() / STEAM_EXPANSION_FACTOR
+			val waterAllowedByRate = MAXIMUM_WATER_CONVERSION_PER_SECOND * deltaSeconds
+			val waterToBoil = minOf(
+				inputContents.amount,
+				waterAllowedByHeat,
+				waterAllowedByOutput,
+				waterAllowedByRate
+			)
+
+			if (waterToBoil <= EPSILON) return 0.0
+
+			val intendedSteam = waterToBoil * STEAM_EXPANSION_FACTOR
+			val steamNotAdded = fluidOutput.addFluid(
+				FluidStack(FluidTypeKeys.DENSE_STEAM, intendedSteam),
+				location
+			)
+			val steamAdded = intendedSteam - steamNotAdded
+			val waterActuallyBoiled = steamAdded / STEAM_EXPANSION_FACTOR
+
+			if (waterActuallyBoiled <= EPSILON) return 0.0
+
+			fluidInput.removeAmount(waterActuallyBoiled)
+			boilerTemperature = maxOf(
+				BOILING_TEMPERATURE,
+				boilerTemperature -
+					((waterActuallyBoiled * WATER_LATENT_HEAT_PER_LITER) / BOILER_THERMAL_MASS)
+			)
+
+			return waterActuallyBoiled
+		}
+
+		private fun updateTemperatureDisplay() {
+			setStatus(text("${boilerTemperature.roundToInt()}°C", NamedTextColor.WHITE))
+		}
+
+		private fun displayBurningParticles() {
+			val particleLocation = getBlockRelative(0, 0, 3).location.toCenterLocation()
+
+			repeat(2) {
+				val offsetX = Random.nextDouble(-2.5, 2.5)
+				val offsetY = Random.nextDouble(-0.45, 0.45)
+				val offsetZ = Random.nextDouble(-2.5, 2.5)
+
+				world.spawnParticle(
+					Particle.FLAME,
+					particleLocation.x + offsetX,
+					particleLocation.y + offsetY,
+					particleLocation.z + offsetZ,
+					1,
+					0.0,
+					0.0,
+					0.0,
+					0.0,
+					null
+				)
+			}
+		}
+
+		companion object {
+			private val TEMPERATURE_KEY = NamespacedKeys.key("fluid_boiler_temperature")
+
+			private const val AMBIENT_TEMPERATURE = 20.0
+			private const val BOILING_TEMPERATURE = 100.0
+			private const val MAXIMUM_TEMPERATURE = 650.0
+
+			private const val BOILER_THERMAL_MASS = 100_000.0
+			private const val WATER_LATENT_HEAT_PER_LITER = 2_257_000.0
+			private const val PASSIVE_COOLING_PER_SECOND = 5.0
+			private const val MAXIMUM_WATER_CONVERSION_PER_SECOND = 5.0
+			private const val STEAM_EXPANSION_FACTOR = 6.0
+			private const val MINIMUM_STEAM_OUTPUT_RELEASE = 5.0
+			private const val FUEL_CONSUMPTION_PER_SECOND = 0.5
+
+			private const val MAXIMUM_DELTA_MILLIS = 1_000L
+			private const val EPSILON = 0.000_001
+		}
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockLiquidFuel.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/boiler/BoilerMultiblockLiquidFuel.kt
@@ -51,7 +51,7 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.random.Random
 
-object BoilerMultiblockFluidFuel : Multiblock(), EntityMultiblock<BoilerMultiblockFluidFuel.FluidBoilerEntity> {
+object BoilerMultiblockLiquidFuel : Multiblock(), EntityMultiblock<BoilerMultiblockLiquidFuel.LiquidFuelBoilerEntity> {
 	override val name: String = "fluidboiler"
 	override val signText: Array<Component?> = createSignText(
 		ofChildren(text("Fluid ", NamedTextColor.GOLD), text("Boiler", HEColorScheme.HE_MEDIUM_GRAY)),
@@ -393,7 +393,6 @@ object BoilerMultiblockFluidFuel : Multiblock(), EntityMultiblock<BoilerMultiblo
 			y(0) {
 				x(-3).anyWall()
 				x(-2).ironBlock()
-
 				x(-1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
 				x(0).anyGlass()
 				x(1).anyGlassPane(PrepackagedPreset.pane(RelativeFace.RIGHT, RelativeFace.LEFT))
@@ -410,7 +409,6 @@ object BoilerMultiblockFluidFuel : Multiblock(), EntityMultiblock<BoilerMultiblo
 		}
 	}
 
-
 	override fun createEntity(
 		manager: MultiblockManager,
 		data: PersistentMultiblockData,
@@ -419,11 +417,11 @@ object BoilerMultiblockFluidFuel : Multiblock(), EntityMultiblock<BoilerMultiblo
 		y: Int,
 		z: Int,
 		structureDirection: BlockFace
-	): FluidBoilerEntity {
-		return FluidBoilerEntity(manager, data, world, x, y, z, structureDirection)
+	): LiquidFuelBoilerEntity {
+		return LiquidFuelBoilerEntity(manager, data, world, x, y, z, structureDirection)
 	}
 
-	class FluidBoilerEntity(
+	class LiquidFuelBoilerEntity(
 		manager: MultiblockManager,
 		data: PersistentMultiblockData,
 		world: World,
@@ -431,7 +429,7 @@ object BoilerMultiblockFluidFuel : Multiblock(), EntityMultiblock<BoilerMultiblo
 		y: Int,
 		z: Int,
 		structureDirection: BlockFace
-	) : MultiblockEntity(manager, BoilerMultiblockFluidFuel, world, x, y, z, structureDirection),
+	) : MultiblockEntity(manager, BoilerMultiblockLiquidFuel, world, x, y, z, structureDirection),
 		DisplayMultiblockEntity,
 		FluidStoringMultiblock,
 		StatusMultiblockEntity,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/turbine/SteamTurbineMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/turbine/SteamTurbineMultiblock.kt
@@ -1,0 +1,174 @@
+package net.horizonsend.ion.server.features.multiblock.type.fluid.turbine
+
+import net.horizonsend.ion.server.features.multiblock.shape.MultiblockShape
+
+object SteamTurbineMultiblock : TurbineMultiblock() {
+	override val maximumSteamConsumptionPerSecond: Double = 7.4
+	override val maximumPowerGenerationPerSecond: Double = 110.0
+	override val steamInputCapacity: Double = 1_000_000.0
+
+	override fun MultiblockShape.buildStructure() {
+		z(0) {
+			y(0) {
+				x(-1).extractor()
+				x(0).ironBlock()
+				x(1).extractor()
+				x(-1).fluidInput()
+				x(0).anyCopperBulb()
+				x(1).fluidInput()
+			}
+			y(-1) {
+				x(-1).fluidInput()
+				x(-1).extractor()
+				x(0).powerInput()
+				x(1).fluidInput()
+				x(1).extractor()
+			}
+		}
+		z(1) {
+			y(-1) {
+				x(-2).lightningRod()
+				x(-1).anyCopperGrate()
+				x(0).steelBlock()
+				x(0).terracottaOrDoubleSlab()
+				x(1).anyCopperGrate()
+				x(2).lightningRod()
+			}
+			y(0) {
+				x(-1).ironBlock()
+				x(0).steelBlock()
+				x(1).ironBlock()
+				x(-1).titaniumBlock()
+				x(0).ironBlock()
+				x(1).titaniumBlock()
+			}
+			y(1) {
+				x(0).titaniumBlock()
+			}
+		}
+		z(2) {
+			y(-1) {
+				x(-2).lightningRod()
+				x(-1).anyCopperGrate()
+				x(0).steelBlock()
+				x(0).terracottaOrDoubleSlab()
+				x(1).anyCopperGrate()
+				x(2).lightningRod()
+			}
+			y(0) {
+				x(-2).ironBlock()
+				x(-1).steelBlock()
+				x(0).anyCopperBulb()
+				x(1).steelBlock()
+				x(2).ironBlock()
+				x(-2).titaniumBlock()
+				x(-1).ironBlock()
+				x(0).ironBlock()
+				x(1).ironBlock()
+				x(2).titaniumBlock()
+			}
+			y(1) {
+				x(-2).ironBlock()
+				x(-2).titaniumBlock()
+				x(0).ironBlock()
+				x(2).ironBlock()
+				x(2).titaniumBlock()
+			}
+			y(2) {
+				x(-1).ironBlock()
+				x(0).ironBlock()
+				x(1).ironBlock()
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+		}
+		z(3) {
+			y(-1) {
+				x(-2).lightningRod()
+				x(-1).anyCopperGrate()
+				x(0).steelBlock()
+				x(0).terracottaOrDoubleSlab()
+				x(1).anyCopperGrate()
+				x(2).lightningRod()
+			}
+			y(0) {
+				x(-1).ironBlock()
+				x(0).steelBlock()
+				x(1).ironBlock()
+				x(-1).titaniumBlock()
+				x(0).ironBlock()
+				x(1).titaniumBlock()
+			}
+			y(1) {
+				x(0).titaniumBlock()
+			}
+		}
+		z(4) {
+			y(-1) {
+				x(-2).lightningRod()
+				x(-1).anyCopperGrate()
+				x(0).steelBlock()
+				x(0).terracottaOrDoubleSlab()
+				x(1).anyCopperGrate()
+				x(2).lightningRod()
+			}
+			y(0) {
+				x(-2).ironBlock()
+				x(-1).steelBlock()
+				x(0).anyCopperBulb()
+				x(1).steelBlock()
+				x(2).ironBlock()
+				x(-2).titaniumBlock()
+				x(-1).ironBlock()
+				x(0).ironBlock()
+				x(1).ironBlock()
+				x(2).titaniumBlock()
+			}
+			y(1) {
+				x(-2).ironBlock()
+				x(-2).titaniumBlock()
+				x(0).ironBlock()
+				x(2).ironBlock()
+				x(2).titaniumBlock()
+			}
+			y(2) {
+				x(-1).ironBlock()
+				x(0).ironBlock()
+				x(1).ironBlock()
+				x(-1).titaniumBlock()
+				x(0).titaniumBlock()
+				x(1).titaniumBlock()
+			}
+		}
+		z(5) {
+			y(-1) {
+				x(-2).lightningRod()
+				x(-1).anyCopperGrate()
+				x(0).steelBlock()
+				x(0).terracottaOrDoubleSlab()
+				x(1).anyCopperGrate()
+				x(2).lightningRod()
+			}
+			y(0) {
+				x(-1).ironBlock()
+				x(0).steelBlock()
+				x(1).ironBlock()
+				x(-1).titaniumBlock()
+				x(0).ironBlock()
+				x(1).titaniumBlock()
+			}
+			y(1) {
+				x(0).titaniumBlock()
+			}
+		}
+		z(6) {
+			y(-1) {
+				x(0).terracottaOrDoubleSlab()
+			}
+			y(0) {
+				x(0).anyCopperBulb()
+			}
+		}
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/turbine/SteamTurbineMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/turbine/SteamTurbineMultiblock.kt
@@ -10,18 +10,13 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 	override fun MultiblockShape.buildStructure() {
 		z(0) {
 			y(0) {
-				x(-1).extractor()
-				x(0).ironBlock()
-				x(1).extractor()
 				x(-1).fluidInput()
 				x(0).anyCopperBulb()
 				x(1).fluidInput()
 			}
 			y(-1) {
-				x(-1).fluidInput()
 				x(-1).extractor()
 				x(0).powerInput()
-				x(1).fluidInput()
 				x(1).extractor()
 			}
 		}
@@ -29,15 +24,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 			y(-1) {
 				x(-2).lightningRod()
 				x(-1).anyCopperGrate()
-				x(0).steelBlock()
 				x(0).terracottaOrDoubleSlab()
 				x(1).anyCopperGrate()
 				x(2).lightningRod()
 			}
 			y(0) {
-				x(-1).ironBlock()
-				x(0).steelBlock()
-				x(1).ironBlock()
 				x(-1).titaniumBlock()
 				x(0).ironBlock()
 				x(1).titaniumBlock()
@@ -50,17 +41,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 			y(-1) {
 				x(-2).lightningRod()
 				x(-1).anyCopperGrate()
-				x(0).steelBlock()
 				x(0).terracottaOrDoubleSlab()
 				x(1).anyCopperGrate()
 				x(2).lightningRod()
 			}
 			y(0) {
-				x(-2).ironBlock()
-				x(-1).steelBlock()
-				x(0).anyCopperBulb()
-				x(1).steelBlock()
-				x(2).ironBlock()
 				x(-2).titaniumBlock()
 				x(-1).ironBlock()
 				x(0).ironBlock()
@@ -68,16 +53,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 				x(2).titaniumBlock()
 			}
 			y(1) {
-				x(-2).ironBlock()
 				x(-2).titaniumBlock()
 				x(0).ironBlock()
-				x(2).ironBlock()
 				x(2).titaniumBlock()
 			}
 			y(2) {
-				x(-1).ironBlock()
-				x(0).ironBlock()
-				x(1).ironBlock()
 				x(-1).titaniumBlock()
 				x(0).titaniumBlock()
 				x(1).titaniumBlock()
@@ -87,15 +67,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 			y(-1) {
 				x(-2).lightningRod()
 				x(-1).anyCopperGrate()
-				x(0).steelBlock()
 				x(0).terracottaOrDoubleSlab()
 				x(1).anyCopperGrate()
 				x(2).lightningRod()
 			}
 			y(0) {
-				x(-1).ironBlock()
-				x(0).steelBlock()
-				x(1).ironBlock()
 				x(-1).titaniumBlock()
 				x(0).ironBlock()
 				x(1).titaniumBlock()
@@ -108,17 +84,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 			y(-1) {
 				x(-2).lightningRod()
 				x(-1).anyCopperGrate()
-				x(0).steelBlock()
 				x(0).terracottaOrDoubleSlab()
 				x(1).anyCopperGrate()
 				x(2).lightningRod()
 			}
 			y(0) {
-				x(-2).ironBlock()
-				x(-1).steelBlock()
-				x(0).anyCopperBulb()
-				x(1).steelBlock()
-				x(2).ironBlock()
 				x(-2).titaniumBlock()
 				x(-1).ironBlock()
 				x(0).ironBlock()
@@ -126,16 +96,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 				x(2).titaniumBlock()
 			}
 			y(1) {
-				x(-2).ironBlock()
 				x(-2).titaniumBlock()
 				x(0).ironBlock()
-				x(2).ironBlock()
 				x(2).titaniumBlock()
 			}
 			y(2) {
-				x(-1).ironBlock()
-				x(0).ironBlock()
-				x(1).ironBlock()
 				x(-1).titaniumBlock()
 				x(0).titaniumBlock()
 				x(1).titaniumBlock()
@@ -145,15 +110,11 @@ object SteamTurbineMultiblock : TurbineMultiblock() {
 			y(-1) {
 				x(-2).lightningRod()
 				x(-1).anyCopperGrate()
-				x(0).steelBlock()
 				x(0).terracottaOrDoubleSlab()
 				x(1).anyCopperGrate()
 				x(2).lightningRod()
 			}
 			y(0) {
-				x(-1).ironBlock()
-				x(0).steelBlock()
-				x(1).ironBlock()
 				x(-1).titaniumBlock()
 				x(0).ironBlock()
 				x(1).titaniumBlock()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/turbine/TurbineMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/fluid/turbine/TurbineMultiblock.kt
@@ -1,0 +1,177 @@
+package net.horizonsend.ion.server.features.multiblock.type.fluid.turbine
+
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_LIGHT_BLUE
+import net.horizonsend.ion.common.utils.text.colors.HEColorScheme.Companion.HE_MEDIUM_GRAY
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.server.core.registration.keys.FluidTypeKeys
+import net.horizonsend.ion.server.features.client.display.modular.DisplayHandlers
+import net.horizonsend.ion.server.features.client.display.modular.TextDisplayHandler
+import net.horizonsend.ion.server.features.client.display.modular.display.MATCH_SIGN_FONT_SIZE
+import net.horizonsend.ion.server.features.client.display.modular.display.PowerEntityDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.fluid.SplitFluidDisplayModule
+import net.horizonsend.ion.server.features.client.display.modular.display.getLinePos
+import net.horizonsend.ion.server.features.multiblock.Multiblock
+import net.horizonsend.ion.server.features.multiblock.entity.PersistentMultiblockData
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.FluidInputMetadata
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.FluidStoringMultiblock
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.storage.FluidRestriction
+import net.horizonsend.ion.server.features.multiblock.entity.type.fluids.storage.FluidStorageContainer
+import net.horizonsend.ion.server.features.multiblock.entity.type.power.SimplePoweredEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.ticked.AsyncTickingMultiblockEntity
+import net.horizonsend.ion.server.features.multiblock.entity.type.ticked.TickedMultiblockEntityParent
+import net.horizonsend.ion.server.features.multiblock.manager.MultiblockManager
+import net.horizonsend.ion.server.features.multiblock.type.EntityMultiblock
+import net.horizonsend.ion.server.features.multiblock.type.fluid.turbine.TurbineMultiblock.TurbineMultiblockEntity
+import net.horizonsend.ion.server.features.transport.inputs.IOData
+import net.horizonsend.ion.server.features.transport.inputs.IOPort
+import net.horizonsend.ion.server.features.transport.inputs.IOType
+import net.horizonsend.ion.server.miscellaneous.registrations.persistence.NamespacedKeys
+import net.kyori.adventure.text.Component
+import org.bukkit.World
+import org.bukkit.block.BlockFace
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataType
+import kotlin.math.floor
+
+abstract class TurbineMultiblock : Multiblock(), EntityMultiblock<TurbineMultiblockEntity> {
+	override val name: String = "turbine"
+
+	abstract val maximumSteamConsumptionPerSecond: Double
+	abstract val maximumPowerGenerationPerSecond: Double
+	abstract val steamInputCapacity: Double
+
+	override val signText: Array<Component?> = createSignText(
+		ofChildren(Component.text("Steam", HE_LIGHT_BLUE), Component.text(" Turbine", HE_MEDIUM_GRAY)),
+		null,
+		null,
+		null
+	)
+
+	override fun createEntity(
+		manager: MultiblockManager,
+		data: PersistentMultiblockData,
+		world: World,
+		x: Int,
+		y: Int,
+		z: Int,
+		structureDirection: BlockFace
+	): TurbineMultiblockEntity {
+		return TurbineMultiblockEntity(data, manager, this, world, x, y, z, structureDirection)
+	}
+
+	class TurbineMultiblockEntity(
+		data: PersistentMultiblockData,
+		manager: MultiblockManager,
+		override val multiblock: TurbineMultiblock,
+		world: World,
+		x: Int,
+		y: Int,
+		z: Int,
+		structureDirection: BlockFace
+	) : SimplePoweredEntity(data, multiblock, manager, x, y, z, world, structureDirection, MAXIMUM_POWER_STORAGE),
+		AsyncTickingMultiblockEntity,
+		FluidStoringMultiblock {
+		override val tickingManager: TickedMultiblockEntityParent.TickingManager = TickedMultiblockEntityParent.TickingManager(2)
+
+		val steamInput = FluidStorageContainer(
+			data,
+			"steam_input",
+			Component.text("Dense Steam Input"),
+			STEAM_INPUT_KEY,
+			multiblock.steamInputCapacity,
+			FluidRestriction.FluidTypeWhitelist(setOf(FluidTypeKeys.DENSE_STEAM))
+		)
+
+		private var generatedPowerRemainder = data.getAdditionalDataOrDefault(POWER_REMAINDER_KEY, PersistentDataType.DOUBLE, 0.0)
+
+		override val ioData: IOData = IOData.builder(this)
+			.addPort(IOType.FLUID, -1, 0, 0) {
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(connectedStore = steamInput, inputAllowed = true, outputAllowed = false)
+				)
+			}
+			.addPort(IOType.FLUID, 1, 0, 0) {
+				IOPort.RegisteredMetaDataInput(
+					this,
+					FluidInputMetadata(connectedStore = steamInput, inputAllowed = true, outputAllowed = false)
+				)
+			}
+			.addPowerInput(0, -1, 0)
+			.build()
+
+		override val displayHandler: TextDisplayHandler = DisplayHandlers.newMultiblockSignOverlay(
+			this,
+			{
+				SplitFluidDisplayModule(
+					handler = it,
+					storage = steamInput,
+					offsetLeft = 0.0,
+					offsetUp = getLinePos(4),
+					offsetBack = 0.0,
+					scale = MATCH_SIGN_FONT_SIZE
+				)
+			},
+			{
+				PowerEntityDisplayModule(
+					handler = it,
+					multiblockEntity = this,
+					offsetLeft = 0.0,
+					offsetUp = getLinePos(2),
+					offsetBack = 0.0,
+					scale = MATCH_SIGN_FONT_SIZE
+				)
+			}
+		)
+
+		override fun getStores(): List<FluidStorageContainer> = listOf(steamInput)
+
+		override fun storeAdditionalData(store: PersistentMultiblockData, adapterContext: PersistentDataAdapterContext) {
+			savePowerData(store)
+			saveStorageData(store)
+			store.addAdditionalData(POWER_REMAINDER_KEY, PersistentDataType.DOUBLE, generatedPowerRemainder)
+		}
+
+		override fun tickAsync() {
+			bootstrapNetwork()
+
+			val deltaSeconds = minOf(deltaTMS, MAXIMUM_DELTA_MILLIS).toDouble() / 1000.0
+			generatePower(deltaSeconds)
+		}
+
+		private fun generatePower(deltaSeconds: Double) {
+			if (powerStorage.isFull()) return
+
+			val steam = steamInput.getContents()
+			if (steam.isEmpty()) return
+
+			if (steam.type != FluidTypeKeys.DENSE_STEAM) return
+
+			val powerPerLiter = multiblock.maximumPowerGenerationPerSecond / multiblock.maximumSteamConsumptionPerSecond
+			val remainingPowerCapacity = powerStorage.getRemainingCapacity().toDouble() - generatedPowerRemainder
+			if (remainingPowerCapacity <= EPSILON) return
+
+			val steamAllowedByRate = multiblock.maximumSteamConsumptionPerSecond * deltaSeconds
+			val steamAllowedByPowerStorage = remainingPowerCapacity / powerPerLiter
+			val steamToConsume = minOf(steam.amount, steamAllowedByRate, steamAllowedByPowerStorage)
+			if (steamToConsume <= EPSILON) return
+
+			steamInput.removeAmount(steamToConsume)
+
+			val exactGeneratedPower = generatedPowerRemainder + (steamToConsume * powerPerLiter)
+			val wholeGeneratedPower = floor(exactGeneratedPower).toInt()
+			generatedPowerRemainder = exactGeneratedPower - wholeGeneratedPower
+
+			if (wholeGeneratedPower > 0) powerStorage.addPower(wholeGeneratedPower)
+		}
+
+		companion object {
+			private const val MAXIMUM_POWER_STORAGE = 500_000
+			private const val MAXIMUM_DELTA_MILLIS = 1_000L
+			private const val EPSILON = 0.000_001
+
+			private val STEAM_INPUT_KEY = NamespacedKeys.key("turbine_steam_input")
+			private val POWER_REMAINDER_KEY = NamespacedKeys.key("turbine_power_remainder")
+		}
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/transport/fluids/types/SimpleGasFluid.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/transport/fluids/types/SimpleGasFluid.kt
@@ -11,6 +11,11 @@ import org.bukkit.Particle.Trail
 import org.bukkit.World
 import org.bukkit.block.BlockFace
 import org.bukkit.util.Vector
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.tan
+import kotlin.random.Random
 
 class SimpleGasFluid(
 	key: IonRegistryKey<FluidType, out FluidType>,
@@ -31,12 +36,37 @@ class SimpleGasFluid(
 	}
 
 	override fun playLeakEffects(world: World, leakingNode: FluidNode, leakingDirection: BlockFace) {
+		val forward = leakingDirection.direction.normalize()
+		val reference = if (forward.y != 0.0) Vector(1.0, 0.0, 0.0) else Vector(0.0, 1.0, 0.0)
+		val right = forward.clone().crossProduct(reference).normalize()
+		val up = right.clone().crossProduct(forward).normalize()
+
+		val azimuth = Random.nextDouble(0.0, PI * 2.0)
+		val spread = Random.nextDouble() * tan(MAXIMUM_LEAK_ANGLE_RADIANS)
+		val randomizedDirection = forward.clone()
+			.add(right.clone().multiply(cos(azimuth) * spread))
+			.add(up.clone().multiply(sin(azimuth) * spread))
+			.normalize()
+
 		val start = leakingNode.getCenter()
-			.add(leakingDirection.direction.multiply(0.5))
+			.add(forward.clone().multiply(0.5))
+			.add(right.clone().multiply(Random.nextDouble(-START_POSITION_VARIATION, START_POSITION_VARIATION)))
+			.add(up.clone().multiply(Random.nextDouble(-START_POSITION_VARIATION, START_POSITION_VARIATION)))
 			.toLocation(world)
-		val destination = start.clone().add(leakingDirection.direction.multiply(leakDistance))
-		val trailOptions = Trail(destination, color, 40)
+		val randomizedDistance = leakDistance * Random.nextDouble(MINIMUM_DISTANCE_MULTIPLIER, MAXIMUM_DISTANCE_MULTIPLIER)
+		val destination = start.clone().add(randomizedDirection.multiply(randomizedDistance))
+		val duration = Random.nextInt(MINIMUM_LEAK_DURATION_TICKS, MAXIMUM_LEAK_DURATION_TICKS + 1)
+		val trailOptions = Trail(destination, color, duration)
 
 		world.spawnParticle(Particle.TRAIL, start, 1, 0.0, 0.0, 0.0, 0.0, trailOptions, true)
+	}
+
+	companion object {
+		private val MAXIMUM_LEAK_ANGLE_RADIANS = Math.toRadians(30.0)
+		private const val START_POSITION_VARIATION = 0.08
+		private const val MINIMUM_DISTANCE_MULTIPLIER = 0.75
+		private const val MAXIMUM_DISTANCE_MULTIPLIER = 1.25
+		private const val MINIMUM_LEAK_DURATION_TICKS = 30
+		private const val MAXIMUM_LEAK_DURATION_TICKS = 60
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/transport/fluids/types/SimpleGasFluid.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/transport/fluids/types/SimpleGasFluid.kt
@@ -1,0 +1,42 @@
+package net.horizonsend.ion.server.features.transport.fluids.types
+
+import net.horizonsend.ion.server.core.registration.IonRegistryKey
+import net.horizonsend.ion.server.features.transport.fluids.FluidType
+import net.horizonsend.ion.server.features.transport.fluids.properties.FluidCategory
+import net.horizonsend.ion.server.features.transport.manager.graph.fluid.FluidNode
+import net.kyori.adventure.text.Component
+import org.bukkit.Color
+import org.bukkit.Particle
+import org.bukkit.Particle.Trail
+import org.bukkit.World
+import org.bukkit.block.BlockFace
+import org.bukkit.util.Vector
+
+class SimpleGasFluid(
+	key: IonRegistryKey<FluidType, out FluidType>,
+	override val displayName: Component,
+	private val color: Color,
+	private val leakDistance: Double = 5.0
+) : FluidType(key) {
+	override val categories: Array<FluidCategory> = arrayOf(FluidCategory.GAS)
+
+	override fun displayInPipe(world: World, origin: Vector, destination: Vector) {
+		val trailOptions = Trail(
+			destination.toLocation(world),
+			color,
+			20
+		)
+
+		world.spawnParticle(Particle.TRAIL, origin.toLocation(world), 1, 0.0, 0.0, 0.0, 0.0, trailOptions, false)
+	}
+
+	override fun playLeakEffects(world: World, leakingNode: FluidNode, leakingDirection: BlockFace) {
+		val start = leakingNode.getCenter()
+			.add(leakingDirection.direction.multiply(0.5))
+			.toLocation(world)
+		val destination = start.clone().add(leakingDirection.direction.multiply(leakDistance))
+		val trailOptions = Trail(destination, color, 40)
+
+		world.spawnParticle(Particle.TRAIL, start, 1, 0.0, 0.0, 0.0, 0.0, trailOptions, true)
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/transport/manager/graph/fluid/FluidNode.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/transport/manager/graph/fluid/FluidNode.kt
@@ -120,7 +120,7 @@ abstract class FluidNode(val volume: Double) : TransportNode {
 		override val flowCapacity = 50.0
 
 		val removalCapacity: Double get() = 50.0
-		val additionCapacity: Double get() = 5.0
+		val additionCapacity: Double get() = 20.0
 
 		override fun isIntact(): Boolean? {
 			val world = getNetwork().manager.transportManager.getWorld()


### PR DESCRIPTION
Enabled /multiblock place for pump Fixed fluid pipes and junctions breaking all connecting fluid pipes and junctions and dropping chorus fruit when broken.
Added Item and fluid boilers to generate steam.
Added set up for later pollution implementation.
Added Turbine generator.

Pumps can be detected with [pump]
Item Boiler can be detected with [boiler]
Liquid Boiler can be detected with [fluidboiler]
Steam turbine can be detected with [turbine]

Item boilers can use dried kelp, redstone, uranium, and coal along with all of their block variants as fuel.
Liquid boiler ca use lava and all fuel gasses in liquid form as fuel.
Boilers input water and output steam, turbine takes in steam and generates energy.

In game usage of this new power source (if added) is not immediately recommended as there are certainly changes to be made and any set ups could be broken in the future.

dev notes in pr comment