### PR TITLE
Disable Lighting (setting), use fullbright if enabled

### DIFF
--- a/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/PlayerSettings.kt
+++ b/common/src/main/kotlin/net/horizonsend/ion/common/database/schema/misc/PlayerSettings.kt
@@ -100,6 +100,8 @@ data class PlayerSettings(
 	var fleetStatus: Boolean = true,
 	var chestShopDisplays: Boolean = true,
 	var miningLaserEffectLevel: Int = 3,
+	var doLightUpdates: Boolean = true,
+
 	var hudIconStarships: Boolean = true,
 	var hudIconSize: Int = 5,
 ) : DbObject {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/IonServer.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/IonServer.kt
@@ -1,6 +1,8 @@
 package net.horizonsend.ion.server
 
 import co.aikar.commands.PaperCommandManager
+import com.comphenix.protocol.ProtocolLibrary
+import com.comphenix.protocol.ProtocolManager
 import net.horizonsend.ion.common.IonComponent
 import net.horizonsend.ion.common.database.DBManager
 import net.horizonsend.ion.common.extensions.prefixProvider
@@ -33,8 +35,11 @@ import org.bukkit.plugin.java.JavaPlugin
 import xyz.xenondevs.invui.InvUI
 import kotlin.system.measureTimeMillis
 
+
 object IonServer : JavaPlugin() {
 	val configProvider = ConfigurationFiles // Ensure initialization
+	var protocolManager: ProtocolManager? = null
+
 
 	override fun onLoad() {
 		WorldReset.onStartup()
@@ -70,6 +75,12 @@ object IonServer : JavaPlugin() {
 				is Player -> "to ${it.name}: "
 				else -> ""
 			}
+		}
+
+		try{
+			protocolManager = ProtocolLibrary.getProtocolManager()
+		}catch (e: Exception){
+			logger.severe("Could not load protocol manager! $e")
 		}
 
 		bootstrapCustomTranslations()
@@ -136,6 +147,12 @@ object IonServer : JavaPlugin() {
 		} catch (e: Exception) {
 			slF4JLogger.error("There was an error shutting down ${component.javaClass.simpleName}! ${e.message}")
 			e.printStackTrace()
+		}
+
+		try {
+			protocolManager?.removePacketListeners(this)
+		}catch (e: Exception){
+			logger.severe("Could not remove protocol manager! $e")
 		}
 
 		IonWorld.unregisterAll()

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/SettingsMainMenuGui.kt
@@ -107,6 +107,7 @@ class SettingsMainMenuGui(player: Player) : SettingsPageGui(player, "Settings") 
 			createSettingsPage(player, "Misc Settings",
 				DBCachedBooleanToggle(text("Toggle Chest Shop Visibility"), "", GuiItem.BOOKMARK, false, PlayerSettings::chestShopDisplays),
 				DBCachedIntegerInput(0, 3, text("Mining Laser Effect Level"), "", GuiItem.BOOKMARK, 3, PlayerSettings::miningLaserEffectLevel),
+				DBCachedBooleanToggle(text("Toggle Light Updates (Use fullbright mods)"), "", GuiItem.STAR, true, PlayerSettings::doLightUpdates),
 			),
 		),
 		createSettingsPage(player, "Sound Settings",

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/gui/custom/settings/commands/SettingsCommand.kt
@@ -348,6 +348,12 @@ object SettingsCommand : SLCommand() {
         handleBooleanToggleSetting(sender, PlayerSettings::hudIconBookmarks, enabled)
     }
 
+	@CommandAlias("graphics misc dolightupdates")
+	@CommandCompletion("true|false")
+	fun onSettingsGraphicsMicDoLightUpdates(sender: Player, @Optional enabled: Boolean?) = asyncCommand(sender) {
+		handleBooleanToggleSetting(sender, PlayerSettings::doLightUpdates, enabled)
+	}
+
     @CommandAlias("graphics effects displayentities")
     @CommandCompletion("@clientDisplayEntitiesVisibility")
     fun onSettingsGraphicsEffectsDisplayEntities(sender: Player, value: ClientDisplayEntities.Visibility) = asyncCommand(sender) {

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/LightManager.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/starship/movement/LightManager.kt
@@ -1,0 +1,80 @@
+package net.horizonsend.ion.server.features.starship.movement
+
+import com.comphenix.protocol.PacketType
+import com.comphenix.protocol.events.ListenerPriority
+import com.comphenix.protocol.events.PacketAdapter
+import com.comphenix.protocol.events.PacketEvent
+import com.comphenix.protocol.wrappers.WrappedBlockData
+import net.horizonsend.ion.common.IonComponent
+import net.horizonsend.ion.common.database.schema.misc.PlayerSettings
+import net.horizonsend.ion.server.IonServer
+import net.horizonsend.ion.server.IonServer.protocolManager
+import net.horizonsend.ion.server.features.cache.PlayerSettingsCache.getSetting
+import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket
+import net.minecraft.network.protocol.game.ClientboundLightUpdatePacketData
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import java.lang.reflect.Field
+
+
+object LightManager : IonComponent() {
+
+	private var lightDataField: Field? = null
+	override fun onEnable() {
+		lightDataField = resolveLightDataField()
+		registerListeners()
+	}
+
+	fun registerListeners() {
+		protocolManager?.addPacketListener(object : PacketAdapter(
+			IonServer, ListenerPriority.HIGHEST,
+			PacketType.Play.Server.LIGHT_UPDATE
+		) {
+			override fun onPacketSending(event: PacketEvent) {
+				if(event.player.getSetting(PlayerSettings::doLightUpdates) == true) return
+				event.setCancelled(true)
+			}
+		})
+
+
+		// Light data embedded in the initial chunk-send packet.
+		protocolManager?.addPacketListener(object : PacketAdapter(
+			IonServer, ListenerPriority.HIGHEST,
+			PacketType.Play.Server.MAP_CHUNK
+		) {
+			override fun onPacketSending(event: PacketEvent?) {
+				stripLights(event ?: return, event.player ?: return)
+			}
+		})
+
+	}
+
+	private fun resolveLightDataField(): Field? {
+		try {
+			for (f in ClientboundLevelChunkWithLightPacket::class.java.getDeclaredFields()) {
+				if (f.type == ClientboundLightUpdatePacketData::class.java) {
+					f.setAccessible(true)
+					return f
+				}
+			}
+		} catch (e: java.lang.Exception) {
+			IonServer.logger.severe("LightPacketManager: could not locate lightData field: $e")
+		}
+		return null
+	}
+
+	fun stripLights(event: PacketEvent, player: Player) {
+		if (player.getSetting(PlayerSettings::doLightUpdates) == true) return
+
+		val packet = event.packet
+		val handler = packet.handle as? ClientboundLevelChunkWithLightPacket ?: return
+		val lightData = handler.lightData
+
+		lightData.skyYMask.clear()
+		lightData.blockYMask.clear()
+		lightData.emptySkyYMask.clear()
+		lightData.emptyBlockYMask.clear()
+		lightData.skyUpdates.clear()
+		lightData.blockUpdates.clear()
+	}
+}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/registrations/Components.kt
@@ -96,6 +96,7 @@ import net.horizonsend.ion.server.features.starship.factory.StarshipFactories
 import net.horizonsend.ion.server.features.starship.fleet.Fleets
 import net.horizonsend.ion.server.features.starship.hyperspace.Hyperspace
 import net.horizonsend.ion.server.features.starship.hyperspace.HyperspaceBeacons
+import net.horizonsend.ion.server.features.starship.movement.LightManager
 import net.horizonsend.ion.server.features.starship.movement.PlanetTeleportCooldown
 import net.horizonsend.ion.server.features.starship.subsystem.shield.StarshipShields
 import net.horizonsend.ion.server.features.transport.NewTransport
@@ -253,4 +254,6 @@ val components: List<IonComponent> = listOf(
 	Environments,
 	Power,
 	SignatureManager,
+
+	LightManager
 )


### PR DESCRIPTION
This commit disables the player receiving light updates from the server. It wont improve fps if you don't use full-bright, however it will slightly improve networking for those who use full-bright mods.

I'd strongly recommend everyone grab a mod that disables light updates & enforces full bright for capital ship combat. Light updates are a huge component of client side fps drops