### PR TITLE
Improve movement while flying

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -721,15 +721,6 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		failIf(!starship.isDirectControlEnabled && !isHoldingController(sender)) {
 			"You need to hold a starship controller to enable direct control"
 		}
-		/*
-		if (starship.initialBlockCount > StarshipType.DESTROYER.maxSize) {
-			sender.serverError(
-				"Only ships of size ${StarshipType.DESTROYER.maxSize} or less can use direct control, " +
-					"this is mostly a performance thing, and will probably change in the future."
-			)
-			return
-		}
-		 */
 
 		starship.setDirectControlEnabled(!starship.isDirectControlEnabled)
 	}
@@ -739,7 +730,7 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 	fun onCruiseControl(sender: Player){
 		val starship = getStarshipPiloting(sender)
 
-		starship.setDirectCruiseControlEnabled(!starship.isDirectCruiseControlEanble)
+		starship.setDirectCruiseControlEnabled(!starship.isDirectCruiseControlEnable)
 	}
 
 	@Suppress("unused")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/command/starship/MiscStarshipCommands.kt
@@ -734,6 +734,14 @@ object MiscStarshipCommands : net.horizonsend.ion.server.command.SLCommand() {
 		starship.setDirectControlEnabled(!starship.isDirectControlEnabled)
 	}
 
+	@CommandAlias("cruisecontrol|cc|CC")
+	@Suppress("unused")
+	fun onCruiseControl(sender: Player){
+		val starship = getStarshipPiloting(sender)
+
+		starship.setDirectCruiseControlEnabled(!starship.isDirectCruiseControlEanble)
+	}
+
 	@Suppress("unused")
 	@CommandAlias("cruise")
 	fun onCruise(sender: Player) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -40,7 +40,7 @@ class SettingsMainMenuGui(player: Player) : SettingsPageGui(player, "Settings") 
 			DBCachedBooleanToggle(text("Switch Light/Heavy Weapon Keys"), "Switches the firing controls for light and heavy weapons.", GuiItem.LIST, false, PlayerSettings::alternateFireButtons),
 			DBCachedBooleanToggle(text("Rotate Player with the ship"), "Disables camera rotation, useful for aiming player guided missiles.", GuiItem.COMPASS_NEEDLE, true, PlayerSettings::playerRotateWithShip),
 
