### PR TITLE
A minor Pvp update.

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/configuration/PVPBalancingConfiguration.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/configuration/PVPBalancingConfiguration.kt
@@ -46,7 +46,7 @@ data class PVPBalancingConfiguration(
 	@Serializable
 	data class EnergyWeapons(
 		val pistol: Singleshot = Singleshot(
-			damage = 3.0,
+			damage = 3.5,
 			damageFalloffMultiplier = 0.0,
 			capacity = 10,
 			ammoPerRefill = 20,
@@ -76,7 +76,7 @@ data class PVPBalancingConfiguration(
 			refillType = "minecraft:lapis_lazuli",
 		),
 		val rifle: Singleshot = Singleshot(
-			damage = 5.5,
+			damage = 6.9,
 			damageFalloffMultiplier = 0.0,
 			capacity = 20,
 			ammoPerRefill = 20,
@@ -106,7 +106,7 @@ data class PVPBalancingConfiguration(
 			refillType = "minecraft:lapis_lazuli",
 		),
 		val submachineBlaster: Singleshot = Singleshot(
-			damage = 1.5,
+			damage = 1.9,
 			damageFalloffMultiplier = 0.0,
 			capacity = 45,
 			ammoPerRefill = 20,
@@ -136,7 +136,7 @@ data class PVPBalancingConfiguration(
 			refillType = "minecraft:lapis_lazuli",
 		),
 		val sniper: Singleshot = Singleshot(
-			damage = 12.0,
+			damage = 15.0,
 			damageFalloffMultiplier = 30.0,
 			capacity = 5,
 			ammoPerRefill = 20,
@@ -166,7 +166,7 @@ data class PVPBalancingConfiguration(
 			refillType = "minecraft:emerald",
 		),
 		val shotgun: Multishot = Multishot(
-			damage = 1.75,
+			damage = 2.2,
 			damageFalloffMultiplier = 0.25,
 			delay = 0,
 			capacity = 4,
@@ -200,7 +200,7 @@ data class PVPBalancingConfiguration(
 		),
 
 		val cannon: Singleshot = Singleshot(
-			damage = 0.5,
+			damage = 0.1,
 			explosionPower = 4.0f,
 			damageFalloffMultiplier = 0.0,
 			capacity = 60,

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/type/weapon/blaster/BlasterProjectile.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/type/weapon/blaster/BlasterProjectile.kt
@@ -2,6 +2,7 @@ package net.horizonsend.ion.server.features.custom.items.type.weapon.blaster
 
 import net.horizonsend.ion.common.database.cache.nations.RelationCache
 import net.horizonsend.ion.common.database.schema.misc.SLPlayer
+import net.horizonsend.ion.common.database.schema.nations.NationRelation
 import net.horizonsend.ion.common.extensions.alert
 import net.horizonsend.ion.common.extensions.information
 import net.horizonsend.ion.server.IonServer
@@ -12,6 +13,7 @@ import net.horizonsend.ion.server.features.starship.damager.addToDamagers
 import net.horizonsend.ion.server.features.world.IonWorld.Companion.hasFlag
 import net.horizonsend.ion.server.features.world.IonWorld.Companion.ion
 import net.horizonsend.ion.server.features.world.WorldFlag
+import net.horizonsend.ion.server.miscellaneous.utils.DamageEvent
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
 import net.horizonsend.ion.server.miscellaneous.utils.coordinates.alongVector
 import net.horizonsend.ion.server.miscellaneous.utils.get
@@ -26,10 +28,12 @@ import org.bukkit.Particle
 import org.bukkit.Particle.DustOptions
 import org.bukkit.Sound
 import org.bukkit.SoundCategory
+import org.bukkit.damage.DamageType
 import org.bukkit.entity.Damageable
 import org.bukkit.entity.Entity
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause
 import org.bukkit.scheduler.BukkitRunnable
 import kotlin.math.pow
 import kotlin.math.roundToInt
@@ -128,7 +132,7 @@ class RayTracedParticleProjectile(
 				// Headshots
 				if (balancing.shouldHeadshot && (hitEntity.eyeLocation.y - hitPosition.y) < (.3 * balancing.shotSize)) {
 					hasHeadshot = true
-					hitEntity.damage(damage * 1.5, shooter)
+					hitEntity.ionDamage(damage * 1.5, shooter)
 
 					hitLocation.world.spawnParticle(Particle.CRIT, hitLocation, 10)
 					shooter?.playSound(sound(key("horizonsend:blaster.hitmarker.standard"), Source.PLAYER, 20f, 0.5f))
@@ -138,7 +142,7 @@ class RayTracedParticleProjectile(
 			}
 
 			if (!hasHeadshot) {
-				hitEntity.damage(damage, shooter)
+				hitEntity.ionDamage(damage, shooter)
 				shooter?.playSound(sound(key("horizonsend:blaster.hitmarker.standard"), Source.PLAYER, 10f, 1f))
 				if (!balancing.shouldPassThroughEntities) return true
 			}
@@ -149,7 +153,7 @@ class RayTracedParticleProjectile(
 		// Flying Entity Check
 		val flyingHitEntity = flyingRayTraceResult?.hitEntity
 		if (flyingHitEntity != null && flyingHitEntity is Damageable) {
-			flyingHitEntity.damage(damage, shooter)
+			flyingHitEntity.ionDamage(damage, shooter)
 
 			if (flyingHitEntity is Player) {
 				if (!glideDisabledPlayers.containsKey(flyingHitEntity.uniqueId)) {
@@ -163,12 +167,12 @@ class RayTracedParticleProjectile(
 					hitNation?.let { hitNation1 ->
 						RelationCache[
 							hitNation1, shootNation
-						].ordinal < 5
+						] >= NationRelation.Level.ALLY
 					}
 				} ?: false
 
 				// Ignore nation if in arena
-				if (!isSameNation || flyingHitEntity.world.hasFlag(WorldFlag.ARENA)) {
+				if ((isSameNation && flyingHitEntity.world.hasFlag(WorldFlag.ARENA)) || !isSameNation) {
 					glideDisabledPlayers[flyingHitEntity.uniqueId] =
 						System.currentTimeMillis() + 3000 // 3 second glide disable
 					flyingHitEntity.alert("Taking fire! Rocket boots powering down!")
@@ -206,5 +210,20 @@ class RayTracedParticleProjectile(
 		location.add(directionVector)
 
 		return false
+	}
+
+	@Suppress("UnstableApiUsage")
+	private fun Damageable.ionDamage(damage: Double, damager: Entity?) {
+		if (damager == null) return
+		DamageEvent.doDamageEvent(
+			damage,
+			DamageCause.PROJECTILE,
+			this,
+			damager,
+			DamageType.PLAYER_ATTACK,
+			this.location,
+			false,
+			false
+		)
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/type/weapon/sword/EnergySword.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/type/weapon/sword/EnergySword.kt
@@ -1,6 +1,7 @@
 package net.horizonsend.ion.server.features.custom.items.type.weapon.sword
 
 import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.BlocksAttacks
 import io.papermc.paper.datacomponent.item.ItemAttributeModifiers
 import net.horizonsend.ion.common.extensions.userError
 import net.horizonsend.ion.common.utils.text.ofChildren
@@ -11,10 +12,12 @@ import net.horizonsend.ion.server.features.custom.items.component.CustomItemComp
 import net.horizonsend.ion.server.features.custom.items.component.Listener.Companion.damageEntityListener
 import net.horizonsend.ion.server.features.custom.items.component.Listener.Companion.damagedHoldingListener
 import net.horizonsend.ion.server.features.custom.items.component.Listener.Companion.leftClickListener
+import net.horizonsend.ion.server.features.custom.items.component.Listener.Companion.playerSwapHandsListener
 import net.horizonsend.ion.server.features.custom.items.component.Listener.Companion.prepareCraftListener
 import net.horizonsend.ion.server.features.custom.items.util.ItemFactory
 import net.horizonsend.ion.server.miscellaneous.registrations.persistence.NamespacedKeys
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.horizonsend.ion.server.miscellaneous.utils.updatePersistentDataContainer
 import net.kyori.adventure.key.Key.key
 import net.kyori.adventure.sound.Sound
 import net.kyori.adventure.text.Component
@@ -27,6 +30,10 @@ import org.bukkit.attribute.AttributeModifier
 import org.bukkit.entity.Player
 import org.bukkit.event.block.Action
 import org.bukkit.inventory.EquipmentSlotGroup
+import org.bukkit.inventory.ItemFlag
+import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
+import kotlin.collections.mapOf
 
 class EnergySword(key: IonRegistryKey<CustomItem, out CustomItem>, type: String, color: TextColor) : CustomItem(
 	key = key,
@@ -36,13 +43,14 @@ class EnergySword(key: IonRegistryKey<CustomItem, out CustomItem>, type: String,
 		.setCustomModel("weapon/energy_sword/${type.lowercase()}_energy_sword")
 		.addData(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers
 			.itemAttributes()
-			.addModifier(Attribute.ATTACK_DAMAGE, AttributeModifier(NamespacedKeys.key("energy_sword_damage"), 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlotGroup.MAINHAND))
-			.addModifier(Attribute.ATTACK_SPEED, AttributeModifier(NamespacedKeys.key("energy_sword_speed"), 1.8, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlotGroup.MAINHAND))
-			.build())
+			.addModifiers(attributes)
+			.build()
+		)
 		.build()
 ) {
 	override val customComponents: CustomItemComponentManager = CustomItemComponentManager(serializationManager).apply {
 		addComponent(CustomComponentTypes.LISTENER_PLAYER_INTERACT, leftClickListener(this@EnergySword) { event, _, item ->
+			if(item.persistentDataContainer.get(NamespacedKeys.DATA_VERSION, PersistentDataType.INTEGER) != LATEST_VERSION) migrateSword(item)
 			event.player.world.playSound(event.player.location, "energy_sword.swing", 1.0f, 1.0f)
 			if (event.action != Action.LEFT_CLICK_BLOCK) return@leftClickListener
 			val player = event.player
@@ -66,6 +74,9 @@ class EnergySword(key: IonRegistryKey<CustomItem, out CustomItem>, type: String,
 		})
 
 		addComponent(CustomComponentTypes.LISTENER_DAMAGED_HOLDING, damagedHoldingListener(this@EnergySword) { event, customItem, item ->
+			//check to see if the customitem is out of date
+			if(item.persistentDataContainer.get(NamespacedKeys.DATA_VERSION, PersistentDataType.INTEGER) != LATEST_VERSION) migrateSword(item)
+
 			val damaged = event.entity
 			if (damaged !is Player) return@damagedHoldingListener
 			if (!damaged.isBlocking) return@damagedHoldingListener
@@ -77,9 +88,35 @@ class EnergySword(key: IonRegistryKey<CustomItem, out CustomItem>, type: String,
 
 			event.damage = 0.0
 			damaged.setCooldown(SHIELD, 15)
+			damaged.clearActiveItem()
 			damaged.setArrowsInBody(/* count = */ 0, /* fireEvent = */ false)
 
 			damaged.world.playSound(Sound.sound(key("horizonsend:energy_sword.strike"), Sound.Source.PLAYER, 5.0f, 1.0f), damaged)
 		})
+	}
+	companion object{
+		val LATEST_VERSION = 1
+
+		val attributes = mapOf<Attribute, AttributeModifier>(
+			Attribute.ATTACK_DAMAGE to AttributeModifier(NamespacedKeys.key("energy_sword_damage"), 10.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlotGroup.MAINHAND),
+			Attribute.ATTACK_SPEED to AttributeModifier(NamespacedKeys.key("energy_sword_speed"), -2.4, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlotGroup.MAINHAND),
+			Attribute.MOVEMENT_SPEED to AttributeModifier(NamespacedKeys.key("energy_sword_movement_speed"), .2, AttributeModifier.Operation.MULTIPLY_SCALAR_1, EquipmentSlotGroup.MAINHAND),
+		)
+
+		fun ItemAttributeModifiers.Builder.addModifiers(attributesToModifiers: Map<Attribute, AttributeModifier>) : ItemAttributeModifiers.Builder {
+			attributesToModifiers.forEach {
+				this.addModifier(it.key, it.value)
+			}
+			return this
+		}
+
+		fun migrateSword(item: ItemStack) {
+			item.setData(
+				DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes().addModifiers(attributes).build(),
+			)
+			item.updatePersistentDataContainer {
+				set(NamespacedKeys.DATA_VERSION, PersistentDataType.INTEGER, LATEST_VERSION)
+			}
+		}
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/type/weapon/sword/SwordListener.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/type/weapon/sword/SwordListener.kt
@@ -1,10 +1,22 @@
 package net.horizonsend.ion.server.features.custom.items.type.weapon.sword
 
+import net.horizonsend.ion.common.database.schema.nations.Nation
+import net.horizonsend.ion.common.utils.miscellaneous.randomInt
 import net.horizonsend.ion.server.IonServer
 import net.horizonsend.ion.server.core.IonServerComponent
 import net.horizonsend.ion.server.core.registration.registries.CustomItemRegistry.Companion.customItem
+import net.horizonsend.ion.server.features.cache.PlayerCache
+import net.horizonsend.ion.server.features.custom.items.type.weapon.blaster.Blaster
+import net.horizonsend.ion.server.features.starship.control.signs.map.planetInRange
+import net.horizonsend.ion.server.features.world.IonWorld.Companion.hasFlag
+import net.horizonsend.ion.server.features.world.IonWorld.Companion.ion
+import net.horizonsend.ion.server.features.world.WorldFlag
 import net.horizonsend.ion.server.miscellaneous.utils.Tasks
+import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Bukkit
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.PlayerDeathEvent
+import kotlin.math.roundToInt
 
 object SwordListener : IonServerComponent() {
 	override fun onEnable() {
@@ -24,7 +36,7 @@ object SwordListener : IonServerComponent() {
 						if (mainCustomItem != null && mainCustomItem is EnergySword ||
 							offhandCustomItem != null && offhandCustomItem is EnergySword
 						) {
-							player.world.playSound(player.location, "horizonsend:energy_sword.idle", 5.0f, 1.0f)
+							player.world.playSound(player.location, "horizonsend:energy_sword.idle", 3.0f, 1.0f)
 						}
 					}
 				}
@@ -36,5 +48,66 @@ object SwordListener : IonServerComponent() {
 				}
 			}
 		}
+	}
+
+	@EventHandler
+	fun onDeath(event: PlayerDeathEvent) {
+		val victim = event.player
+		val killer = event.entity.killer ?: return
+		val customItem = killer.inventory.itemInMainHand.customItem ?: return
+
+		if (customItem !is Blaster<*>) return
+
+		val arena: String = if (killer.world.hasFlag(WorldFlag.ARENA)) "<#555555>[<#ffff66>Arena<#555555>]<reset> " else ""
+
+		val blaster = customItem.displayName
+		val victimColor = if (victim.hasMetadata("NPC")) "<#FFFFFF>" else "<#" + Integer.toHexString((PlayerCache[victim].nationOid?.let { Nation.findById(it) }?.color ?: 16777215)) + ">"
+
+		val killerColor = "<#" + Integer.toHexString((PlayerCache[killer].nationOid?.let { Nation.findById(it) }?.color ?: 16777215)) + ">"
+
+		val distance = killer.location.distance(victim.location)
+		val verb = when(randomInt(0, 32)){
+			0-> "cut down"
+			1-> "kebabed"
+			2-> "stabbed"
+			3-> "sliced"
+			4-> "mauled"
+			5-> "slain"
+			6-> "pierced"
+			7-> "slashed"
+			8-> "clobbered"
+			9-> "poked"
+			10-> "felled"
+			11-> "wrecked"
+			12-> "cleaved"
+			13-> "discombobulated"
+			14-> "bamboozled"
+			15-> "clowned on"
+			16-> "diced"
+			17-> "skewered"
+			18-> "trashed"
+			19-> "whacked"
+			20-> "bested"
+			21-> "executed"
+			22-> "knocked out"
+			23-> "killed"
+			24-> "butchered"
+			25-> "carved"
+			26-> "vanquished"
+			27-> "dispatched"
+			28-> "gutted"
+			29-> "destroyed"
+			30-> "eliminated"
+			31-> "smoked"
+			32-> "neutralised"
+			else -> "deezed" //should never happen
+		}
+		val newMessage = MiniMessage.miniMessage()
+			.deserialize(
+				"$arena$victimColor${victim.name}<reset> was $verb by $killerColor${killer.name}<reset> from ${distance.roundToInt()} blocks away, using "
+			)
+			.append(blaster)
+
+		event.deathMessage(newMessage)
 	}
 }

--- a/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/util/ItemFactory.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/features/custom/items/util/ItemFactory.kt
@@ -9,6 +9,7 @@ import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import java.util.function.Consumer
@@ -20,7 +21,8 @@ class ItemFactory private constructor(
 	val maxStackSize: Int?,
 	val nameSupplier: Supplier<Component>?,
 	val loreSupplier: ((ItemStack) -> List<Component>)?,
-	val itemModifiers: List<Consumer<ItemStack>>
+	val itemModifiers: List<Consumer<ItemStack>>,
+	val itemFlags: List<ItemFlag>
 ) {
 	fun construct(): ItemStack {
 		val base = ItemStack(material)
@@ -31,6 +33,7 @@ class ItemFactory private constructor(
 		if (loreSupplier != null) base.setData(DataComponentTypes.LORE, ItemLore.lore(loreSupplier.invoke(base)))
 
 		itemModifiers.forEach { it.accept(base) }
+		itemFlags.forEach { base.addItemFlags(it) }
 
 		return base
 	}
@@ -49,6 +52,7 @@ class ItemFactory private constructor(
 			this.nameSupplier = from.nameSupplier
 			this.loreSupplier = from.loreSupplier
 			this.itemModifiers = from.itemModifiers.toMutableList()
+			this.itemFlags = from.itemFlags.toMutableList()
 		}
 
 		private var material = Material.WARPED_FUNGUS_ON_A_STICK
@@ -57,6 +61,7 @@ class ItemFactory private constructor(
 		private var nameSupplier: Supplier<Component>? = null
 		private var loreSupplier: ((ItemStack) -> List<Component>)? = null
 		private var itemModifiers: MutableList<Consumer<ItemStack>> = mutableListOf()
+		private var itemFlags: MutableList<ItemFlag> = mutableListOf()
 
 		fun setMaterial(material: Material): Builder {
 			this.material = material
@@ -89,6 +94,11 @@ class ItemFactory private constructor(
 			return this
 		}
 
+		fun addFlag(flag: ItemFlag): Builder {
+			this.itemFlags += flag
+			return this
+		}
+
 		fun <T: Any> addData(type: DataComponentType.Valued<T>, data: T): Builder {
 			this.itemModifiers += Consumer<ItemStack> {
 				it.setData(type, data)
@@ -115,6 +125,7 @@ class ItemFactory private constructor(
 				nameSupplier = this.nameSupplier,
 				loreSupplier = this.loreSupplier,
 				itemModifiers = this.itemModifiers,
+				itemFlags = this.itemFlags,
 			)
 		}
 	}

--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/DamageEvent.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/DamageEvent.kt
@@ -2,9 +2,7 @@
 
 package net.horizonsend.ion.server.miscellaneous.utils
 
-import com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent
 import com.google.common.base.Function
-import io.papermc.paper.event.entity.EntityKnockbackEvent
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.attribute.Attribute
@@ -19,7 +17,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityDamageEvent.DamageModifier
 import org.bukkit.potion.PotionEffectType
-import org.bukkit.util.Vector
 import kotlin.math.max
 import kotlin.math.min
 
@@ -58,8 +55,10 @@ object DamageEvent {
 		modifierFunctions[DamageModifier.BLOCKING] = Function { damage: Double -> damage }
 		modifierFunctions[DamageModifier.RESISTANCE] = Function { damage: Double -> damage }
 
-		if (!goesThroughBlocking && (entity as? LivingEntity)?.activeItem?.type == Material.SHIELD){
-			damageModifiers[DamageModifier.BLOCKING] = -baseDamage
+		if (!goesThroughBlocking && (entity as? LivingEntity)?.activeItem?.type == Material.SHIELD ){
+			if (entity is Player && !entity.hasCooldown(Material.SHIELD)) {
+				damageModifiers[DamageModifier.BLOCKING] = -baseDamage
+			}
 		}
 
 		//If the player has resistance, on HE this will likely never happen however it never hurts to be prepared
@@ -73,6 +72,7 @@ object DamageEvent {
 		event.callEvent()
 		if (!event.isCancelled){
 			entity.damage(event.finalDamage, damager)
+
 		}
 
 		(entity as? Player)?.isSprinting =  wasSprinting ?: false //We dont want to stop the entity sprinting by accident


### PR DESCRIPTION
- Fixed Energy swords having a ridiculously high attack speed
- Fixed Energy swords never having to stop blocking
- Changed blasters to use DamageEvents not just pure damage
- Buffed the energy swords damage to 10 from 6
- Gave the energy sword a 20% movement boost to catch up to people.
- Allowed the energy swords balancing to be changed between restarts by adding a kind of migrator for it.
- Added addFlag method to the ItemFactory
- Added verbs to the energy sword, and added an [arena] tag when applicable