### PR TITLE
Remove lighting updates and heightmap updates in optimized movement.

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/OptimizedMovement.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/OptimizedMovement.kt
@@ -333,11 +333,11 @@ object OptimizedMovement {
 //				lightModule.updateSectionStatus(SectionPos.of(chunk.x, sectionKey, chunk.z), false)
 			}
 
-			updateHeightMaps(nmsChunk)
+			//updateHeightMaps(nmsChunk)
 			nmsChunk.markUnsaved()
 		}
 
-		lightModule.`starlight$serverRelightChunks`(relightChunks, {}, {})
+		//lightModule.`starlight$serverRelightChunks`(relightChunks, {}, {})
 	}
 
 	/**
@@ -401,11 +401,10 @@ object OptimizedMovement {
 //				lightModule.updateSectionStatus(SectionPos.of(chunk.x, sectionKey, chunk.z), false)
 			}
 
-			updateHeightMaps(nmsChunk)
 			nmsChunk.markUnsaved()
 		}
 
-		lightModule.`starlight$serverRelightChunks`(relightChunks, {}, {})
+		//lightModule.`starlight$serverRelightChunks`(relightChunks, {}, {})
 
 		for ((index, tile) in capturedTiles) {
 			val blockKey = newPositionArray[index]


### PR DESCRIPTION
As proof to the nessecity. 
### Client Side Spark of 3 dreadnoughts moving
<img width="1870" height="726" alt="image" src="https://github.com/user-attachments/assets/9a4994f5-20c9-4f4e-979b-bb9490725319" />

The circled box is the light updates caused by ships moving. 25% of my lag.
I could be wrong on this.