-			DBCachedEnumCycle(PlayerInput.TertiaryButtonControl::class.java, text("Change Tertiary Control Function"), "Changes the functionality of the Tertiary Control (jumping in dc)", GuiItem.LIST, 0, PlayerSettings::tertiaryButtonControl),
+			DBCachedEnumCycle(PlayerInput.TertiaryButtonControl::class.java, text("Change Tertiary Control Function"), "Changes the functionality of the Tertiary Control (sprint key in dc)", GuiItem.LIST, 0, PlayerSettings::tertiaryButtonControl),
 		),
 		createSettingsPage(player, "Sidebar Settings",
 			createSettingsPage(player, "Combat Timer Settings",

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -14,6 +14,7 @@ import net.horizonsend.ion.server.features.sidebar.MainSidebar
 import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar.ContactsColoring
 import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar.ContactsSorting
 import net.horizonsend.ion.server.features.starship.control.input.PlayerDirectControlInput
+import net.horizonsend.ion.server.features.starship.control.input.PlayerInput
 import net.horizonsend.ion.server.miscellaneous.AudioRange
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
@@ -38,7 +39,8 @@ class SettingsMainMenuGui(player: Player) : SettingsPageGui(player, "Settings") 
 			DBCachedBooleanToggle(text("Toggle DC Speed Boost Key"), "Enabling this setting changes the DC boost key to a toggle.", GuiItem.LIST, false, PlayerSettings::toggleDcBoost),
 			DBCachedBooleanToggle(text("Switch Light/Heavy Weapon Keys"), "Switches the firing controls for light and heavy weapons.", GuiItem.LIST, false, PlayerSettings::alternateFireButtons),
 			DBCachedBooleanToggle(text("Rotate Player with the ship"), "Disables camera rotation, useful for aiming player guided missiles.", GuiItem.COMPASS_NEEDLE, true, PlayerSettings::playerRotateWithShip),
-			DBCachedEnumCycle(PlayerDirectControlInput.TertiaryButtonControl::class.java, text("Change Tertiary Control Function"), "Changes the functionality of the Tertiary Control (jumping in dc)", GuiItem.LIST, 0, PlayerSettings::tertiaryButtonControl),
+
+			DBCachedEnumCycle(PlayerInput.TertiaryButtonControl::class.java, text("Change Tertiary Control Function"), "Changes the functionality of the Tertiary Control (jumping in dc)", GuiItem.LIST, 0, PlayerSettings::tertiaryButtonControl),
 		),
 		createSettingsPage(player, "Sidebar Settings",
 			createSettingsPage(player, "Combat Timer Settings",

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
@@ -17,6 +17,7 @@ import net.horizonsend.ion.server.features.gui.custom.settings.SoundSettings
 import net.horizonsend.ion.server.features.sidebar.MainSidebar
 import net.horizonsend.ion.server.features.sidebar.tasks.ContactsSidebar
 import net.horizonsend.ion.server.features.starship.control.input.PlayerDirectControlInput
+import net.horizonsend.ion.server.features.starship.control.input.PlayerInput
 import net.horizonsend.ion.server.miscellaneous.AudioRange
 import net.horizonsend.ion.server.miscellaneous.utils.slPlayerId
 import org.bukkit.entity.Player
@@ -92,8 +93,8 @@ object SettingsCommand : SLCommand() {
 
 	@CommandAlias("control tertiarycontrollers")
 	@CommandCompletion("@controlTertiaryControl")
-	fun onSettingsControlChangeTertiaryControl(sender: Player, value: PlayerDirectControlInput.TertiaryButtonControl) = asyncCommand(sender) {
-		handleEnumCycleSetting(sender, PlayerSettings::tertiaryButtonControl, value, PlayerDirectControlInput.TertiaryButtonControl::class.java)
+	fun onSettingsControlChangeTertiaryControl(sender: Player, value: PlayerInput.TertiaryButtonControl) = asyncCommand(sender) {
+		handleEnumCycleSetting(sender, PlayerSettings::tertiaryButtonControl, value, PlayerInput.TertiaryButtonControl::class.java)
 	}
 
     @CommandAlias("sidebar combattimer enablecombattimerinfo")

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/hyperdrive/HyperdriveMultiblock.kt
@@ -62,7 +62,8 @@ abstract class HyperdriveMultiblock : Multiblock(), InteractableMultiblock, Disp
 	}
 
 	override fun onSignInteract(sign: Sign, player: Player, event: PlayerInteractEvent) {
-		if (ActiveStarships.findByPilot(player)?.isDirectControlEnabled == true) return
+		val starship = ActiveStarships.findByPilot(player)
+		if (starship?.isDirectControlEnabled == true || starship?.isDirectCruiseControlEnable == true) return
 		NavigationCommand.openNavigationGui(player)
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -46,8 +46,11 @@ import net.horizonsend.ion.server.features.starship.control.controllers.player.U
 import net.horizonsend.ion.server.features.starship.control.input.AIDirectControlInput
 import net.horizonsend.ion.server.features.starship.control.input.AIShiftFlightInput
 import net.horizonsend.ion.server.features.starship.control.input.PlayerDirectControlInput
+import net.horizonsend.ion.server.features.starship.control.input.PlayerDirectCruiseControlInput
 import net.horizonsend.ion.server.features.starship.control.input.PlayerShiftFlightInput
+import net.horizonsend.ion.server.features.starship.control.movement.CruiseData
 import net.horizonsend.ion.server.features.starship.control.movement.DirectControlHandler
+import net.horizonsend.ion.server.features.starship.control.movement.DirectCruiseControlHandler
 import net.horizonsend.ion.server.features.starship.control.movement.ShiftFlightHandler
 import net.horizonsend.ion.server.features.starship.control.movement.StarshipControl
 import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising
@@ -375,10 +378,12 @@ class Starship(
 	//endregion
 
 	//region Movement
-	var cruiseData = StarshipCruising.CruiseData(this)
+	var cruiseData = CruiseData(this)
 	var lastBlockedTime: Long = 0
 	val manualMoveCooldownMillis: Long = (cbrt(initialBlockCount.toDouble()) * 40).toLong()
 	var speedLimit = -1
+	val directCruiseSpeedMultiplier: Double = 1.0
+
 	// manual move is sneak/direct control
 	var lastManualMove = System.nanoTime() / 1_000_000
 
@@ -462,6 +467,10 @@ class Starship(
 		return controller.movementHandler is DirectControlHandler
 	}
 
+	val isDirectCruiseControlEanble: Boolean get(){
+		return controller.movementHandler is DirectCruiseControlHandler
+	}
+
 	var directControlCenter: Location? = null
 
 	// Stored on starship so it can't be reset by switching to dc and back
@@ -483,6 +492,22 @@ class Starship(
 				val controller = controller as AIController
 				if (enabled) controller.movementHandler = DirectControlHandler(controller, AIDirectControlInput(controller)) else
 					controller.movementHandler = ShiftFlightHandler(controller, AIShiftFlightInput(controller))
+			}
+			else -> return
+		}
+	}
+
+	fun setDirectCruiseControlEnabled(enabled: Boolean){
+		if (enabled && this.isDirectControlEnabled) {
+			this.userErrorAction("Direct Cruise Control cannot be enabled while Direct Control is activated")
+			return
+		}
+		when (controller) {
+			is ActivePlayerController -> {
+				val controller = controller as ActivePlayerController
+				if (enabled) controller.movementHandler =
+					DirectCruiseControlHandler(controller, PlayerDirectCruiseControlInput(controller)) else
+					controller.movementHandler = ShiftFlightHandler(controller, PlayerShiftFlightInput(controller))
 			}
 			else -> return
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -173,6 +173,9 @@ class Starship(
 	val carriedShips: MutableMap<StarshipData, LongOpenHashSet> = carriedShips.toMutableMap()
 	val statusEffects: MutableMap<StarshipStatusEffectType, MutableList<StarshipStatusEffect>> = mutableMapOf()
 
+	var cruiseTickCount = 0
+	var moveThisShipThisTick = false
+
 	var world: World = data.bukkitWorld()
 		set(value) {
 			ActiveStarships.updateWorld(this, field, value)
@@ -186,6 +189,12 @@ class Starship(
 		subsystems.forEach { it.tick() }
 		shiftKinematicEstimator.removeData()
 		cruiseKinematicEstimator.removeData()
+
+		cruiseTickCount+=1
+		if(cruiseTickCount.toDouble() == 20*StarshipCruising.SECONDS_PER_CRUISE){
+			cruiseTickCount = 0
+			moveThisShipThisTick = true
+		}
 
 		if (forecastEnabled) {
 			displayForecast(this)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -382,7 +382,9 @@ class Starship(
 	var lastBlockedTime: Long = 0
 	val manualMoveCooldownMillis: Long = (cbrt(initialBlockCount.toDouble()) * 40).toLong()
 	var speedLimit = -1
-	val directCruiseSpeedMultiplier: Double = 1.0
+
+	//direct cruise, cruise speedup (brings direct cruise in line with shift fly speed in certain situations).
+	var directCruiseSpeedAddition: Double = 0.0
 
 	// manual move is sneak/direct control
 	var lastManualMove = System.nanoTime() / 1_000_000

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -12,7 +12,6 @@ import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.extensions.informationAction
 import net.horizonsend.ion.common.extensions.serverError
 import net.horizonsend.ion.common.extensions.success
-import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.extensions.userErrorAction
 import net.horizonsend.ion.common.utils.miscellaneous.d
 import net.horizonsend.ion.common.utils.miscellaneous.squared
@@ -479,7 +478,7 @@ class Starship(
 		return controller.movementHandler is DirectControlHandler
 	}
 
-	val isDirectCruiseControlEanble: Boolean get(){
+	val isDirectCruiseControlEnable: Boolean get(){
 		return controller.movementHandler is DirectCruiseControlHandler
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/Starship.kt
@@ -12,6 +12,7 @@ import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.extensions.informationAction
 import net.horizonsend.ion.common.extensions.serverError
 import net.horizonsend.ion.common.extensions.success
+import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.extensions.userErrorAction
 import net.horizonsend.ion.common.utils.miscellaneous.d
 import net.horizonsend.ion.common.utils.miscellaneous.squared
@@ -491,6 +492,12 @@ class Starship(
 	fun setDirectControlEnabled(enabled: Boolean) {
 		if (enabled && StarshipCruising.isCruising(this)) {
 			this.userErrorAction("Direct Control cannot be enabled while cruising")
+			return
+		}
+		if (this.initialBlockCount > 12501){
+			this.userErrorAction(
+				"Only ships of size 12500 or less can use direct control"
+			)
 			return
 		}
 		when (controller) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipComputers.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/StarshipComputers.kt
@@ -90,7 +90,7 @@ object StarshipComputers : IonServerComponent() {
 		}
 
 		val starship = PilotedStarships[player]
-		if (starship != null && starship.isDirectControlEnabled) {
+		if (starship != null && (starship.isDirectControlEnabled || starship.isDirectCruiseControlEnable)) {
 			player.userErrorActionMessage("Cannot interact with starship computer while in Direct Control!")
 			return
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/InputInterfaces.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/InputInterfaces.kt
@@ -2,13 +2,22 @@ package net.horizonsend.ion.server.features.starship.control.input
 
 
 import com.destroystokyo.paper.event.player.PlayerJumpEvent
+import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
+import net.horizonsend.ion.common.extensions.success
+import net.horizonsend.ion.server.command.admin.debugBanner
+import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSettingOrThrow
+import net.horizonsend.ion.server.features.starship.Starship
+import net.horizonsend.ion.server.features.starship.active.ActiveStarships
 import net.horizonsend.ion.server.features.starship.control.controllers.Controller
+import net.horizonsend.ion.server.features.starship.control.movement.CruiseData
 import net.horizonsend.ion.server.miscellaneous.utils.coordinates.Vec3i
 import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerItemHeldEvent
 import org.bukkit.event.player.PlayerMoveEvent
 import org.bukkit.event.player.PlayerToggleSneakEvent
 import org.bukkit.util.Vector
+import kotlin.collections.indexOf
+import kotlin.collections.set
 
 
 interface InputHandler {
@@ -43,12 +52,55 @@ interface DirecterControlInput : InputHandler {
 	override fun getData(): Vec3i
 }
 
+interface DirectCruiseControlInput : InputHandler {
+	override fun getData(): CruiseData
+}
+
 interface PlayerInput {
 	val player : Player
 	fun handleMove(event: PlayerMoveEvent) {}
 	fun handleSneak(event: PlayerToggleSneakEvent) {}
 	fun handleJump(event: PlayerJumpEvent) {}
 	fun handlePlayerHoldItem(event: PlayerItemHeldEvent) {}
+	fun handleTertiaryInput(starship: Starship) {
+		when(TertiaryButtonControl.entries[player.getSettingOrThrow(PlayerSettings::tertiaryButtonControl)]) {
+			TertiaryButtonControl.NOTHING->{}
+			TertiaryButtonControl.DISRUPT-> {
+				//Disrupts the ship the player is looking at
+				player.debugBanner("INTERACT EVENT DISRUPT TARGETING START")
+				val targetShip = ActiveStarships.getInWorld(player.world).filter {
+					it.centerOfMass.toCenterVector().distanceSquared(player.location.toVector()) <=
+						starship.balancing.interdictionRange * starship.balancing.interdictionRange &&
+						it != ActiveStarships.findByPassenger(player)
+				}.sortedBy { it.centerOfMass.toCenterVector().subtract(player.location.toVector()).angle(player.eyeLocation.direction) }.firstOrNull()
+
+				targetShip.let {
+					if (it == starship) return //should prevent setting to yourself
+					starship.disruptorTarget = it
+					starship.onlinePassengers.forEach { player -> player.success("Disruptor enabled on ${it?.identifier ?: "unknown starship; their hyperdrive is disabled as long as your starship is in range"}") }
+				}
+				player.debugBanner("INTERACT EVENT DISRUPT TARGETING END")
+			}
+			TertiaryButtonControl.CHANGE_WEAPON_SET ->{
+				val currentWeaponSet = 	starship.weaponSetSelections[player.uniqueId] ?: ""
+				val indexOf = starship.weaponSets.keys().indexOf(currentWeaponSet)+1
+				//if the player hasn't selected a weapon set, or has reached the last weapon set, give them the first one in the index.
+				if(indexOf == -1 || indexOf == starship.weaponSets.size()) {
+					starship.weaponSetSelections[player.uniqueId] = starship.weaponSets.keys().first()
+				}
+				else{
+					starship.weaponSetSelections[player.uniqueId] = starship.weaponSets.keys().elementAt(indexOf)
+				}
+				player.success("Took control of weaponset ${starship.weaponSetSelections[player.uniqueId]}")
+			}
+		}
+	}
+
+	enum class TertiaryButtonControl{
+		NOTHING,
+		DISRUPT,
+		CHANGE_WEAPON_SET,
+	}
 }
 
 interface AIInput {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/InputInterfaces.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/InputInterfaces.kt
@@ -82,14 +82,17 @@ interface PlayerInput {
 				player.debugBanner("INTERACT EVENT DISRUPT TARGETING END")
 			}
 			TertiaryButtonControl.CHANGE_WEAPON_SET ->{
+				val setOfWeaponSets = starship.weaponSets.keys().toSet()
 				val currentWeaponSet = 	starship.weaponSetSelections[player.uniqueId] ?: ""
-				val indexOf = starship.weaponSets.keys().indexOf(currentWeaponSet)+1
+
+				val indexOf = setOfWeaponSets.indexOf(currentWeaponSet)+1
+
 				//if the player hasn't selected a weapon set, or has reached the last weapon set, give them the first one in the index.
-				if(indexOf == -1 || indexOf == starship.weaponSets.size()) {
-					starship.weaponSetSelections[player.uniqueId] = starship.weaponSets.keys().first()
+				if(indexOf == -1 || indexOf == setOfWeaponSets.size) {
+					starship.weaponSetSelections[player.uniqueId] = setOfWeaponSets.first()
 				}
 				else{
-					starship.weaponSetSelections[player.uniqueId] = starship.weaponSets.keys().elementAt(indexOf)
+					starship.weaponSetSelections[player.uniqueId] = setOfWeaponSets.elementAt(indexOf)
 				}
 				player.success("Took control of weaponset ${starship.weaponSetSelections[player.uniqueId]}")
 			}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
@@ -141,11 +141,17 @@ class PlayerDirectControlInput(override val controller: PlayerController) : Dire
 		if (input.isRight) strafe += 1.0
 		if (input.isForward) ascend += 1.0
 		if (input.isBackward) ascend -= 1.0
-		if(input.isJump) {
+		if(input.isSprint) {
 			if(player.server.currentTick-lastTertiaryInput > 10) {
 				handleTertiaryInput(starship)
 				lastTertiaryInput = player.server.currentTick
 			}
+		}
+		if(input.isJump){
+			starship.reactor.powerDistributor.thrusterPortion = 0.1
+		}
+		else {
+			starship.reactor.powerDistributor.thrusterPortion = 0.5
 		}
 
 		// Convert to world-relative vector

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
@@ -3,6 +3,8 @@ package net.horizonsend.ion.server.features.starship.control.input
 //import net.horizonsend.ion.server.features.nations.NationBuffTypes
 import com.destroystokyo.paper.event.player.PlayerJumpEvent
 import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
+import net.horizonsend.ion.common.extensions.information
+import net.horizonsend.ion.common.extensions.informationAction
 import net.horizonsend.ion.common.extensions.success
 import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.server.command.admin.debug
@@ -148,6 +150,7 @@ class PlayerDirectControlInput(override val controller: PlayerController) : Dire
 			}
 		}
 		if(input.isJump){
+			starship.informationAction("Drifting")
 			starship.reactor.powerDistributor.thrusterPortion = 0.1
 		}
 		else {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectControlInput.kt
@@ -143,7 +143,7 @@ class PlayerDirectControlInput(override val controller: PlayerController) : Dire
 		if (input.isBackward) ascend -= 1.0
 		if(input.isJump) {
 			if(player.server.currentTick-lastTertiaryInput > 10) {
-				handleTertiaryInput()
+				handleTertiaryInput(starship)
 				lastTertiaryInput = player.server.currentTick
 			}
 		}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
@@ -88,11 +88,11 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 			starship.directControlCenter = center
 		}
 
-		val effectiveCooldown = ceil(starship.manualMoveCooldownMillis/50.0) * 50
+		val effectiveCooldown = ceil(starship.manualMoveCooldownMillis/50.0) * 100
 
 		val shiftFlySpeed = max(starship.type.balancing.maxSneakFlyAccel.d(), 1.0).div(effectiveCooldown).times(2000.0).toInt().toDouble()
 
-		var dir = player.eyeLocation.direction.normalize()
+		var dir = player.eyeLocation.direction.setY(0).normalize()
 		dir.setY(0)
 		if(currentInput.isForward){
 			starship.directCruiseSpeedAddition = shiftFlySpeed

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
@@ -1,0 +1,165 @@
+package net.horizonsend.ion.server.features.starship.control.input
+
+import com.destroystokyo.paper.event.player.PlayerJumpEvent
+import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
+import net.horizonsend.ion.common.utils.text.ofChildren
+import net.horizonsend.ion.server.command.admin.debug
+import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSetting
+import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
+import net.horizonsend.ion.server.features.starship.control.movement.CruiseData
+import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising
+import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising.startCruising
+import net.horizonsend.ion.server.miscellaneous.utils.minecraft
+import net.kyori.adventure.text.Component.keybind
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.NamedTextColor.GRAY
+import net.kyori.adventure.text.format.NamedTextColor.YELLOW
+import net.minecraft.world.entity.Relative
+import org.bukkit.event.player.PlayerTeleportEvent
+import org.bukkit.event.player.PlayerToggleSneakEvent
+import org.bukkit.util.Vector
+import kotlin.math.PI
+
+class PlayerDirectCruiseControlInput(override val controller: PlayerController): PlayerInput, DirectCruiseControlInput{
+	override val player get() = controller.player
+
+	private var lastTertiaryInput = 0
+
+	var verticalMovement = 0.0
+
+	var ticksToBlockMovementFor = 0
+
+	override fun create() {
+		val message = ofChildren(
+			text("Cruise Control: ", GRAY),
+			text("ON ", GRAY),
+			text("[Use /cc to turn it off - use W/A/S/D to maneuver - hold sneak (", YELLOW),
+			keybind("key.sneak", YELLOW),
+			text(") to move down - hold jump(", YELLOW),
+			keybind("key.jump", YELLOW),
+			text(") to move up - hold both to stop cruising]", YELLOW)
+		)
+
+		controller.sendMessage(message)
+
+		if (player.getSetting(PlayerSettings::floatWhileDc) == true) {
+			player.walkSpeed = 0f
+			player.flySpeed = 0f
+			player.allowFlight = true
+			player.isFlying = true
+		} else {
+			player.walkSpeed = 0.009f
+			player.allowFlight = false
+		}
+
+		val playerLoc = player.location
+		val newCenter = playerLoc.toBlockLocation().add(0.5, playerLoc.y.rem(1), 0.5)
+
+		starship.directControlCenter = newCenter
+		player.teleport(newCenter)
+	}
+
+	override fun destroy() {
+		controller.sendMessage(ofChildren(text("Cruise Control: ", GRAY), text("OFF ", NamedTextColor.RED), text("[Use /cc to turn it on]", YELLOW)))
+
+		player.walkSpeed = 0.2f // default
+		player.flySpeed = 0.06f
+		player.isFlying = false
+	}
+
+	override fun getData(): CruiseData {
+		val currentInput = player.currentInput
+
+		var center = starship.directControlCenter
+		if (center == null) {
+			starship.debug("Direct control center adjusted")
+			val pilotLocation = player.location
+			center = pilotLocation.toBlockLocation().add(0.5, 0.0, 0.5)
+			starship.directControlCenter = center
+		}
+
+		val dir = player.eyeLocation.direction.normalize()
+		dir.setY(0)
+		if(currentInput.isForward) dir.multiply(1)
+		//Handle forward diagonal, and Left
+		if(currentInput.isLeft && currentInput.isForward) dir.rotateAroundY(PI/4)
+		else if(currentInput.isBackward && currentInput.isLeft) dir.rotateAroundY(3*PI/4)
+		else if(currentInput.isLeft) dir.rotateAroundY(PI/2)
+
+		//handle Forward diagnonal, and right
+		else if(currentInput.isRight && currentInput.isForward) dir.rotateAroundY(-PI/4)
+		else if(currentInput.isBackward && currentInput.isRight) dir.rotateAroundY(-3*PI/4)
+		else if(currentInput.isRight)dir.rotateAroundY(-PI/2)
+		else if(currentInput.isBackward) dir.multiply(-1)
+
+		val verticalDistance = .1
+		if(currentInput.isJump) dir.add(Vector(0.0, verticalDistance, 0.0))
+		if(currentInput.isSneak) dir.add(Vector(0.0, -verticalDistance, 0.0))
+
+
+		//if the player hits space bar and sneak at the same time, cancel cruising
+		if(currentInput.isJump && currentInput.isSneak){
+			StarshipCruising.stopCruising(starship.controller, starship)
+			ticksToBlockMovementFor = 5
+			return starship.cruiseData
+		}
+
+		//handle tertiary control
+		if(currentInput.isSprint) {
+			if(player.server.currentTick-lastTertiaryInput > 10) {
+				handleTertiaryInput(starship)
+				lastTertiaryInput = player.server.currentTick
+			}
+		}
+
+		if (player.getSetting(PlayerSettings::floatWhileDc) == true) {
+			player.walkSpeed = 0f
+			player.flySpeed = 0f
+			player.isFlying = true
+		} else {
+			player.walkSpeed = 0.009f
+		}
+
+		// If player moved, teleport them back to dc center
+		if (player.location.subtract(center).length() > .5) {
+			val newLoc = center.clone()
+
+			player.minecraft.teleportTo(
+				newLoc.world.minecraft,
+				newLoc.x,
+				newLoc.y,
+				newLoc.z,
+				setOf(
+					Relative.X_ROT,
+					Relative.Y_ROT,
+				),
+				0f,
+				0f,
+				false,
+				PlayerTeleportEvent.TeleportCause.PLUGIN
+			)
+		}
+
+		if(ticksToBlockMovementFor != 0){
+			ticksToBlockMovementFor -=1
+			return starship.cruiseData
+		}
+
+		//If the player gives an input, change our direction
+		if(currentInput.isForward || currentInput.isBackward || currentInput.isLeft || currentInput.isRight || currentInput.isJump || currentInput.isSneak) {
+			ticksToBlockMovementFor +=2
+			startCruising(
+				starship.controller, starship, dir.normalize(), true
+			)
+		}
+
+		return starship.cruiseData
+	}
+
+	override fun handleJump(event: PlayerJumpEvent) {
+		event.isCancelled = true
+	}
+
+	override fun handleSneak(event: PlayerToggleSneakEvent) {}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
@@ -2,6 +2,7 @@ package net.horizonsend.ion.server.features.starship.control.input
 
 import com.destroystokyo.paper.event.player.PlayerJumpEvent
 import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
+import net.horizonsend.ion.common.utils.miscellaneous.d
 import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.server.command.admin.debug
 import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSetting
@@ -16,10 +17,12 @@ import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.NamedTextColor.GRAY
 import net.kyori.adventure.text.format.NamedTextColor.YELLOW
 import net.minecraft.world.entity.Relative
+import org.bukkit.Material
 import org.bukkit.event.player.PlayerTeleportEvent
 import org.bukkit.event.player.PlayerToggleSneakEvent
 import org.bukkit.util.Vector
 import kotlin.math.PI
+import kotlin.math.max
 
 class PlayerDirectCruiseControlInput(override val controller: PlayerController): PlayerInput, DirectCruiseControlInput{
 	override val player get() = controller.player
@@ -69,19 +72,29 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 	}
 
 	override fun getData(): CruiseData {
+		//if the player is not holding a clock, do not accept anything
+		if (player.inventory.itemInMainHand.type != Material.CLOCK) return starship.cruiseData
 		val currentInput = player.currentInput
 
 		var center = starship.directControlCenter
 		if (center == null) {
-			starship.debug("Direct control center adjusted")
+			starship.debug("Cruise control center adjusted")
 			val pilotLocation = player.location
 			center = pilotLocation.toBlockLocation().add(0.5, 0.0, 0.5)
 			starship.directControlCenter = center
 		}
 
+		val shiftFlySpeed = (max(starship.type.balancing.maxSneakFlyAccel.d(), 1.0).div(starship.manualMoveCooldownMillis)).times(2000.0)
+
 		val dir = player.eyeLocation.direction.normalize()
 		dir.setY(0)
-		if(currentInput.isForward) dir.multiply(1)
+		if(currentInput.isForward){
+			starship.directCruiseSpeedAddition = shiftFlySpeed
+		}
+		else {
+			starship.directCruiseSpeedAddition = 0.0
+		}
+
 		//Handle forward diagonal, and Left
 		if(currentInput.isLeft && currentInput.isForward) dir.rotateAroundY(PI/4)
 		else if(currentInput.isBackward && currentInput.isLeft) dir.rotateAroundY(3*PI/4)
@@ -93,7 +106,8 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 		else if(currentInput.isRight)dir.rotateAroundY(-PI/2)
 		else if(currentInput.isBackward) dir.multiply(-1)
 
-		val verticalDistance = .1
+		val verticalDistance = shiftFlySpeed/starship.cruiseData.targetSpeed
+
 		if(currentInput.isJump) dir.add(Vector(0.0, verticalDistance, 0.0))
 		if(currentInput.isSneak) dir.add(Vector(0.0, -verticalDistance, 0.0))
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
@@ -182,7 +182,7 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 			)
 		}
 		//if the player doesn't provide an input stop the ship moving
-		else {
+		else if(StarshipCruising.isCruising(starship)){
 			stopCruising(starship.controller, starship)
 		}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
@@ -10,6 +10,7 @@ import net.horizonsend.ion.server.features.starship.control.controllers.player.P
 import net.horizonsend.ion.server.features.starship.control.movement.CruiseData
 import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising
 import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising.startCruising
+import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising.stopCruising
 import net.horizonsend.ion.server.miscellaneous.utils.minecraft
 import net.kyori.adventure.text.Component.keybind
 import net.kyori.adventure.text.Component.text
@@ -114,7 +115,7 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 
 		//if the player hits space bar and sneak at the same time, cancel cruising
 		if(currentInput.isJump && currentInput.isSneak){
-			StarshipCruising.stopCruising(starship.controller, starship)
+			stopCruising(starship.controller, starship)
 			ticksToBlockMovementFor = 5
 			return starship.cruiseData
 		}
@@ -166,6 +167,10 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 			startCruising(
 				starship.controller, starship, dir.normalize(), true
 			)
+		}
+		//if the player doesn't provide an input stop the ship moving
+		else {
+			stopCruising(starship.controller, starship)
 		}
 
 		return starship.cruiseData

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/input/PlayerDirectCruiseControlInput.kt
@@ -1,11 +1,14 @@
 package net.horizonsend.ion.server.features.starship.control.input
 
 import com.destroystokyo.paper.event.player.PlayerJumpEvent
+import io.papermc.paper.entity.TeleportFlag
 import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
 import net.horizonsend.ion.common.utils.miscellaneous.d
 import net.horizonsend.ion.common.utils.text.ofChildren
 import net.horizonsend.ion.server.command.admin.debug
 import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSetting
+import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSettingOrThrow
+import net.horizonsend.ion.server.features.nations.utils.getPing
 import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
 import net.horizonsend.ion.server.features.starship.control.movement.CruiseData
 import net.horizonsend.ion.server.features.starship.control.movement.StarshipCruising
@@ -23,6 +26,7 @@ import org.bukkit.event.player.PlayerTeleportEvent
 import org.bukkit.event.player.PlayerToggleSneakEvent
 import org.bukkit.util.Vector
 import kotlin.math.PI
+import kotlin.math.ceil
 import kotlin.math.max
 
 class PlayerDirectCruiseControlInput(override val controller: PlayerController): PlayerInput, DirectCruiseControlInput{
@@ -30,8 +34,7 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 
 	private var lastTertiaryInput = 0
 
-	var verticalMovement = 0.0
-
+	private var internalTick = 0
 	var ticksToBlockMovementFor = 0
 
 	override fun create() {
@@ -85,9 +88,11 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 			starship.directControlCenter = center
 		}
 
-		val shiftFlySpeed = (max(starship.type.balancing.maxSneakFlyAccel.d(), 1.0).div(starship.manualMoveCooldownMillis)).times(2000.0)
+		val effectiveCooldown = ceil(starship.manualMoveCooldownMillis/50.0) * 50
 
-		val dir = player.eyeLocation.direction.normalize()
+		val shiftFlySpeed = max(starship.type.balancing.maxSneakFlyAccel.d(), 1.0).div(effectiveCooldown).times(2000.0).toInt().toDouble()
+
+		var dir = player.eyeLocation.direction.normalize()
 		dir.setY(0)
 		if(currentInput.isForward){
 			starship.directCruiseSpeedAddition = shiftFlySpeed
@@ -107,18 +112,17 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 		else if(currentInput.isRight)dir.rotateAroundY(-PI/2)
 		else if(currentInput.isBackward) dir.multiply(-1)
 
+		//handle side cruising + vertical element
 		val verticalDistance = shiftFlySpeed/starship.cruiseData.targetSpeed
-
 		if(currentInput.isJump) dir.add(Vector(0.0, verticalDistance, 0.0))
 		if(currentInput.isSneak) dir.add(Vector(0.0, -verticalDistance, 0.0))
 
-
-		//if the player hits space bar and sneak at the same time, cancel cruising
-		if(currentInput.isJump && currentInput.isSneak){
-			stopCruising(starship.controller, starship)
-			ticksToBlockMovementFor = 5
-			return starship.cruiseData
+		//handle just vertical element on its own. No side cruising
+		if((currentInput.isSneak || currentInput.isJump) && !(currentInput.isForward || currentInput.isRight || currentInput.isBackward || currentInput.isLeft)){
+			dir = Vector(0.0,verticalDistance.times(if(currentInput.isSneak) -1.0 else 1.0),0.0)
 		}
+		//if there is a vertical element, do not let the directCruiseSpeedAddition be added
+		if (currentInput.isSneak || currentInput.isJump) starship.directCruiseSpeedAddition = 0.0
 
 		//handle tertiary control
 		if(currentInput.isSprint) {
@@ -127,6 +131,15 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 				lastTertiaryInput = player.server.currentTick
 			}
 		}
+
+		// Ping compensation
+		val refreshRate = if (player.getSettingOrThrow(PlayerSettings::dcRefreshRate) == -1) {getPing(player) * 2.0}
+		else (player.getSettingOrThrow(PlayerSettings::dcRefreshRate).toDouble())
+		val catchCooldown = (ceil(refreshRate / 50.0)).toInt().coerceAtLeast(2)
+
+		internalTick++
+		if (internalTick % catchCooldown != 0) return starship.cruiseData // reduce teleports to make it non hyper sensitive
+		internalTick = 0
 
 		if (player.getSetting(PlayerSettings::floatWhileDc) == true) {
 			player.walkSpeed = 0f
@@ -137,7 +150,7 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 		}
 
 		// If player moved, teleport them back to dc center
-		if (player.location.subtract(center).length() > .5) {
+		if (currentInput.isForward || currentInput.isBackward || currentInput.isLeft || currentInput.isRight || currentInput.isJump || currentInput.isSneak) {
 			val newLoc = center.clone()
 
 			player.minecraft.teleportTo(
@@ -165,7 +178,7 @@ class PlayerDirectCruiseControlInput(override val controller: PlayerController):
 		if(currentInput.isForward || currentInput.isBackward || currentInput.isLeft || currentInput.isRight || currentInput.isJump || currentInput.isSneak) {
 			ticksToBlockMovementFor +=2
 			startCruising(
-				starship.controller, starship, dir.normalize(), true
+				starship.controller, starship, dir, true
 			)
 		}
 		//if the player doesn't provide an input stop the ship moving

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/CruiseData.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/CruiseData.kt
@@ -34,7 +34,7 @@ class CruiseData(
             else 0.0
         } ?: 0.0
 
-        val limitedTarget = (targetSpeed * (1 + speedModifier) * (1 - slowModifier) * starship.disabledThrusterRatio + /*nationCruiseModifier + */dominionBpsModifier * starship.directCruiseSpeedMultiplier).toInt()
+        val limitedTarget = (targetSpeed * (1 + speedModifier) * (1 - slowModifier) * starship.disabledThrusterRatio + /*nationCruiseModifier + */dominionBpsModifier + starship.directCruiseSpeedAddition).toInt()
 
         val dir = this.targetDir ?: Vector()
         val speed = if (maxSpeed <= 0) limitedTarget else min(limitedTarget, maxSpeed)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/CruiseData.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/CruiseData.kt
@@ -1,0 +1,80 @@
+package net.horizonsend.ion.server.features.starship.control.movement
+
+import net.horizonsend.ion.common.utils.miscellaneous.roundToHundredth
+import net.horizonsend.ion.server.features.nations.DominionTerritoryBuffTypes
+import net.horizonsend.ion.server.features.starship.active.ActiveControlledStarship
+import net.horizonsend.ion.server.features.starship.status_effects.StarshipStatusEffectTypes
+import org.bukkit.util.Vector
+import kotlin.math.min
+
+class CruiseData(
+    val starship: ActiveControlledStarship,
+    var velocity: Vector = Vector(),
+    var targetSpeed: Int = 0,
+    var targetDir: Vector? = null,
+    var accel: Double = 0.0
+) {
+    var lastBlockCount = starship.initialBlockCount
+
+    fun accelerate(maxSpeed: Int, thrusterPower: Double) {
+        val speedModifier = starship.getStrongestActiveStatusEffectFromType(StarshipStatusEffectTypes.CRUISE_SPEED)?.strength ?: 0.0
+        val slowModifier = starship.getStrongestActiveStatusEffectFromType(StarshipStatusEffectTypes.CRUISE_SLOW)?.strength ?: 0.0
+        /*
+        val nationCruiseModifier = starship.playerPilot?.let { player ->
+            val cruiseBuffActive = NationBuffTypes.isEffectActive(player, NationBuffTypes.CRUISE_SPEED)
+            if (cruiseBuffActive) {
+                NationBuffTypes.CRUISE_SPEED.value
+            } else 0.0
+        } ?: 0.0
+         */
+
+        val dominionBpsModifier = starship.playerPilot?.let { player ->
+            if (DominionTerritoryBuffTypes.isEffectActive(player, DominionTerritoryBuffTypes.SPEED))
+                DominionTerritoryBuffTypes.SPEED.value
+            else 0.0
+        } ?: 0.0
+
+        val limitedTarget = (targetSpeed * (1 + speedModifier) * (1 - slowModifier) * starship.disabledThrusterRatio + /*nationCruiseModifier + */dominionBpsModifier * starship.directCruiseSpeedMultiplier).toInt()
+
+        val dir = this.targetDir ?: Vector()
+        val speed = if (maxSpeed <= 0) limitedTarget else min(limitedTarget, maxSpeed)
+        val newVelocity = dir.clone().multiply(speed)
+
+        moveTowards(velocity, newVelocity, getRealAccel(thrusterPower) * StarshipCruising.SECONDS_PER_CRUISE)
+
+        if (velocity.x.isNaN()) velocity.x = 0.0
+		if (velocity.y.isNaN()) velocity.y = 0.0
+		if (velocity.z.isNaN()) velocity.z = 0.0
+	}
+
+    // multiplied by power percent and rounded to the nearest hundredth
+    fun getRealAccel(thrusterPower: Double): Double {
+        /*
+        val nationAccelerationModifier = starship.playerPilot?.let { player ->
+            val accelerationBuffActive = NationBuffTypes.isEffectActive(player, NationBuffTypes.ACCELERATION)
+            if (accelerationBuffActive) {
+                NationBuffTypes.ACCELERATION.value
+            } else 0.0
+        } ?: 0.0
+         */
+
+        val dominionAccelModifier = starship.playerPilot?.let { player ->
+            if (DominionTerritoryBuffTypes.isEffectActive(player, DominionTerritoryBuffTypes.ACCELERATION))
+                DominionTerritoryBuffTypes.ACCELERATION.value
+            else 0.0
+        } ?: 0.0
+        return (accel * thrusterPower + /*nationAccelerationModifier + */dominionAccelModifier).roundToHundredth()
+    }
+
+    private fun moveTowards(vector: Vector, other: Vector, maxDistance: Double): Vector {
+        val direction = other.clone().subtract(vector).normalize()
+        val distance = min(maxDistance, other.distance(vector))
+        if (distance < maxDistance) {
+            vector.x = other.x
+            vector.y = other.y
+            vector.z = other.z
+            return vector
+        }
+        return vector.add(direction.multiply(distance))
+    }
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/DirectControlHandler.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/DirectControlHandler.kt
@@ -83,7 +83,7 @@ class DirectControlHandler(controller: Controller, override val input: DirectCon
 
 		// The starship's direction
 		val direction = starship.getTargetForward()
-        val oversizeModifier = if (starship.initialBlockCount > StarshipType.DESTROYER.maxSize) 0.5 else 1.0
+        val oversizeModifier = if (starship.initialBlockCount > StarshipType.ASSAULT_DESTROYER.maxSize) 0.5 else 1.0
 		val speedModifier = starship.getStrongestActiveStatusEffectFromType(StarshipStatusEffectTypes.DIRECT_CONTROL_SPEED)?.strength ?: 0.0
 		val slowModifier = starship.getStrongestActiveStatusEffectFromType(StarshipStatusEffectTypes.DIRECT_CONTROL_SLOW)?.strength ?: 0.0
 		/*

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/DirectCruiseControlHandler.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/DirectCruiseControlHandler.kt
@@ -1,0 +1,35 @@
+package net.horizonsend.ion.server.features.starship.control.movement
+
+import net.horizonsend.ion.common.extensions.userErrorAction
+import net.horizonsend.ion.server.features.starship.StarshipType
+import net.horizonsend.ion.server.features.starship.control.controllers.Controller
+import net.horizonsend.ion.server.features.starship.control.controllers.player.PlayerController
+import net.horizonsend.ion.server.features.starship.control.input.DirectCruiseControlInput
+import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
+
+class DirectCruiseControlHandler(controller: Controller, override val input: DirectCruiseControlInput
+) : MovementHandler(controller, "Cruise Control",	input) {
+	val player get() = (controller as? PlayerController)?.player
+
+	override fun create() {
+		input.create()
+	}
+
+	override fun destroy() {
+		starship.cruiseData.targetSpeed = 0
+		input.destroy()
+	}
+
+	override fun tick() {
+		if (starship.isTeleporting) return
+
+		if (starship.type == StarshipType.PLATFORM) return controller.userErrorAction("This ship type is not capable of moving.")
+
+		if (Hyperspace.isWarmingUp(starship) || Hyperspace.isMoving(starship)) {
+			starship.setDirectCruiseControlEnabled(false)
+			return
+		}
+
+		input.getData()
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
@@ -150,7 +150,7 @@ object StarshipCruising : IonServerComponent() {
 		val dx = if (abs(dir.x) >= 0.5) sign(dir.x).toInt() else 0
 		val dz = if (abs(dir.z) > 0.5) sign(dir.z).toInt() else 0
 
-		if (dx == 0 && dz == 0) {
+		if (dx == 0 && dz == 0 && allowVerticalMovement) {
 			controller.userErrorAction("Can't go up or down")
 
 			return
@@ -175,9 +175,9 @@ object StarshipCruising : IonServerComponent() {
 		starship.cruiseData.targetDir = Vector(
 			dx,
 			0,
-			dz).normalize().add(
+			dz).add(
 				if(allowVerticalMovement) Vector(0.0,dir.y,0.0) else Vector()
-			)
+			).normalize()
 
 		val realAccel = starship.cruiseData.getRealAccel(starship.reactor.powerDistributor.thrusterPortion)
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
@@ -3,7 +3,6 @@ package net.horizonsend.ion.server.features.starship.control.movement
 import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
 import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.extensions.informationAction
-import net.horizonsend.ion.common.extensions.success
 import net.horizonsend.ion.common.extensions.userErrorAction
 import net.horizonsend.ion.common.utils.miscellaneous.roundToHundredth
 import net.horizonsend.ion.common.utils.text.colors.Colors
@@ -35,7 +34,6 @@ import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor.color
 import org.bukkit.util.Vector
-import org.litote.kmongo.month
 import kotlin.math.abs
 import kotlin.math.sign
 
@@ -152,14 +150,19 @@ object StarshipCruising : IonServerComponent() {
 		val dx = if (abs(dir.x) >= 0.5) sign(dir.x).toInt() else 0
 		val dz = if (abs(dir.z) > 0.5) sign(dir.z).toInt() else 0
 
-		if (dx == 0 && dz == 0 && allowVerticalMovement) {
+		if (dx == 0 && dz == 0 && !allowVerticalMovement) {
 			controller.userErrorAction("Can't go up or down")
 
 			return
 		}
 
+		val forwardDirection = starship.forward.direction
+		val forwardDx = if (abs(forwardDirection.x) >= 0.5) sign(forwardDirection.x).toInt() else 0
+		val forwardDz = if (abs(forwardDirection.z) > 0.5) sign(forwardDirection.z).toInt() else 0
+
 		// ThrustData is a binomial data class so we can just expand it like this
-		var (accel, maxSpeed) = starship.getThrustData(dx, dz)
+		var (accel, maxSpeed) = if(dx == 0 && dz == 0) starship.getThrustData(forwardDx, forwardDz)
+		else starship.getThrustData(dx, dz)
 		if (maxSpeed == 0) {
 			controller.userErrorAction("Can't cruise in that direction")
 
@@ -179,7 +182,7 @@ object StarshipCruising : IonServerComponent() {
 			0,
 			dz).add(
 				if(allowVerticalMovement) Vector(0.0,dir.y,0.0) else Vector()
-			).normalize()
+			).normalize().multiply(if(dx==0&&dz==0) dir.length() else 1.0)
 
 		val realAccel = starship.cruiseData.getRealAccel(starship.reactor.powerDistributor.thrusterPortion)
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
@@ -35,6 +35,7 @@ import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor.color
 import org.bukkit.util.Vector
+import org.litote.kmongo.month
 import kotlin.math.abs
 import kotlin.math.sign
 
@@ -42,9 +43,10 @@ object StarshipCruising : IonServerComponent() {
 	const val SECONDS_PER_CRUISE = 2.0
 
 	override fun onEnable() {
-		Tasks.syncRepeat(0L, (20 * SECONDS_PER_CRUISE).toLong()) {
+		Tasks.syncRepeat(0L, 1) {
 
-			for (starship in ActiveStarships.allControlledStarships()) {
+			for (starship in ActiveStarships.allControlledStarships().filter { it.moveThisShipThisTick }) {
+				starship.moveThisShipThisTick = false
 				if (!PilotedStarships.isPiloted(starship)) continue
 
 				if (shouldStopCruising(starship)) {
@@ -56,7 +58,7 @@ object StarshipCruising : IonServerComponent() {
 		}
 	}
 
-	private fun updateCruisingShip(starship: ActiveControlledStarship) {
+	fun updateCruisingShip(starship: ActiveControlledStarship) {
 		processUpdatedHullIntegrity(starship)
 
 		val oldVelocity = starship.cruiseData.velocity.clone()
@@ -129,7 +131,7 @@ object StarshipCruising : IonServerComponent() {
 		starship.generateThrusterMap()
 	}
 
-	private fun shouldStopCruising(starship: ActiveControlledStarship): Boolean {
+	fun shouldStopCruising(starship: ActiveControlledStarship): Boolean {
 		if (starship.isDirectControlEnabled) return true
 
 		if (starship.controller is NoOpController || starship.controller is UnpilotedController) return true

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipCruising.kt
@@ -30,93 +30,16 @@ import net.horizonsend.ion.server.features.starship.status_effects.StarshipStatu
 import net.horizonsend.ion.server.miscellaneous.playSoundInRadius
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import net.horizonsend.ion.server.miscellaneous.utils.actualType
-import net.horizonsend.ion.server.miscellaneous.utils.leftFace
-import net.horizonsend.ion.server.miscellaneous.utils.rightFace
 import net.horizonsend.ion.server.miscellaneous.utils.runnable
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor.color
-import org.bukkit.block.BlockFace
 import org.bukkit.util.Vector
 import kotlin.math.abs
-import kotlin.math.min
 import kotlin.math.sign
 
 object StarshipCruising : IonServerComponent() {
 	const val SECONDS_PER_CRUISE = 2.0
-
-	class CruiseData(
-		val starship: ActiveControlledStarship,
-		var velocity: Vector = Vector(),
-		var targetSpeed: Int = 0,
-		var targetDir: Vector? = null,
-		var accel: Double = 0.0
-	) {
-		var lastBlockCount = starship.initialBlockCount
-
-		fun accelerate(maxSpeed: Int, thrusterPower: Double) {
-			val speedModifier = starship.getStrongestActiveStatusEffectFromType(StarshipStatusEffectTypes.CRUISE_SPEED)?.strength ?: 0.0
-			val slowModifier = starship.getStrongestActiveStatusEffectFromType(StarshipStatusEffectTypes.CRUISE_SLOW)?.strength ?: 0.0
-			/*
-			val nationCruiseModifier = starship.playerPilot?.let { player ->
-				val cruiseBuffActive = NationBuffTypes.isEffectActive(player, NationBuffTypes.CRUISE_SPEED)
-				if (cruiseBuffActive) {
-					NationBuffTypes.CRUISE_SPEED.value
-				} else 0.0
-			} ?: 0.0
-			 */
-
-			val dominionBpsModifier = starship.playerPilot?.let { player ->
-				if (DominionTerritoryBuffTypes.isEffectActive(player, DominionTerritoryBuffTypes.SPEED))
-					DominionTerritoryBuffTypes.SPEED.value
-				else 0.0
-			} ?: 0.0
-
-			val limitedTarget = (targetSpeed * (1 + speedModifier) * (1 - slowModifier) * starship.disabledThrusterRatio + /*nationCruiseModifier + */dominionBpsModifier).toInt()
-
-			val dir = this.targetDir ?: Vector()
-			val speed = if (maxSpeed <= 0) limitedTarget else min(limitedTarget, maxSpeed)
-			val newVelocity = dir.clone().multiply(speed)
-
-			newVelocity.y = 0.0
-			moveTowards(velocity, newVelocity, getRealAccel(thrusterPower) * SECONDS_PER_CRUISE)
-			velocity.y = 0.0
-
-			if (velocity.x.isNaN()) velocity.x = 0.0
-			if (velocity.z.isNaN()) velocity.z = 0.0
-		}
-
-		// multiplied by power percent and rounded to the nearest hundredth
-		fun getRealAccel(thrusterPower: Double): Double {
-			/*
-			val nationAccelerationModifier = starship.playerPilot?.let { player ->
-				val accelerationBuffActive = NationBuffTypes.isEffectActive(player, NationBuffTypes.ACCELERATION)
-				if (accelerationBuffActive) {
-					NationBuffTypes.ACCELERATION.value
-				} else 0.0
-			} ?: 0.0
-			 */
-
-			val dominionAccelModifier = starship.playerPilot?.let { player ->
-				if (DominionTerritoryBuffTypes.isEffectActive(player, DominionTerritoryBuffTypes.ACCELERATION))
-					DominionTerritoryBuffTypes.ACCELERATION.value
-				else 0.0
-			} ?: 0.0
-			return (accel * thrusterPower + /*nationAccelerationModifier + */dominionAccelModifier).roundToHundredth()
-		}
-
-		private fun moveTowards(vector: Vector, other: Vector, maxDistance: Double): Vector {
-			val direction = other.clone().subtract(vector).normalize()
-			val distance = min(maxDistance, other.distance(vector))
-			if (distance < maxDistance) {
-				vector.x = other.x
-				vector.y = other.y
-				vector.z = other.z
-				return vector
-			}
-			return vector.add(direction.multiply(distance))
-		}
-	}
 
 	override fun onEnable() {
 		Tasks.syncRepeat(0L, (20 * SECONDS_PER_CRUISE).toLong()) {
@@ -214,7 +137,7 @@ object StarshipCruising : IonServerComponent() {
 		return Hyperspace.isWarmingUp(starship)
 	}
 
-	fun startCruising(controller: Controller, starship: ActiveControlledStarship, dir: Vector) {
+	fun startCruising(controller: Controller, starship: ActiveControlledStarship, dir: Vector, allowVerticalMovement: Boolean = false) {
 		if (starship.type == PLATFORM) {
 			controller.userErrorAction("This ship type is not capable of moving.")
 			return
@@ -241,7 +164,7 @@ object StarshipCruising : IonServerComponent() {
 			return
 		}
 
-		maxSpeed /= 2
+		maxSpeed /= 2 //This change was done to save the server from imploding from chunk loading lag.
 		maxSpeed = (maxSpeed * starship.balancing.cruiseSpeedMultiplier).toInt()
 		maxSpeed = minOf(maxSpeed, starship.balancing.maxCruiseSpeed)
 
@@ -249,7 +172,12 @@ object StarshipCruising : IonServerComponent() {
 
 		starship.cruiseData.accel = accel
 		starship.cruiseData.targetSpeed = maxSpeed
-		starship.cruiseData.targetDir = Vector(dx, 0, dz).normalize()
+		starship.cruiseData.targetDir = Vector(
+			dx,
+			0,
+			dz).normalize().add(
+				if(allowVerticalMovement) Vector(0.0,dir.y,0.0) else Vector()
+			)
 
 		val realAccel = starship.cruiseData.getRealAccel(starship.reactor.powerDistributor.thrusterPortion)
 
@@ -277,7 +205,7 @@ object StarshipCruising : IonServerComponent() {
 			}
 		} else {
 			starship.informationAction("Adjusted dir to $info <yellow>[Left click to stop]")
-			if (starship.controller !is AIController) starship.success("Adjusted dir to $info <yellow>[Left click to stop]")
+			//if (starship.controller !is AIController) starship.success("Adjusted dir to $info <yellow>[Left click to stop]")
 		}
 
 		// Sound alert for cruise
@@ -360,17 +288,4 @@ object StarshipCruising : IonServerComponent() {
 	fun isCruisingAndAccelerating(starship: ActiveControlledStarship) = starship.cruiseData.targetDir != null
 	// If the starship is moving due to cruising at all, even if not accelerating
 	fun isCruising(starship: ActiveControlledStarship) = starship.cruiseData.velocity.lengthSquared() != 0.0
-
-	enum class Diagonal {
-		DIAGONAL_LEFT { override fun getRightFace(forward: BlockFace): BlockFace { return forward.leftFace } },
-		DIAGONAL_RIGHT { override fun getRightFace(forward: BlockFace): BlockFace { return forward.rightFace } }
-
-		;
-
-		abstract fun getRightFace(forward: BlockFace): BlockFace
-
-		fun vector(forward: BlockFace): Vector {
-			return forward.direction.add(getRightFace(forward).direction).normalize()
-		}
-	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/StarshipMovement.kt
@@ -1,10 +1,12 @@
 package net.horizonsend.ion.server.features.starship.movement
 
+import github.scarsz.discordsrv.dependencies.kyori.adventure.text.Component
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet
 import net.horizonsend.ion.common.database.schema.Cryopod
 import net.horizonsend.ion.common.database.schema.starships.StarshipData
 import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.common.extensions.serverError
+import net.horizonsend.ion.common.extensions.userErrorAction
 import net.horizonsend.ion.common.utils.miscellaneous.d
 import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.features.player.CombatTimer
@@ -72,8 +74,10 @@ abstract class StarshipMovement(val starship: ActiveStarship) : TranslationAcces
 			return
 		}
 
+		var ignoreYMovement = false
+
 		if (displaceY(starship.min.y) < 0) {
-			throw StarshipOutOfBoundsException("Minimum height limit reached")
+			ignoreYMovement = true
 		}
 
 		if (displaceY(starship.max.y) >= world1.maxHeight) {
@@ -82,7 +86,13 @@ abstract class StarshipMovement(val starship: ActiveStarship) : TranslationAcces
 				return
 			}
 
-			throw StarshipOutOfBoundsException("Maximum height limit reached")
+			ignoreYMovement = true
+		}
+
+		//if we would be moving out of the world height bounds, set the y movement to 0, instead of blocking the entire movement
+		if(ignoreYMovement){
+			(this as? TranslateMovement)?.dy = 0
+			starship.userErrorAction("World Height Limit Reached")
 		}
 
 		validateWorldBorders(starship.min, starship.max, findPassengers(world1), world2)

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/TranslateMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/TranslateMovement.kt
@@ -27,7 +27,7 @@ import kotlin.math.min
 class TranslateMovement(
 	starship: ActiveStarship,
 	val dx: Int,
-	val dy: Int,
+	var dy: Int,
 	val dz: Int,
 	override val newWorld: World? = null,
 	val source: MovementSource

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/reactor/PowerDistributor.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/reactor/PowerDistributor.kt
@@ -6,7 +6,6 @@ class PowerDistributor {
 	var weaponPortion: Double = 0.5
 		private set
 	var thrusterPortion: Double = 0.5
-		private set
 
 	fun setDivision(shield: Double, weapon: Double, thruster: Double, bypassCheck : Boolean = false) {
 		check(bypassCheck or (shield + weapon + thruster - 1.0 <= 1e-4)) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/world/environment/modules/NoGravityEnvironmentModule.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/world/environment/modules/NoGravityEnvironmentModule.kt
@@ -33,7 +33,7 @@ class NoGravityEnvironmentModule(manager: WorldEnvironmentManager, val ignoreInd
 			}
 
 			// do not update fly speed if the player is piloting and is in direct control
-			if (ActiveStarships.findByPilot(player)?.isDirectControlEnabled == true && player.getSetting(PlayerSettings::floatWhileDc) == true) continue
+			if ((ActiveStarships.findByPilot(player)?.isDirectControlEnabled == true || ActiveStarships.findByPilot(player)?.isDirectCruiseControlEnable == true) && player.getSetting(PlayerSettings::floatWhileDc) == true) continue
 
 			// only allow players to fly at full speed if ignoreIndoors is false and the player is inside
 			if (!ignoreIndoors && isInside(player.eyeLocation, 1)) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/listener/gear/DoubleJumpListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/listener/gear/DoubleJumpListener.kt
@@ -33,7 +33,7 @@ object DoubleJumpListener : SLEventListener() {
 	fun onToggleFlight(event: PlayerToggleFlightEvent) {
 		// player is trying to stop flying
 		if (!event.isFlying) {
-			if (ActiveStarships.findByPilot(event.player)?.isDirectControlEnabled == true && event.player.getSetting(PlayerSettings::floatWhileDc) == true) {
+			if ((ActiveStarships.findByPilot(event.player)?.isDirectControlEnabled == true || ActiveStarships.findByPilot(event.player)?.isDirectCruiseControlEanble == true) && event.player.getSetting(PlayerSettings::floatWhileDc) == true) {
 				event.isCancelled = true
 			}
 			return

--- a/server/src/main/kotlin/net/horizonsend/ion/server/listener/gear/DoubleJumpListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/listener/gear/DoubleJumpListener.kt
@@ -33,7 +33,7 @@ object DoubleJumpListener : SLEventListener() {
 	fun onToggleFlight(event: PlayerToggleFlightEvent) {
 		// player is trying to stop flying
 		if (!event.isFlying) {
-			if ((ActiveStarships.findByPilot(event.player)?.isDirectControlEnabled == true || ActiveStarships.findByPilot(event.player)?.isDirectCruiseControlEanble == true) && event.player.getSetting(PlayerSettings::floatWhileDc) == true) {
+			if ((ActiveStarships.findByPilot(event.player)?.isDirectControlEnabled == true || ActiveStarships.findByPilot(event.player)?.isDirectCruiseControlEnable == true) && event.player.getSetting(PlayerSettings::floatWhileDc) == true) {
 				event.isCancelled = true
 			}
 			return


### PR DESCRIPTION
### Movement Changes:
First I should note, these will not constitute any change in the balancing of the server. The aim of these improvements is to make movements easier.

**1. Cruise Timing Change:** Currently for some reason, all ships cruising move at the same 2 second mark. Given 8 lancers moving, all 8 would move at the same tick. This would mean all 8 would need to be processed within 50ms or the server would suffer a massive lag spike. To fix this, the time will now be started when the ship pilots. Not when the server started. (Essentially the timer has been added to the ship, and it's no longer global)

**2. Drift Key & Tertiary Input change:** Tertiary controls have been moved to the sprint key. This was done to facilitate the new control movement Cruise control. The jump key for DC will instead be for drifting. For those curious this is done by using the old logic of power-modes, where we set the power-mode of thrusters to 10, when the player holds the jump key.

**3. Cruise Control:** Currently to fight in large ships (larger then 12.5k), one needs to use /cruise or cruise signs. This has been distasteful to some players to say the least. More importantly as well, it required players to use shift flight whilst cruising, this is purely awful for the server, as alongside the 2 seconds cruising timer, you're now moving once every second as well with shift flying. Yielding 3 movements every 2 seconds.
Thus to fix these 2 issues, a new command /cc (/cruise control as well) has been added that allows players to use WASD to move side to side whilst in cruise. Where looking forward and pressing w moves you forward, looking to the right side and pressing d would move you backwards. To not be confused, this is in parity with current cruise combat, but without the extra movements, and the friction of having to shift fly.  (Those who played CCNet will find this system somewhat familiar, just HE has more inertia)
Finally, to have parity with shift + cruise, shifting in this control method will move you down, and space will move you up. 
Importantly to ensure this keeps parity and consistency with current cruise+shift svs dynamics, you only gain the additional shift speed when you cruise in the direction you are looking.

**4. DC Max Size:** Finally, as a minor change, the max size for DC has been made to be 12500. This was previously done, however the large fights the server now sees requires its implementation again.