### PR TITLE
Make Black Ops not appear on dynmap. Fixed hardcoded values

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipTypeBalancing.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/starship/StarshipTypeBalancing.kt
@@ -621,6 +621,8 @@ data class NewStarshipBalancing(
 			warmupTime = 8,
 			interdictionRange = 350,
 			contactsRange = 700,
+			dynmapVisibility = false,
+			probeVisibility = false,
 			jumpStrength = 1.0,
 			wellStrength = 1.0,
 			hyperspaceRangeMultiplier = 1.5,
@@ -773,6 +775,7 @@ data class NewStarshipBalancing(
 			sneakFlyAccelDistance = 5,
 			maxSneakFlyAccel = 2,
 			interdictionRange = 500,
+			canUseInterdictionWell = true,
 			jumpStrength = 1.0,
 			warmupTime = 10,
 			wellStrength = 1.0,
@@ -853,6 +856,7 @@ data class NewStarshipBalancing(
 			sneakFlyAccelDistance = 6,
 			maxSneakFlyAccel = 2,
 			interdictionRange = 1000,
+			canUseInterdictionWell = true,
 			jumpStrength = 1.0,
 			warmupTime = 10,
 			wellStrength = 2.0,
@@ -1154,6 +1158,7 @@ data class NewStarshipBalancing(
 			maxSneakFlyAccel = 2,
 			interdictionRange = 850,
 			contactsRange = 700,
+			dynmapVisibility = false,
 			warmupTime = 10,
 			jumpStrength = 2.0,
 			wellStrength = 1.0,
@@ -1350,6 +1355,7 @@ data class NewStarshipBalancing(
 			sneakFlyAccelDistance = 5,
 			maxSneakFlyAccel = 3,
 			interdictionRange = 2000,
+			canUseInterdictionWell = true,
 			warmupTime = 15,
 			jumpStrength = 1.0,
 			wellStrength = 3.0,
@@ -1774,7 +1780,10 @@ sealed interface StarshipTypeBalancing {
 	val sneakFlyAccelDistance: Int
 	val maxSneakFlyAccel: Int
 	val interdictionRange: Int
+	val canUseInterdictionWell: Boolean //specifies whether the user may use the gravity well multiblock on their ship.
 	var contactsRange: Int //specifies the maximum distance this ship can be seen on contacts
+	var dynmapVisibility: Boolean //specifies whether this ship may ever be seen on dynmap
+	var probeVisibility: Boolean
 	val jumpStrength: Double
 	val wellStrength: Double
 	val hyperspaceRangeMultiplier: Double
@@ -1788,6 +1797,8 @@ sealed interface StarshipTypeBalancing {
 
 	val weaponOverrides: List<StarshipWeaponBalancing<*>>
 	val commandBurstOverrides: List<StarshipCommandBurstBalancing>
+
+	val isAllowedOnPlanets: Boolean
 }
 
 @Serializable
@@ -1803,7 +1814,10 @@ open class StanrdardStarshipTypeBalancing(
 
 	override var maxSneakFlyAccel: Int,
 	override var interdictionRange: Int,
+	override var canUseInterdictionWell: Boolean = false,
 	override var contactsRange: Int = 2500,
+	override var dynmapVisibility: Boolean  = true,
+	override var probeVisibility: Boolean = true,
 	override var jumpStrength: Double,
 	override var wellStrength: Double,
 	override var hyperspaceRangeMultiplier: Double,
@@ -1817,6 +1831,8 @@ open class StanrdardStarshipTypeBalancing(
 
 	override val weaponOverrides: List<StarshipWeaponBalancing<*>> = listOf(),
 	override val commandBurstOverrides: List<StarshipCommandBurstBalancing> = listOf(),
+
+	override val isAllowedOnPlanets: Boolean = true
 ) : StarshipTypeBalancing
 
 @Serializable
@@ -1831,7 +1847,10 @@ open class GroundStarshipBalancing(
 	override var sneakFlyAccelDistance: Int,
 	override var maxSneakFlyAccel: Int,
 	override var interdictionRange: Int,
+	override var canUseInterdictionWell: Boolean = false,
 	override var contactsRange: Int = 2500,
+	override var dynmapVisibility: Boolean  = true,
+	override var probeVisibility: Boolean = true,
 	override var jumpStrength: Double,
 	override var wellStrength: Double,
 	override var hyperspaceRangeMultiplier: Double,
@@ -1845,6 +1864,8 @@ open class GroundStarshipBalancing(
 
 	override val weaponOverrides: List<StarshipWeaponBalancing<*>> = listOf(),
 	override val commandBurstOverrides: List<StarshipCommandBurstBalancing> = listOf(),
+
+	override val isAllowedOnPlanets: Boolean = true
 ) : StarshipTypeBalancing
 
 @Serializable

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/gravitywell/GravityWellMultiblock.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/multiblock/type/starship/gravitywell/GravityWellMultiblock.kt
@@ -33,7 +33,7 @@ abstract class GravityWellMultiblock : Multiblock(), InteractableMultiblock, Dis
 		if (StarshipCruising.isCruising(starship) && starship.initialBlockCount < 4800) {
 			return player.userError("This cannot be activated while cruising on ships smaller than 4800 blocks!")
 		}
-		if (starship.type != StarshipType.INTERDICTOR_GUNSHIP && starship.type != StarshipType.INTERDICTOR_CORVETTE && starship.type != StarshipType.INTERDICTOR_DESTROYER) {
+		if (!starship.type.balancing.canUseInterdictionWell) {
 			return player.userError("Only interdictors can use gravity wells!")
 		}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/ActiveStarshipMechanics.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/active/ActiveStarshipMechanics.kt
@@ -446,7 +446,7 @@ object ActiveStarshipMechanics : IonServerComponent() {
 	 * Map visibility check
 	 */
 	private fun isInPOI(player: Player, starship: ActiveControlledStarship?): Boolean {
-		if (starship?.type == StarshipType.RECON_STARFIGHTER) return false
+		if (starship?.type?.balancing?.dynmapVisibility == false) return false
 
 		val beacons = ConfigurationFiles.serverConfiguration().beacons
 			.filter { it.spaceLocation.world == player.world.name }
@@ -466,7 +466,7 @@ object ActiveStarshipMechanics : IonServerComponent() {
 	 * Second, important visibility check (basically only for combat)
 	 */
 	private fun isInSuperPOI(player: Player, starship: ActiveControlledStarship?): Boolean {
-		if (starship?.type == StarshipType.RECON_STARFIGHTER) return false
+		if (starship?.type?.balancing?.dynmapVisibility == false) return false
 		return CombatTimer.isPvpCombatTagged(player)
 	}
 

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipControl.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/control/movement/StarshipControl.kt
@@ -33,11 +33,8 @@ object StarshipControl : IonServerComponent() {
 			.firstOrNull()
 			?: return false
 
-		// Don't allow battlecruisers to enter planets
-		if (starship.type == BATTLECRUISER && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
-		if (starship.type == StarshipType.BARGE && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
-		if (starship.type == StarshipType.LANCER_BATTLECRUISER && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
-		if (starship.type == StarshipType.INDUSTRIAL_COMMAND_SHIP && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS) ) return false
+		// Don't allow some ships to enter planets
+		if (!starship.type.balancing.isAllowedOnPlanets && !starship.world.ion.hasFlag(WorldFlag.NO_SUPERCAPITAL_REQUIREMENTS)) return false
 
 		// Don't allow players that have recently entered planets to re-enter again
 		val controller = starship.controller

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/secondary/AdvancedProbeWeaponSubsystem.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/subsystem/weapon/secondary/AdvancedProbeWeaponSubsystem.kt
@@ -89,7 +89,7 @@ class AdvancedProbeWeaponSubsystem(
 				it.controller is PlayerController &&
 					it.world == starship.world &&
 					it.centerOfMass.distanceSquared(starship.centerOfMass) < range * range &&
-					it.type != StarshipType.RECON_STARFIGHTER
+					it.type.balancing.probeVisibility
 			}
 			val totalShips = ships.size
 			for (ship in ships) {


### PR DESCRIPTION
For some reason, hardcoded values were used for like half the features pertaining to starships. Interdictors, recon fighters, black ops, supercaps as examples. The values remain the same, only moved to a more accesible location